### PR TITLE
[codex] Document rebuild architecture decision

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Start here:
 - `AGENTS.md` - guidance for AI coding agents working on the repo.
 - `docs/PROJECT_BRIEF.md` - product intent and MVP definition.
 - `docs/ARCHITECTURE.md` - current architecture and suggested future boundaries.
+- `docs/adr/0001-rebuild-architecture.md` - accepted rebuild architecture decision.
 - `docs/MODERNISATION_PLAN.md` - safe path for updating or rebuilding the app.
 - `docs/ROADMAP.md` - staged product/engineering roadmap.
 
@@ -64,7 +65,7 @@ The legacy data layer currently contains hard-coded local database credentials. 
 
 ## Recommended next steps
 
-1. Verify whether the legacy app can still install/build/run.
-2. Add `.env.example` and remove hard-coded DB credentials.
-3. Decide whether to incrementally modernise or rebuild around the documented domain model.
+1. Scaffold the pnpm workspace described in `docs/adr/0001-rebuild-architecture.md`.
+2. Add Vite + React, Fastify, shared domain, and Drizzle + SQLite packages.
+3. Add scoring v0 in the domain package with tests.
 4. Implement the smallest playable MVP: pick a team, enter/import results, calculate scores, show leaderboard.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,11 @@
 # Architecture Notes
 
+## Rebuild decision
+
+The accepted rebuild decision is recorded in [ADR 0001: Rebuild architecture and app foundation](adr/0001-rebuild-architecture.md).
+
+In short: the current app is disposable legacy/reference, and the next foundation should be a small pnpm workspace with a Vite + React web app, Fastify API, SQLite database, Drizzle migrations, and isolated TypeScript domain package. The notes below describe the legacy app and historical target boundaries; prefer ADR 0001 for new implementation work.
+
 ## Current architecture
 
 Fantasy Sumo currently has a simple full-stack TypeScript structure:

--- a/docs/MODERNISATION_PLAN.md
+++ b/docs/MODERNISATION_PLAN.md
@@ -23,6 +23,8 @@ The current stack is old enough that a direct dependency upgrade may be more exp
 
 ## Recommended path
 
+Update: [ADR 0001](adr/0001-rebuild-architecture.md) has chosen the controlled rebuild path. The legacy app should now be treated as disposable reference rather than something to stabilise before feature work.
+
 ### Phase 0: Preserve current knowledge
 
 - Add docs describing product intent, current architecture, and roadmap.
@@ -43,6 +45,8 @@ Exit criteria:
 - `npm install` works on the documented Node version.
 - `npm test` works, or known test blockers are documented.
 - App can start locally, or blockers are captured.
+
+This phase is now optional. Do it only if a future ticket needs to recover specific legacy behaviour, such as the old banzuke import shape.
 
 ### Phase 2: Decide upgrade vs rebuild
 
@@ -66,12 +70,13 @@ Suggested order:
 
 Likely attractive because the current app is small and unfinished.
 
-Potential target:
+Accepted target:
 
 - Vite + React + TypeScript for the client.
-- Express/Fastify/Hono or Next.js/Remix depending on desired deployment shape.
-- SQLite/Postgres/MySQL depending on hosting preference.
-- Prisma/Drizzle or simple SQL migrations.
+- Fastify API server.
+- pnpm workspace with small `apps/*` and `packages/*` boundaries.
+- SQLite for the first local MVP.
+- Drizzle for schema and migrations.
 - Vitest/Jest for tests.
 
 Do not rebuild blindly. First preserve:
@@ -87,9 +92,9 @@ For the quickest useful hobby-project version:
 
 - TypeScript throughout.
 - Vite + React for the client.
-- Express or Hono API server.
+- Fastify API server.
 - SQLite for local-first development, moving to Postgres if deploying publicly.
-- Drizzle or Prisma for schema/migrations.
+- Drizzle for schema/migrations.
 - Vitest for domain/service tests.
 - Playwright later for core user flows.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -10,22 +10,23 @@ Goal: make the project understandable and safe for future AI/human contributors.
 - [x] Add project brief.
 - [x] Add architecture notes.
 - [x] Add modernization plan.
+- [x] Decide rebuild architecture and app foundation.
 - [ ] Add local setup instructions once verified.
 - [ ] Add `.env.example`.
 - [ ] Document database schema or replace it with migrations.
 
-## Stage 2: Legacy app stabilisation
+## Stage 2: Rebuild foundation
 
-Goal: understand whether to upgrade or rebuild.
+Goal: replace the disposable legacy prototype with a clean pnpm workspace foundation as described in `docs/adr/0001-rebuild-architecture.md`.
 
-- [ ] Identify working Node version.
-- [ ] Confirm dependency install works.
-- [ ] Confirm TypeScript build works.
-- [ ] Confirm client dev server works.
-- [ ] Confirm Express server starts.
-- [ ] Confirm `/api/get-rankings` works with local data.
-- [ ] Confirm `/api/update-rankings` still imports banzuke data.
-- [ ] Replace hard-coded DB credentials with env vars.
+- [ ] Add pnpm workspace configuration.
+- [ ] Create Vite + React web app.
+- [ ] Create Fastify API with a health endpoint.
+- [ ] Create shared TypeScript domain package.
+- [ ] Add Drizzle + SQLite database package and migration setup.
+- [ ] Add first scoring v0 function with tests.
+- [ ] Update README setup commands for pnpm.
+- [ ] Remove legacy runtime files once the new scaffold replaces them.
 
 ## Stage 3: Playable local MVP
 

--- a/docs/adr/0001-rebuild-architecture.md
+++ b/docs/adr/0001-rebuild-architecture.md
@@ -1,0 +1,147 @@
+# ADR 0001: Rebuild architecture and app foundation
+
+## Status
+
+Accepted.
+
+## Context
+
+Fantasy Sumo is an unfinished prototype. The existing app can display banzuke/ranking data from a local MySQL database, but it does not yet implement the fantasy game loop. Its stack is also old: React 16, TypeScript 3, webpack 4, Express 4, TSLint, `request`, and MySQL X DevAPI.
+
+The project brief prioritises a small playable MVP over a large platform:
+
+- one active basho at a time;
+- a fixed team size;
+- simple win-based scoring;
+- basic banzuke/results import or admin update path;
+- a leaderboard;
+- local-first development before public deployment.
+
+The current code is therefore useful as historical reference for domain names, banzuke display, and the old sumo.or.jp import shape, but it should not constrain the rebuild.
+
+## Decision
+
+Rebuild Fantasy Sumo as a clean, modern TypeScript web app. Treat the old app as disposable legacy/reference and replace the runtime foundation rather than incrementally upgrading the current webpack/Express/MySQL prototype.
+
+Use `pnpm` for package management, matching the approach used in Super Tiro and avoiding further investment in the current `npm`/`package-lock.json` setup.
+
+Use a pnpm workspace from the start, but keep it small:
+
+```text
+apps/
+  web/          Vite + React client
+  api/          Fastify API server
+packages/
+  domain/       Pure domain logic, scoring, validation, shared types
+  db/           SQLite schema, migrations, repositories
+```
+
+This is slightly more structure than a single package, but it keeps the client, API, scoring rules, and persistence boundaries explicit without turning the project into a platform. It also lets the MVP share TypeScript domain types without coupling the React app directly to server internals.
+
+Use Fastify for the API instead of keeping Express temporarily. The existing Express server is only a thin route wrapper, so keeping it would preserve little value. Fastify gives a modern TypeScript-friendly foundation, straightforward validation hooks, good test ergonomics, and enough performance/headroom without adding platform complexity.
+
+Use SQLite for the first MVP database. The app should be local-first while the core game loop is being proven, and SQLite avoids local MySQL/Postgres setup as a blocker for contributors. Revisit Postgres when the app needs a shared hosted deployment, concurrent public users, or production backup/operations work.
+
+Use Drizzle for persistence and migrations. Drizzle keeps the schema close to TypeScript, has a lighter runtime footprint than Prisma, works well with SQLite, and is enough for the MVP's simple relational model. Raw SQL can still be used for small reporting queries where it is clearer, but schema changes should go through migrations.
+
+Use Vitest for unit tests, with the first test coverage focused on `packages/domain` scoring, pick validation, team lock rules, and leaderboard ordering. Add Playwright later when the browser flow stabilises.
+
+## Proposed Source Structure
+
+The implementation ticket should replace the legacy layout with this structure:
+
+```text
+apps/
+  web/
+    src/
+      app/
+      features/
+        basho/
+        team-selection/
+        leaderboard/
+      api/
+      main.tsx
+  api/
+    src/
+      server.ts
+      config/
+      routes/
+      services/
+      repositories/
+      importers/
+packages/
+  domain/
+    src/
+      basho/
+      rikishi/
+      fantasy-team/
+      scoring/
+      leaderboard/
+      index.ts
+  db/
+    drizzle/
+      migrations/
+    src/
+      schema.ts
+      client.ts
+      repositories/
+docs/
+  adr/
+```
+
+Boundary rules:
+
+- `packages/domain` must stay persistence-free and framework-free.
+- `apps/api` owns HTTP request/response handling, application workflows, and admin import endpoints.
+- `packages/db` owns schema, migrations, database client creation, and repository implementations.
+- `apps/web` owns browser UI and calls the API rather than importing server code.
+- Import logic stays separate from scoring logic.
+
+## Initial MVP Data Model
+
+Start with tables and domain objects for:
+
+- `Basho`
+- `Rikishi`
+- `BanzukeEntry`
+- `FantasyTeam`
+- `FantasyPick`
+- `BoutResult`
+
+Keep scoring v0 simple:
+
+- +1 point for each win by a picked rikishi;
+- 0 points for a loss or absence;
+- team score is the sum of picked rikishi points;
+- ties are allowed initially.
+
+## Trade-offs
+
+A single package would be slightly faster to scaffold, but it would blur the API/domain/persistence boundaries that matter most for this app. A small workspace is the better default because scoring and data import should remain isolated and testable.
+
+Postgres would be a better first choice for a public hosted app, but it adds setup overhead before the MVP is playable. SQLite is the right first choice for a local-first rebuild and can be replaced later behind repository boundaries.
+
+Prisma would provide a polished ORM experience, but it is heavier than the MVP needs. Drizzle is a better fit for explicit schema, lightweight migrations, and simple SQL-shaped data access.
+
+Keeping Express would reduce one dependency decision, but the legacy Express app has no meaningful structure to preserve. Fastify is the cleaner baseline for the rebuild.
+
+## Consequences
+
+- The next implementation ticket should scaffold the pnpm workspace and minimal apps/packages only; it should not attempt the full product rebuild.
+- The legacy `src/`, webpack config, npm lockfile, and MySQL connection can be removed during the scaffold ticket once the replacement skeleton is in place.
+- Documentation and setup should move from npm commands to pnpm commands.
+- Any retained banzuke import knowledge should be copied into a new importer module or fixture before deleting legacy code.
+- No production deployment assumptions are made by this decision.
+
+## Next Implementation Ticket
+
+Issue #5 should scaffold the rebuild foundation:
+
+1. Add `pnpm-workspace.yaml`, root package scripts, and a current TypeScript baseline.
+2. Create `apps/web` with Vite + React.
+3. Create `apps/api` with a minimal Fastify health endpoint.
+4. Create `packages/domain` with a tested scoring v0 function.
+5. Create `packages/db` with Drizzle + SQLite configured and an initial empty migration setup.
+6. Update README setup commands for the new pnpm workflow.
+
+Do not implement the full team selection flow, importer, or leaderboard UI in that ticket unless it is explicitly rescoped.


### PR DESCRIPTION
## Summary

- Adds ADR 0001 choosing the rebuild architecture and app foundation for issue #4.
- Documents the old app as disposable legacy/reference and selects pnpm, a small workspace, Vite + React, Fastify, SQLite, Drizzle, and Vitest.
- Updates README, architecture notes, modernization plan, and roadmap so the next implementation ticket can scaffold the new foundation without re-litigating the architecture.

## Trade-offs

- Uses a small pnpm workspace instead of a single package to keep web, API, domain, and persistence boundaries clear.
- Chooses SQLite for the first local MVP instead of Postgres/MySQL to avoid database setup blocking a playable version.
- Chooses Drizzle over Prisma for lighter schema and migration management.
- Moves directly to Fastify because the legacy Express server has little structure to preserve.

## Validation

- Docs-only change; no runtime rewrite attempted.
- Ran `git diff --cached --check` before commit.

Closes #4