### PR TITLE
Define core domain model and scoring rules

### DIFF
--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -23,7 +23,7 @@ describe("GET /api/health", () => {
     expect(response.json()).toEqual({
       ok: true,
       service: "fantasy-sumo-api",
-      foundation: "foundation",
+      domain: "core-ready",
     });
   });
 });

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,5 +1,4 @@
 import Fastify from "fastify";
-import { foundationLabel } from "@fantasy-sumo/domain";
 
 export function buildApp() {
   const app = Fastify({
@@ -9,7 +8,7 @@ export function buildApp() {
   app.get("/api/health", async () => ({
     ok: true,
     service: "fantasy-sumo-api",
-    foundation: foundationLabel,
+    domain: "core-ready",
   }));
 
   return app;

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -11,5 +11,6 @@ describe("App", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Vite + React")).toBeInTheDocument();
     expect(screen.getByText("Fastify")).toBeInTheDocument();
+    expect(screen.getByText("Domain core")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,3 @@
-import { foundationLabel } from "@fantasy-sumo/domain";
-
 export function App() {
   return (
     <main className="app-shell">
@@ -21,7 +19,7 @@ export function App() {
           </div>
           <div>
             <dt>Package</dt>
-            <dd>{foundationLabel}</dd>
+            <dd>Domain core</dd>
           </div>
         </dl>
       </section>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -68,6 +68,7 @@ Current behaviour:
 - Exports shared TypeScript types for `Basho`, `Rikishi`, `BanzukeEntry`, `FantasyTeam`, `FantasyPick`, `BoutResult`, and `LeaderboardEntry`.
 - Scores a rikishi as one point per win.
 - Scores a team as the sum of all wins by the team's picked rikishi.
+- Supports optional day-bounded scoring with `throughDay` so callers can calculate standings after a specific basho day without relying on an implicit "latest" result.
 - Calculates a leaderboard ordered by score descending.
 - Allows tied team scores and orders ties deterministically by display name, then team id.
 - Validates duplicate picks and exact team size when a team size is supplied.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,14 +15,14 @@ apps/
   web/          Vite + React smoke app
   api/          Fastify API
 packages/
-  domain/       Shared TypeScript domain boundary placeholder
+  domain/       Shared TypeScript domain types, validation, scoring
 ```
 
 The active app is split into:
 
 - a React client built by Vite;
 - a Fastify API compiled by TypeScript;
-- a shared framework-free domain package;
+- a shared framework-free domain package with MVP types, pick validation, scoring, and leaderboard calculation;
 - root pnpm scripts for dev, build, test, lint, and formatting.
 
 ## Front end
@@ -58,6 +58,25 @@ Current limitations:
 - No auth.
 - No typed API contracts.
 - No fantasy team, tournament, scoring, result, or leaderboard endpoints yet.
+
+## Domain package
+
+The domain package entry point is `packages/domain/src/index.ts`.
+
+Current behaviour:
+
+- Exports shared TypeScript types for `Basho`, `Rikishi`, `BanzukeEntry`, `FantasyTeam`, `FantasyPick`, `BoutResult`, and `LeaderboardEntry`.
+- Scores a rikishi as one point per win.
+- Scores a team as the sum of all wins by the team's picked rikishi.
+- Calculates a leaderboard ordered by score descending.
+- Allows tied team scores and orders ties deterministically by display name, then team id.
+- Validates duplicate picks and exact team size when a team size is supplied.
+
+Current limitations:
+
+- No scoring bonuses yet.
+- No rank-band or budget validation yet.
+- No persistence or API dependency by design.
 
 ## Data layer
 

--- a/docs/PROJECT_BRIEF.md
+++ b/docs/PROJECT_BRIEF.md
@@ -74,6 +74,7 @@ Start with something simple and transparent:
 - +1 point for each win by a picked rikishi.
 - 0 points for a loss or absence.
 - Team score is the sum of all picked rikishi points.
+- Scores can be calculated from all supplied results or through a specific basho day.
 - Leaderboard entries are ordered by score descending.
 - Tied teams are allowed and are ordered deterministically by display name, then team id.
 

--- a/docs/PROJECT_BRIEF.md
+++ b/docs/PROJECT_BRIEF.md
@@ -74,6 +74,7 @@ Start with something simple and transparent:
 - +1 point for each win by a picked rikishi.
 - 0 points for a loss or absence.
 - Team score is the sum of all picked rikishi points.
-- Ties are allowed initially.
+- Leaderboard entries are ordered by score descending.
+- Tied teams are allowed and are ordered deterministically by display name, then team id.
 
 Keep this in an isolated scoring module so future bonuses can be added safely.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -24,7 +24,7 @@ Goal: replace the disposable legacy prototype with a clean pnpm workspace founda
 - [x] Create Fastify API with a health endpoint.
 - [x] Create shared TypeScript domain package.
 - [ ] Add Drizzle + SQLite database package and migration setup.
-- [ ] Add first scoring v0 function with tests.
+- [x] Add first scoring v0 function with tests.
 - [x] Update README setup commands for pnpm.
 - [x] Remove legacy runtime files once the new scaffold replaces them.
 
@@ -32,14 +32,14 @@ Goal: replace the disposable legacy prototype with a clean pnpm workspace founda
 
 Goal: make the core game loop work locally.
 
-- [ ] Define MVP scoring rules.
-- [ ] Add scoring module and tests.
-- [ ] Model basho/tournament data.
-- [ ] Model rikishi/banzuke entries.
-- [ ] Model fantasy teams and picks.
+- [x] Define MVP scoring rules.
+- [x] Add scoring module and tests.
+- [x] Model basho/tournament data.
+- [x] Model rikishi/banzuke entries.
+- [x] Model fantasy teams and picks.
 - [ ] Add team selection flow.
 - [ ] Add result import or manual result entry.
-- [ ] Add leaderboard calculation.
+- [x] Add leaderboard calculation.
 - [ ] Add leaderboard UI.
 
 ## Stage 4: Friendly single-league version

--- a/packages/domain/src/index.test.ts
+++ b/packages/domain/src/index.test.ts
@@ -1,8 +1,0 @@
-import { describe, expect, it } from "vitest";
-import { foundationLabel } from "./index";
-
-describe("foundationLabel", () => {
-  it("identifies the shared domain package boundary", () => {
-    expect(foundationLabel).toBe("foundation");
-  });
-});

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -1,1 +1,25 @@
-export const foundationLabel = "foundation";
+export type {
+  BanzukeEntry,
+  Basho,
+  BashoStatus,
+  BoutResult,
+  FantasyPick,
+  FantasyTeam,
+  LeaderboardEntry,
+  PickValidationError,
+  PickValidationErrorCode,
+  PickValidationOptions,
+  Rikishi,
+  RikishiScore,
+  TeamScore,
+} from "./types.js";
+export {
+  calculateLeaderboard,
+  compareLeaderboardEntries,
+} from "./leaderboard.js";
+export {
+  calculateRikishiScore,
+  calculateTeamScore,
+  countPickedRikishiWins,
+} from "./scoring.js";
+export { validateFantasyPicks } from "./validation.js";

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -11,6 +11,7 @@ export type {
   PickValidationOptions,
   Rikishi,
   RikishiScore,
+  ScoringOptions,
   TeamScore,
 } from "./types.js";
 export {

--- a/packages/domain/src/leaderboard.test.ts
+++ b/packages/domain/src/leaderboard.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import { calculateLeaderboard } from "./leaderboard.js";
+import type { BoutResult, FantasyPick, FantasyTeam } from "./types.js";
+
+const teams: FantasyTeam[] = [
+  {
+    id: "team-b",
+    bashoId: "2026-05",
+    displayName: "Beta",
+  },
+  {
+    id: "team-a",
+    bashoId: "2026-05",
+    displayName: "Alpha",
+  },
+  {
+    id: "team-c",
+    bashoId: "2026-05",
+    displayName: "Gamma",
+  },
+];
+
+const picks: FantasyPick[] = [
+  {
+    teamId: "team-a",
+    rikishiId: "onosato",
+  },
+  {
+    teamId: "team-b",
+    rikishiId: "kotozakura",
+  },
+  {
+    teamId: "team-c",
+    rikishiId: "hoshoryu",
+  },
+];
+
+const results: BoutResult[] = [
+  {
+    id: "bout-1",
+    bashoId: "2026-05",
+    day: 1,
+    winnerRikishiId: "onosato",
+    loserRikishiId: "kotozakura",
+  },
+  {
+    id: "bout-2",
+    bashoId: "2026-05",
+    day: 2,
+    winnerRikishiId: "onosato",
+    loserRikishiId: "hoshoryu",
+  },
+  {
+    id: "bout-3",
+    bashoId: "2026-05",
+    day: 3,
+    winnerRikishiId: "kotozakura",
+    loserRikishiId: "hoshoryu",
+  },
+];
+
+describe("calculateLeaderboard", () => {
+  it("orders multiple teams by score descending", () => {
+    expect(
+      calculateLeaderboard(teams, picks, results).map((entry) => ({
+        teamId: entry.teamId,
+        score: entry.score,
+        rank: entry.rank,
+      })),
+    ).toEqual([
+      {
+        teamId: "team-a",
+        score: 2,
+        rank: 1,
+      },
+      {
+        teamId: "team-b",
+        score: 1,
+        rank: 2,
+      },
+      {
+        teamId: "team-c",
+        score: 0,
+        rank: 3,
+      },
+    ]);
+  });
+
+  it("orders tied teams deterministically by display name, then team id", () => {
+    const tiedTeams: FantasyTeam[] = [
+      {
+        id: "team-c",
+        bashoId: "2026-05",
+        displayName: "Same",
+      },
+      {
+        id: "team-a",
+        bashoId: "2026-05",
+        displayName: "Same",
+      },
+      {
+        id: "team-b",
+        bashoId: "2026-05",
+        displayName: "Another",
+      },
+    ];
+
+    expect(
+      calculateLeaderboard(tiedTeams, [], []).map((entry) => ({
+        teamId: entry.teamId,
+        displayName: entry.displayName,
+        score: entry.score,
+      })),
+    ).toEqual([
+      {
+        teamId: "team-b",
+        displayName: "Another",
+        score: 0,
+      },
+      {
+        teamId: "team-a",
+        displayName: "Same",
+        score: 0,
+      },
+      {
+        teamId: "team-c",
+        displayName: "Same",
+        score: 0,
+      },
+    ]);
+  });
+});

--- a/packages/domain/src/leaderboard.test.ts
+++ b/packages/domain/src/leaderboard.test.ts
@@ -86,6 +86,34 @@ describe("calculateLeaderboard", () => {
     ]);
   });
 
+  it("can calculate leaderboard standings through a specific basho day", () => {
+    expect(
+      calculateLeaderboard(teams, picks, results, {
+        throughDay: 2,
+      }).map((entry) => ({
+        teamId: entry.teamId,
+        score: entry.score,
+        rank: entry.rank,
+      })),
+    ).toEqual([
+      {
+        teamId: "team-a",
+        score: 2,
+        rank: 1,
+      },
+      {
+        teamId: "team-b",
+        score: 0,
+        rank: 2,
+      },
+      {
+        teamId: "team-c",
+        score: 0,
+        rank: 3,
+      },
+    ]);
+  });
+
   it("orders tied teams deterministically by display name, then team id", () => {
     const tiedTeams: FantasyTeam[] = [
       {

--- a/packages/domain/src/leaderboard.ts
+++ b/packages/domain/src/leaderboard.ts
@@ -1,0 +1,42 @@
+import { calculateTeamScore } from "./scoring.js";
+import type {
+  BoutResult,
+  FantasyPick,
+  FantasyTeam,
+  LeaderboardEntry,
+  TeamScore,
+} from "./types.js";
+
+export function calculateLeaderboard(
+  teams: readonly FantasyTeam[],
+  picks: readonly FantasyPick[],
+  boutResults: readonly BoutResult[],
+): LeaderboardEntry[] {
+  const sortedScores = teams
+    .map((team) => calculateTeamScore(team, picks, boutResults))
+    .sort(compareLeaderboardEntries);
+
+  return sortedScores.map((entry, index) => ({
+    ...entry,
+    rank: index + 1,
+  }));
+}
+
+export function compareLeaderboardEntries(
+  first: TeamScore,
+  second: TeamScore,
+): number {
+  if (first.score !== second.score) {
+    return second.score - first.score;
+  }
+
+  const displayNameComparison = first.displayName.localeCompare(
+    second.displayName,
+  );
+
+  if (displayNameComparison !== 0) {
+    return displayNameComparison;
+  }
+
+  return first.teamId.localeCompare(second.teamId);
+}

--- a/packages/domain/src/leaderboard.ts
+++ b/packages/domain/src/leaderboard.ts
@@ -4,6 +4,7 @@ import type {
   FantasyPick,
   FantasyTeam,
   LeaderboardEntry,
+  ScoringOptions,
   TeamScore,
 } from "./types.js";
 
@@ -11,9 +12,10 @@ export function calculateLeaderboard(
   teams: readonly FantasyTeam[],
   picks: readonly FantasyPick[],
   boutResults: readonly BoutResult[],
+  options: ScoringOptions = {},
 ): LeaderboardEntry[] {
   const sortedScores = teams
-    .map((team) => calculateTeamScore(team, picks, boutResults))
+    .map((team) => calculateTeamScore(team, picks, boutResults, options))
     .sort(compareLeaderboardEntries);
 
   return sortedScores.map((entry, index) => ({

--- a/packages/domain/src/scoring.test.ts
+++ b/packages/domain/src/scoring.test.ts
@@ -69,6 +69,18 @@ describe("calculateRikishiScore", () => {
       score: 1,
     });
   });
+
+  it("can score a rikishi through a specific basho day", () => {
+    expect(
+      calculateRikishiScore("onosato", results, {
+        throughDay: 2,
+      }),
+    ).toEqual({
+      rikishiId: "onosato",
+      wins: 0,
+      score: 0,
+    });
+  });
 });
 
 describe("calculateTeamScore", () => {
@@ -116,5 +128,24 @@ describe("calculateTeamScore", () => {
     ];
 
     expect(calculateTeamScore(team, picks, results).score).toBe(1);
+  });
+
+  it("can score a team through a specific basho day", () => {
+    const picks: FantasyPick[] = [
+      {
+        teamId: team.id,
+        rikishiId: "kotozakura",
+      },
+      {
+        teamId: team.id,
+        rikishiId: "onosato",
+      },
+    ];
+
+    expect(
+      calculateTeamScore(team, picks, results, {
+        throughDay: 2,
+      }).score,
+    ).toBe(1);
   });
 });

--- a/packages/domain/src/scoring.test.ts
+++ b/packages/domain/src/scoring.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import {
+  calculateRikishiScore,
+  calculateTeamScore,
+  countPickedRikishiWins,
+} from "./scoring.js";
+import type { BoutResult, FantasyPick, FantasyTeam } from "./types.js";
+
+const team: FantasyTeam = {
+  id: "team-a",
+  bashoId: "2026-05",
+  displayName: "Team A",
+};
+
+const results: BoutResult[] = [
+  {
+    id: "bout-1",
+    bashoId: "2026-05",
+    day: 1,
+    winnerRikishiId: "kotozakura",
+    loserRikishiId: "hoshoryu",
+  },
+  {
+    id: "bout-2",
+    bashoId: "2026-05",
+    day: 2,
+    winnerRikishiId: "hoshoryu",
+    loserRikishiId: "kotozakura",
+  },
+  {
+    id: "bout-3",
+    bashoId: "2026-05",
+    day: 3,
+    winnerRikishiId: "onosato",
+    loserRikishiId: "kotozakura",
+  },
+];
+
+describe("countPickedRikishiWins", () => {
+  it("scores one point for a single rikishi win", () => {
+    expect(countPickedRikishiWins("onosato", results)).toBe(1);
+  });
+
+  it("scores zero for losses", () => {
+    expect(countPickedRikishiWins("kirishima", results)).toBe(0);
+  });
+
+  it("does not score an absent winner as a win", () => {
+    expect(
+      countPickedRikishiWins("onosato", [
+        {
+          id: "bout-absent",
+          bashoId: "2026-05",
+          day: 4,
+          winnerRikishiId: "onosato",
+          loserRikishiId: "kotozakura",
+          winnerAbsent: true,
+        },
+      ]),
+    ).toBe(0);
+  });
+});
+
+describe("calculateRikishiScore", () => {
+  it("returns wins and score for a picked rikishi", () => {
+    expect(calculateRikishiScore("kotozakura", results)).toEqual({
+      rikishiId: "kotozakura",
+      wins: 1,
+      score: 1,
+    });
+  });
+});
+
+describe("calculateTeamScore", () => {
+  it("scores a team as the sum of picked rikishi wins", () => {
+    const picks: FantasyPick[] = [
+      {
+        teamId: team.id,
+        rikishiId: "kotozakura",
+      },
+      {
+        teamId: team.id,
+        rikishiId: "onosato",
+      },
+    ];
+
+    expect(calculateTeamScore(team, picks, results)).toMatchObject({
+      teamId: team.id,
+      displayName: team.displayName,
+      score: 2,
+      rikishiScores: [
+        {
+          rikishiId: "kotozakura",
+          wins: 1,
+          score: 1,
+        },
+        {
+          rikishiId: "onosato",
+          wins: 1,
+          score: 1,
+        },
+      ],
+    });
+  });
+
+  it("ignores picks belonging to other teams", () => {
+    const picks: FantasyPick[] = [
+      {
+        teamId: team.id,
+        rikishiId: "kotozakura",
+      },
+      {
+        teamId: "team-b",
+        rikishiId: "onosato",
+      },
+    ];
+
+    expect(calculateTeamScore(team, picks, results).score).toBe(1);
+  });
+});

--- a/packages/domain/src/scoring.ts
+++ b/packages/domain/src/scoring.ts
@@ -4,24 +4,26 @@ import type {
   FantasyTeam,
   Rikishi,
   RikishiScore,
+  ScoringOptions,
   TeamScore,
 } from "./types.js";
 
 export function countPickedRikishiWins(
   rikishiId: Rikishi["id"],
   boutResults: readonly BoutResult[],
+  options: ScoringOptions = {},
 ): number {
-  return boutResults.filter(
-    (result) =>
-      result.winnerRikishiId === rikishiId && result.winnerAbsent !== true,
+  return filterResultsForScoring(boutResults, options).filter(
+    (result) => result.winnerRikishiId === rikishiId,
   ).length;
 }
 
 export function calculateRikishiScore(
   rikishiId: Rikishi["id"],
   boutResults: readonly BoutResult[],
+  options: ScoringOptions = {},
 ): RikishiScore {
-  const wins = countPickedRikishiWins(rikishiId, boutResults);
+  const wins = countPickedRikishiWins(rikishiId, boutResults, options);
 
   return {
     rikishiId,
@@ -34,10 +36,11 @@ export function calculateTeamScore(
   team: FantasyTeam,
   picks: readonly FantasyPick[],
   boutResults: readonly BoutResult[],
+  options: ScoringOptions = {},
 ): TeamScore {
   const teamPicks = picks.filter((pick) => pick.teamId === team.id);
   const rikishiScores = teamPicks.map((pick) =>
-    calculateRikishiScore(pick.rikishiId, boutResults),
+    calculateRikishiScore(pick.rikishiId, boutResults, options),
   );
 
   return {
@@ -49,4 +52,15 @@ export function calculateTeamScore(
     ),
     rikishiScores,
   };
+}
+
+function filterResultsForScoring(
+  boutResults: readonly BoutResult[],
+  options: ScoringOptions,
+): BoutResult[] {
+  return boutResults.filter(
+    (result) =>
+      result.winnerAbsent !== true &&
+      (options.throughDay === undefined || result.day <= options.throughDay),
+  );
 }

--- a/packages/domain/src/scoring.ts
+++ b/packages/domain/src/scoring.ts
@@ -1,0 +1,52 @@
+import type {
+  BoutResult,
+  FantasyPick,
+  FantasyTeam,
+  Rikishi,
+  RikishiScore,
+  TeamScore,
+} from "./types.js";
+
+export function countPickedRikishiWins(
+  rikishiId: Rikishi["id"],
+  boutResults: readonly BoutResult[],
+): number {
+  return boutResults.filter(
+    (result) =>
+      result.winnerRikishiId === rikishiId && result.winnerAbsent !== true,
+  ).length;
+}
+
+export function calculateRikishiScore(
+  rikishiId: Rikishi["id"],
+  boutResults: readonly BoutResult[],
+): RikishiScore {
+  const wins = countPickedRikishiWins(rikishiId, boutResults);
+
+  return {
+    rikishiId,
+    wins,
+    score: wins,
+  };
+}
+
+export function calculateTeamScore(
+  team: FantasyTeam,
+  picks: readonly FantasyPick[],
+  boutResults: readonly BoutResult[],
+): TeamScore {
+  const teamPicks = picks.filter((pick) => pick.teamId === team.id);
+  const rikishiScores = teamPicks.map((pick) =>
+    calculateRikishiScore(pick.rikishiId, boutResults),
+  );
+
+  return {
+    teamId: team.id,
+    displayName: team.displayName,
+    score: rikishiScores.reduce(
+      (total, rikishiScore) => total + rikishiScore.score,
+      0,
+    ),
+    rikishiScores,
+  };
+}

--- a/packages/domain/src/types.ts
+++ b/packages/domain/src/types.ts
@@ -54,6 +54,10 @@ export interface RikishiScore {
   score: number;
 }
 
+export interface ScoringOptions {
+  throughDay?: BoutResult["day"];
+}
+
 export interface TeamScore {
   teamId: FantasyTeam["id"];
   displayName: FantasyTeam["displayName"];

--- a/packages/domain/src/types.ts
+++ b/packages/domain/src/types.ts
@@ -1,0 +1,80 @@
+export type BashoStatus = "upcoming" | "active" | "complete";
+
+export interface Basho {
+  id: string;
+  name: string;
+  startDate: string;
+  endDate: string;
+  status: BashoStatus;
+}
+
+export interface Rikishi {
+  id: string;
+  shikona: string;
+  heya?: string;
+}
+
+export interface BanzukeEntry {
+  id: string;
+  bashoId: Basho["id"];
+  rikishiId: Rikishi["id"];
+  rank: string;
+  rankOrder: number;
+}
+
+export interface FantasyTeam {
+  id: string;
+  bashoId: Basho["id"];
+  displayName: string;
+  ownerName?: string;
+  createdAt?: string;
+  lockedAt?: string;
+}
+
+export interface FantasyPick {
+  id?: string;
+  teamId: FantasyTeam["id"];
+  rikishiId: Rikishi["id"];
+}
+
+export interface BoutResult {
+  id: string;
+  bashoId: Basho["id"];
+  day: number;
+  winnerRikishiId: Rikishi["id"];
+  loserRikishiId: Rikishi["id"];
+  kimarite?: string;
+  winnerAbsent?: boolean;
+  loserAbsent?: boolean;
+}
+
+export interface RikishiScore {
+  rikishiId: Rikishi["id"];
+  wins: number;
+  score: number;
+}
+
+export interface TeamScore {
+  teamId: FantasyTeam["id"];
+  displayName: FantasyTeam["displayName"];
+  score: number;
+  rikishiScores: RikishiScore[];
+}
+
+export interface LeaderboardEntry extends TeamScore {
+  rank: number;
+}
+
+export type PickValidationErrorCode = "duplicate-pick" | "invalid-team-size";
+
+export interface PickValidationError {
+  code: PickValidationErrorCode;
+  message: string;
+  rikishiId?: Rikishi["id"];
+  expectedTeamSize?: number;
+  actualTeamSize?: number;
+}
+
+export interface PickValidationOptions {
+  teamSize?: number;
+}

--- a/packages/domain/src/validation.test.ts
+++ b/packages/domain/src/validation.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { validateFantasyPicks } from "./validation.js";
+
+describe("validateFantasyPicks", () => {
+  it("accepts unique picks at the expected team size", () => {
+    expect(
+      validateFantasyPicks(
+        [
+          {
+            teamId: "team-a",
+            rikishiId: "onosato",
+          },
+          {
+            teamId: "team-a",
+            rikishiId: "kotozakura",
+          },
+        ],
+        {
+          teamSize: 2,
+        },
+      ),
+    ).toEqual([]);
+  });
+
+  it("rejects duplicate picks", () => {
+    expect(
+      validateFantasyPicks([
+        {
+          teamId: "team-a",
+          rikishiId: "onosato",
+        },
+        {
+          teamId: "team-a",
+          rikishiId: "onosato",
+        },
+      ]),
+    ).toEqual([
+      {
+        code: "duplicate-pick",
+        message: "Rikishi onosato has been picked more than once.",
+        rikishiId: "onosato",
+      },
+    ]);
+  });
+
+  it("rejects an invalid team size", () => {
+    expect(
+      validateFantasyPicks(
+        [
+          {
+            teamId: "team-a",
+            rikishiId: "onosato",
+          },
+        ],
+        {
+          teamSize: 2,
+        },
+      ),
+    ).toEqual([
+      {
+        code: "invalid-team-size",
+        message: "Expected 2 picks, received 1.",
+        expectedTeamSize: 2,
+        actualTeamSize: 1,
+      },
+    ]);
+  });
+});

--- a/packages/domain/src/validation.ts
+++ b/packages/domain/src/validation.ts
@@ -1,0 +1,61 @@
+import type {
+  FantasyPick,
+  PickValidationError,
+  PickValidationOptions,
+  Rikishi,
+} from "./types.js";
+
+export function validateFantasyPicks(
+  picks: readonly FantasyPick[],
+  options: PickValidationOptions = {},
+): PickValidationError[] {
+  return [
+    ...validateTeamSize(picks, options),
+    ...validateDuplicatePicks(picks),
+  ];
+}
+
+function validateTeamSize(
+  picks: readonly FantasyPick[],
+  options: PickValidationOptions,
+): PickValidationError[] {
+  if (options.teamSize === undefined || picks.length === options.teamSize) {
+    return [];
+  }
+
+  return [
+    {
+      code: "invalid-team-size",
+      message: `Expected ${options.teamSize} picks, received ${picks.length}.`,
+      expectedTeamSize: options.teamSize,
+      actualTeamSize: picks.length,
+    },
+  ];
+}
+
+function validateDuplicatePicks(
+  picks: readonly FantasyPick[],
+): PickValidationError[] {
+  return findDuplicateRikishiIds(picks).map((rikishiId) => ({
+    code: "duplicate-pick",
+    message: `Rikishi ${rikishiId} has been picked more than once.`,
+    rikishiId,
+  }));
+}
+
+function findDuplicateRikishiIds(
+  picks: readonly FantasyPick[],
+): Rikishi["id"][] {
+  const seen = new Set<Rikishi["id"]>();
+  const duplicates = new Set<Rikishi["id"]>();
+
+  for (const pick of picks) {
+    if (seen.has(pick.rikishiId)) {
+      duplicates.add(pick.rikishiId);
+    }
+
+    seen.add(pick.rikishiId);
+  }
+
+  return [...duplicates].sort();
+}


### PR DESCRIPTION
## Summary

- Adds reusable MVP domain types for basho, rikishi, banzuke entries, fantasy teams, picks, bout results, and leaderboard entries.
- Adds pure scoring functions for rikishi wins and team totals using scoring v0: one point per picked rikishi win, zero for losses or absence.
- Adds leaderboard calculation ordered by score descending with deterministic tie ordering by display name, then team id.
- Adds pick validation for duplicate rikishi picks and exact team size checks.
- Updates docs to describe the implemented domain package and scoring v0 rules.

## Validation

- `pnpm build`
- `pnpm test`
- `pnpm lint`
- `pnpm format:check`

Closes #6