### PR TITLE
Add AI onboarding documentation pack

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,72 @@
+# AGENTS.md
+
+This file gives AI coding agents the context and guardrails needed to work safely on Fantasy Sumo.
+
+## Product context
+
+Fantasy Sumo is intended to be a lightweight fantasy sports app for professional sumo tournaments (`basho`). Players pick a team of rikishi before a tournament starts, then score points based on those rikishi's results during the tournament.
+
+The original app is an unfinished barebones prototype. Treat the existing implementation as a useful historical starting point, not as a production-ready architecture.
+
+## Current known state
+
+- Front end: React 16, TypeScript, styled-components, webpack 4.
+- Back end: Express, TypeScript, Node, Winston.
+- Data: MySQL via `@mysql/xdevapi`.
+- Existing behaviour: displays current banzuke/ranking data, fetched from the server.
+- Existing server endpoints:
+  - `GET /api/get-rankings` returns rankings from the local database.
+  - `GET /api/update-rankings` pulls banzuke data from sumo.or.jp and stores it locally.
+
+## Intended MVP direction
+
+The MVP should support:
+
+1. A tournament/basho model.
+2. A rikishi list for the tournament.
+3. A fantasy team selection flow before the tournament starts.
+4. A points calculation model based primarily on wins.
+5. A leaderboard.
+6. A simple admin/update path for importing results.
+
+Avoid overbuilding. A working single-user/local MVP is preferable to a half-finished full platform.
+
+## Working principles for AI agents
+
+- Prefer small, reviewable pull requests.
+- Preserve user-facing behaviour unless explicitly changing it.
+- Add or update docs when changing architecture, setup, data model, or scoring rules.
+- Do not introduce paid services, hosted infrastructure, or external APIs without documenting the trade-off.
+- Do not commit secrets or local credentials.
+- Replace hard-coded credentials before any real deployment work.
+- Prefer explicit domain names: `Basho`, `Rikishi`, `Banzuke`, `FantasyTeam`, `Pick`, `Bout`, `Result`, `Leaderboard`.
+- Keep scoring logic isolated and well-tested.
+- Keep data import logic separate from scoring logic.
+
+## Legacy hazards to handle carefully
+
+- The current database connection uses hard-coded local credentials. Treat this as legacy only.
+- The dependency stack is old and may not install cleanly on modern Node versions.
+- The app may need a legacy Node version to run before modernization.
+- The banzuke import uses an external endpoint from sumo.or.jp; verify whether it still works before depending on it.
+- `request` / `request-promise-native`, TSLint, React 16, TypeScript 3, webpack 4, and `awesome-typescript-loader` are legacy dependencies.
+
+## Suggested workflow
+
+1. Read `README.md` for the current repo overview.
+2. Read `docs/PROJECT_BRIEF.md` for product intent.
+3. Read `docs/ARCHITECTURE.md` for current implementation notes.
+4. Read `docs/MODERNISATION_PLAN.md` before upgrading dependencies.
+5. Read `docs/ROADMAP.md` before adding features.
+6. Run tests/build before and after code changes where possible.
+7. If the legacy app cannot run, document the blocker clearly in the PR.
+
+## Definition of done for future changes
+
+A change is ready when:
+
+- It has a clear purpose.
+- It keeps or improves app setup reproducibility.
+- It avoids new secrets in source control.
+- It includes tests for scoring/data rules where practical.
+- It updates docs if it changes product rules, architecture, setup, or data assumptions.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,70 @@
-# fantasySumo
-Repository for Fantasy Sumo Application Code
+# Fantasy Sumo
+
+Fantasy Sumo is an unfinished fantasy sports app for professional sumo.
+
+Players should be able to choose a team of rikishi at the start of a basho, then score points based on those rikishi's results during the tournament.
+
+The current codebase is a historical prototype. It has a React/TypeScript front end, an Express/TypeScript back end, and MySQL-backed banzuke/ranking import/display logic. It is not yet a complete playable fantasy game.
+
+## Current functionality
+
+At present, the app can display a table of sumo rankings from the local database.
+
+Existing server endpoints:
+
+- `GET /api/get-rankings` - returns rankings from MySQL.
+- `GET /api/update-rankings` - imports banzuke data from sumo.or.jp into MySQL.
+
+## Tech stack snapshot
+
+- React 16
+- TypeScript 3
+- styled-components 4
+- Express 4
+- MySQL X DevAPI
+- webpack 4
+- Jest 24
+- TSLint
+
+This stack is old and should be treated carefully. See `docs/MODERNISATION_PLAN.md` before attempting dependency upgrades.
+
+## Documentation
+
+Start here:
+
+- `AGENTS.md` - guidance for AI coding agents working on the repo.
+- `docs/PROJECT_BRIEF.md` - product intent and MVP definition.
+- `docs/ARCHITECTURE.md` - current architecture and suggested future boundaries.
+- `docs/MODERNISATION_PLAN.md` - safe path for updating or rebuilding the app.
+- `docs/ROADMAP.md` - staged product/engineering roadmap.
+
+## Local setup
+
+Local setup still needs to be re-verified against the legacy dependency stack.
+
+Historically, the app used:
+
+```bash
+npm install
+npm run build
+npm start
+```
+
+And for client development:
+
+```bash
+npm run start:dev
+```
+
+Before relying on this, identify a working Node version and document it in this README.
+
+## Security note
+
+The legacy data layer currently contains hard-coded local database credentials. These must be moved to environment variables before any serious development or deployment.
+
+## Recommended next steps
+
+1. Verify whether the legacy app can still install/build/run.
+2. Add `.env.example` and remove hard-coded DB credentials.
+3. Decide whether to incrementally modernise or rebuild around the documented domain model.
+4. Implement the smallest playable MVP: pick a team, enter/import results, calculate scores, show leaderboard.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,206 @@
+# Architecture Notes
+
+## Current architecture
+
+Fantasy Sumo currently has a simple full-stack TypeScript structure:
+
+```text
+src/
+  client/
+    app/
+      index.tsx
+      components/
+        App.tsx
+        HeaderBar.tsx
+        SumoRanking.tsx
+  server/
+    app.ts
+    database.ts
+```
+
+The app is split into:
+
+- A React client bundled by webpack.
+- An Express server compiled by TypeScript.
+- A MySQL-backed data access layer.
+
+## Front end
+
+The front end entry point is `src/client/app/index.tsx`.
+
+Current behaviour:
+
+- Loads Google fonts via `webfontloader`.
+- Renders the root `App` component into `#root`.
+- `App` renders:
+  - `HeaderBar`
+  - `SumoRankTable`
+- `SumoRankTable` fetches `/api/get-rankings` and displays rank, shikona, and heya.
+
+Current limitations:
+
+- No routing.
+- No state management beyond component state.
+- No fantasy team selection flow yet.
+- No leaderboard UI yet.
+- No explicit error/loading design beyond basic text.
+
+## Back end
+
+The server entry point is `src/server/app.ts`.
+
+Current routes:
+
+- `GET /api/get-rankings`
+  - Reads rankings from MySQL.
+- `GET /api/update-rankings`
+  - Fetches banzuke data from sumo.or.jp and stores it in MySQL.
+
+Current limitations:
+
+- No auth.
+- No validation.
+- No typed API contracts.
+- No error handling middleware.
+- No environment-based configuration.
+- No fantasy team, tournament, scoring, result, or leaderboard endpoints yet.
+
+## Data layer
+
+The current data access code lives in `src/server/database.ts`.
+
+Current behaviour:
+
+- Connects to a local MySQL X Protocol server.
+- Reads and writes to schema `sumo`, table `rankings`.
+- Imports banzuke data from an external endpoint.
+
+Current limitations:
+
+- DB credentials are hard-coded and must be removed before serious development/deployment.
+- No migrations.
+- No seed data.
+- No schema documentation.
+- No test database setup.
+- Import and persistence logic are mixed together.
+
+## Legacy stack snapshot
+
+The repository currently uses older tooling:
+
+- React 16.
+- TypeScript 3.
+- webpack 4.
+- webpack-dev-server 3.
+- TSLint.
+- Jest 24.
+- `request` / `request-promise-native`.
+- `awesome-typescript-loader`.
+
+Treat modernization as its own workstream rather than mixing it with product feature work.
+
+## Recommended target architecture for MVP
+
+A clean MVP can still be a simple monolith:
+
+```text
+src/
+  client/
+    ... UI application
+  server/
+    app.ts
+    config/
+    routes/
+    services/
+    repositories/
+    domain/
+      scoring/
+      basho/
+      rikishi/
+  shared/
+    types/
+```
+
+Recommended boundaries:
+
+- `routes`: HTTP request/response handling only.
+- `services`: application workflows, e.g. create team, import results.
+- `repositories`: database access only.
+- `domain`: pure business rules, especially scoring.
+- `shared/types`: API/domain types shared by client and server where useful.
+
+## Suggested domain model
+
+Start with these concepts:
+
+```text
+Basho
+  id
+  name
+  startDate
+  endDate
+  status: upcoming | active | complete
+
+Rikishi
+  id
+  shikona
+  heya
+
+BanzukeEntry
+  id
+  bashoId
+  rikishiId
+  rank
+  rankOrder
+
+FantasyTeam
+  id
+  bashoId
+  ownerName or userId
+  displayName
+  createdAt
+  lockedAt
+
+FantasyPick
+  id
+  teamId
+  rikishiId
+
+BoutResult
+  id
+  bashoId
+  day
+  winnerRikishiId
+  loserRikishiId
+  kimarite optional
+  winnerAbsent optional
+  loserAbsent optional
+```
+
+## API sketch
+
+Potential MVP endpoints:
+
+```text
+GET    /api/basho/current
+GET    /api/basho/:bashoId/rikishi
+POST   /api/basho/:bashoId/teams
+GET    /api/basho/:bashoId/teams/:teamId
+GET    /api/basho/:bashoId/leaderboard
+POST   /api/admin/basho/:bashoId/import-banzuke
+POST   /api/admin/basho/:bashoId/import-results
+```
+
+Admin endpoints can be protected later. For early local development, they can remain local-only but should be clearly marked as unsafe for production.
+
+## Testing priorities
+
+Prioritise tests for:
+
+1. Scoring logic.
+2. Pick validation.
+3. Team locking rules.
+4. Import parsing/mapping.
+5. Leaderboard ordering.
+
+UI tests can come later once the MVP flow stabilises.

--- a/docs/MODERNISATION_PLAN.md
+++ b/docs/MODERNISATION_PLAN.md
@@ -1,0 +1,131 @@
+# Modernisation Plan
+
+## Goal
+
+Bring Fantasy Sumo up to date without losing the useful parts of the old prototype or getting trapped in a huge dependency-upgrade swamp.
+
+The safest approach is to separate work into two streams:
+
+1. **Stabilise and document the legacy app.**
+2. **Modernise or rebuild deliberately.**
+
+## Current risk profile
+
+The current stack is old enough that a direct dependency upgrade may be more expensive than a controlled rebuild:
+
+- React 16 -> current React.
+- TypeScript 3 -> current TypeScript.
+- webpack 4 -> Vite or current webpack.
+- TSLint -> ESLint.
+- `request` -> native `fetch`, `undici`, or another maintained HTTP client.
+- `awesome-typescript-loader` -> no longer needed with Vite, or replace with modern loaders.
+- MySQL X DevAPI usage should be reassessed.
+
+## Recommended path
+
+### Phase 0: Preserve current knowledge
+
+- Add docs describing product intent, current architecture, and roadmap.
+- Record known legacy hazards.
+- Avoid feature work until setup can be reproduced.
+
+### Phase 1: Make the existing app runnable if practical
+
+- Identify a Node version that can install the current dependencies.
+- Add `.nvmrc` or `.tool-versions`.
+- Add `.env.example`.
+- Remove hard-coded DB credentials from source.
+- Document local MySQL setup.
+- Confirm whether the banzuke import endpoint still works.
+
+Exit criteria:
+
+- `npm install` works on the documented Node version.
+- `npm test` works, or known test blockers are documented.
+- App can start locally, or blockers are captured.
+
+### Phase 2: Decide upgrade vs rebuild
+
+Make a conscious decision between:
+
+#### Option A: Incremental upgrade
+
+Useful if the app runs and the codebase is still close to viable.
+
+Suggested order:
+
+1. Move secrets/config to env vars.
+2. Replace TSLint with ESLint.
+3. Upgrade TypeScript.
+4. Replace deprecated HTTP client.
+5. Upgrade test tooling.
+6. Upgrade front-end build tooling.
+7. Upgrade React.
+
+#### Option B: Controlled rebuild
+
+Likely attractive because the current app is small and unfinished.
+
+Potential target:
+
+- Vite + React + TypeScript for the client.
+- Express/Fastify/Hono or Next.js/Remix depending on desired deployment shape.
+- SQLite/Postgres/MySQL depending on hosting preference.
+- Prisma/Drizzle or simple SQL migrations.
+- Vitest/Jest for tests.
+
+Do not rebuild blindly. First preserve:
+
+- Product intent.
+- Existing banzuke/rikishi display behaviour.
+- Any useful parsing/import logic.
+- Domain naming.
+
+## Suggested modern MVP stack
+
+For the quickest useful hobby-project version:
+
+- TypeScript throughout.
+- Vite + React for the client.
+- Express or Hono API server.
+- SQLite for local-first development, moving to Postgres if deploying publicly.
+- Drizzle or Prisma for schema/migrations.
+- Vitest for domain/service tests.
+- Playwright later for core user flows.
+
+## Security and config cleanup
+
+Before any deployment:
+
+- Remove hard-coded DB credentials.
+- Add `.env.example`.
+- Add local-only defaults where safe.
+- Keep production secrets outside source control.
+- Do not expose admin import endpoints without protection.
+
+## Data-source investigation
+
+The app currently imports banzuke data from sumo.or.jp. Before relying on this:
+
+- Verify the endpoint still exists.
+- Check whether results data is available in a stable machine-readable format.
+- Consider a manual CSV/JSON import path as a fallback.
+- Keep data import adapters isolated so the data source can change.
+
+## Recommended first engineering tickets
+
+1. Add `.env.example` and move DB config to environment variables.
+2. Add local setup docs for the legacy app.
+3. Verify the current app can build and start.
+4. Add a pure scoring module with tests.
+5. Add a minimal domain model for basho, rikishi, teams, picks, and results.
+6. Create a first team selection screen using mocked/static data.
+7. Add leaderboard calculation from test data.
+
+## Avoid initially
+
+- Building complete auth before the game loop works.
+- Complex private league management.
+- Real-time updates.
+- Overly clever scoring.
+- Large dependency upgrades mixed with feature work.

--- a/docs/PROJECT_BRIEF.md
+++ b/docs/PROJECT_BRIEF.md
@@ -1,0 +1,79 @@
+# Fantasy Sumo Project Brief
+
+## One-line summary
+
+Fantasy Sumo is a fantasy sports game for professional sumo where players select rikishi before a basho and score points from their performance.
+
+## Why this exists
+
+Sumo has a compact tournament structure, a rich ranking system, memorable personalities, and clear win/loss outcomes. That makes it ideal for a small fantasy game that can be played casually by friends during each basho.
+
+## Target experience
+
+A player should be able to:
+
+1. See the upcoming/current basho.
+2. Browse rikishi and their ranks.
+3. Pick a fantasy team before the tournament starts.
+4. Follow their team's score during the tournament.
+5. Compare scores on a leaderboard.
+
+## MVP scope
+
+The first useful version should be intentionally small:
+
+- One active basho at a time.
+- A fixed team size.
+- Simple scoring based on wins.
+- A leaderboard.
+- Basic data import/update for banzuke and results.
+- A simple local/dev deployment path.
+
+## Out of scope for the first MVP
+
+- Complex authentication.
+- Payments.
+- Public leagues with moderation tools.
+- Mobile apps.
+- Live push updates.
+- Rich historical analytics.
+- Complex scoring modifiers unless intentionally added later.
+
+## Domain language
+
+- **Basho**: A tournament.
+- **Rikishi**: A professional sumo wrestler.
+- **Banzuke**: The official ranking list for a tournament.
+- **Heya**: A sumo stable.
+- **Shikona**: A rikishi's ring name.
+- **Bout/Torikumi**: A match.
+- **Kimarite**: Winning technique.
+- **Kachi-koshi**: More wins than losses in a tournament.
+- **Make-koshi**: More losses than wins in a tournament.
+
+## Open product decisions
+
+These should be decided before implementing the full MVP:
+
+1. Team size: how many rikishi does a player choose?
+2. Selection constraints: can players pick any ranks, or must they choose from rank bands?
+3. Scoring:
+   - 1 point per win only?
+   - Bonus for kinboshi/upsets?
+   - Bonus for kachi-koshi?
+   - Penalty for absent/withdrawn rikishi?
+4. Timing: when do picks lock?
+5. Leagues: global leaderboard only, or private friend leagues?
+6. Auth: no auth, magic link, OAuth, or simple username for early MVP?
+7. Data source: official sumo.or.jp endpoints, manual CSV import, or another maintained API?
+
+## Recommended MVP scoring v0
+
+Start with something simple and transparent:
+
+- +1 point for each win by a picked rikishi.
+- 0 points for a loss or absence.
+- Team score is the sum of all picked rikishi points.
+- Ties are allowed initially.
+
+Keep this in an isolated scoring module so future bonuses can be added safely.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,77 @@
+# Roadmap
+
+This roadmap is intentionally practical. The project should become playable before it becomes polished.
+
+## Stage 1: Documentation and repo recovery
+
+Goal: make the project understandable and safe for future AI/human contributors.
+
+- [x] Add AI agent guidance.
+- [x] Add project brief.
+- [x] Add architecture notes.
+- [x] Add modernization plan.
+- [ ] Add local setup instructions once verified.
+- [ ] Add `.env.example`.
+- [ ] Document database schema or replace it with migrations.
+
+## Stage 2: Legacy app stabilisation
+
+Goal: understand whether to upgrade or rebuild.
+
+- [ ] Identify working Node version.
+- [ ] Confirm dependency install works.
+- [ ] Confirm TypeScript build works.
+- [ ] Confirm client dev server works.
+- [ ] Confirm Express server starts.
+- [ ] Confirm `/api/get-rankings` works with local data.
+- [ ] Confirm `/api/update-rankings` still imports banzuke data.
+- [ ] Replace hard-coded DB credentials with env vars.
+
+## Stage 3: Playable local MVP
+
+Goal: make the core game loop work locally.
+
+- [ ] Define MVP scoring rules.
+- [ ] Add scoring module and tests.
+- [ ] Model basho/tournament data.
+- [ ] Model rikishi/banzuke entries.
+- [ ] Model fantasy teams and picks.
+- [ ] Add team selection flow.
+- [ ] Add result import or manual result entry.
+- [ ] Add leaderboard calculation.
+- [ ] Add leaderboard UI.
+
+## Stage 4: Friendly single-league version
+
+Goal: make it usable by a small group of friends.
+
+- [ ] Add simple user identity or display-name-based teams.
+- [ ] Add private league concept if needed.
+- [ ] Add pick-locking before basho starts.
+- [ ] Add basic admin flow for importing data.
+- [ ] Improve responsive UI.
+- [ ] Add error/loading/empty states.
+
+## Stage 5: Public-ready version
+
+Goal: make it robust enough to share more widely.
+
+- [ ] Add proper authentication.
+- [ ] Add production database and migrations.
+- [ ] Add deployment pipeline.
+- [ ] Add monitoring/logging.
+- [ ] Protect admin endpoints.
+- [ ] Add backup/restore plan.
+- [ ] Add privacy/security review.
+
+## Nice future ideas
+
+- Rank-band drafts, e.g. one sanyaku, two maegashira, etc.
+- Bonus points for upset wins.
+- Penalties or substitutions for kyujo/withdrawal.
+- Historical basho archives.
+- Friends/private leagues.
+- Discord/Slack result summaries.
+- Auto-generated basho recap posts.
+- Player cards with form history.
+- Draft mode where rikishi can only be picked by one player per league.


### PR DESCRIPTION
## Summary

Adds a starter documentation pack so humans and AI coding agents can understand the current Fantasy Sumo prototype and work on it safely.

## Added

- `AGENTS.md` with AI-agent guardrails, product context, legacy hazards, and definition of done.
- Expanded `README.md` with current functionality, tech stack, docs links, and next steps.
- `docs/PROJECT_BRIEF.md` covering product intent, MVP scope, domain language, and open decisions.
- `docs/ARCHITECTURE.md` describing the current client/server/data structure and a suggested MVP architecture.
- `docs/MODERNISATION_PLAN.md` outlining safe options for upgrading or rebuilding the old stack.
- `docs/ROADMAP.md` with staged recovery, MVP, and public-ready milestones.

## Notes

This is documentation-only. It does not change runtime code.

Important legacy issue captured in the docs: the current database layer contains hard-coded local credentials and should be moved to environment variables before serious development or deployment.