### PR TITLE
Build MVP API routes for basho, rikishi, teams and leaderboard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ The original app was an unfinished barebones prototype. Treat the removed legacy
 - Back end: Fastify, TypeScript, Node.
 - Shared code: `packages/domain` for framework-free domain boundaries.
 - Data: SQLite via `packages/db`, with Drizzle schema, migration SQL, repositories, and seed data.
-- Existing behaviour: displays a foundation smoke page and exposes local MVP API routes for health, basho, rikishi, team creation/retrieval, and leaderboard data.
+- Existing behaviour: displays a foundation smoke page and exposes local game API routes for health, basho, rikishi, team creation/retrieval, and leaderboard data.
 
 ## Intended MVP direction
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ The original app was an unfinished barebones prototype. Treat the removed legacy
 - Back end: Fastify, TypeScript, Node.
 - Shared code: `packages/domain` for framework-free domain boundaries.
 - Data: SQLite via `packages/db`, with Drizzle schema, migration SQL, repositories, and seed data.
-- Existing behaviour: displays a foundation smoke page and exposes `GET /api/health`.
+- Existing behaviour: displays a foundation smoke page and exposes local MVP API routes for health, basho, rikishi, team creation/retrieval, and leaderboard data.
 
 ## Intended MVP direction
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The current codebase has been reset onto the clean rebuild foundation described 
 
 ## Current functionality
 
-At present, the app has the first local MVP foundations:
+At present, the app has the first local playable foundations:
 
 - A Vite + React front-end smoke page.
 - A Fastify API with health, basho, rikishi, team, and leaderboard endpoints.

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ The current codebase has been reset onto the clean rebuild foundation described 
 
 ## Current functionality
 
-At present, the app has only foundation smoke functionality:
+At present, the app has the first local MVP foundations:
 
 - A Vite + React front-end smoke page.
-- A Fastify API with `GET /api/health`.
+- A Fastify API with health, basho, rikishi, team, and leaderboard endpoints.
 - A shared TypeScript domain package with MVP types, validation, scoring, and leaderboard logic.
 - A local SQLite + Drizzle database package with schema, migration, repositories, and sample seed data.
 - Vitest, ESLint, and Prettier wired through pnpm scripts.
@@ -69,6 +69,14 @@ Local URLs:
 
 - Web: `http://localhost:5173`
 - API health: `http://localhost:3000/api/health`
+
+Useful API endpoints:
+
+- `GET /api/basho/current`
+- `GET /api/basho/:bashoId/rikishi`
+- `POST /api/basho/:bashoId/teams`
+- `GET /api/basho/:bashoId/teams/:teamId`
+- `GET /api/basho/:bashoId/leaderboard`
 
 Useful checks:
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,12 +4,13 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx watch src/server.ts",
-    "build": "tsc -p tsconfig.json",
+    "dev": "pnpm --filter @fantasy-sumo/db build && tsx watch src/server.ts",
+    "build": "pnpm --filter @fantasy-sumo/db build && tsc -p tsconfig.json",
     "start": "node dist/server.js",
-    "test": "vitest run src"
+    "test": "pnpm --filter @fantasy-sumo/db build && vitest run src"
   },
   "dependencies": {
+    "@fantasy-sumo/db": "workspace:*",
     "@fantasy-sumo/domain": "workspace:*",
     "fastify": "^5.6.2"
   },

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "@fantasy-sumo/db": "workspace:*",
     "@fantasy-sumo/domain": "workspace:*",
-    "fastify": "^5.6.2"
+    "fastify": "^5.6.2",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^24.10.1",

--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -1,36 +1,21 @@
-import { mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import type { FastifyInstance } from "fastify";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import {
-  createDatabaseClient,
-  runMigrations,
-  seedDatabase,
-  type DatabaseClient,
-} from "@fantasy-sumo/db";
+import { createDatabaseClient, type DatabaseClient } from "@fantasy-sumo/db";
 import { buildApp } from "./app.js";
 
 let app: FastifyInstance;
 let client: DatabaseClient;
-let tmpRoot: string;
 
 beforeEach(() => {
-  tmpRoot = mkdtempSync(join(tmpdir(), "fantasy-sumo-api-"));
-  client = createDatabaseClient(`file:${join(tmpRoot, "test.sqlite")}`);
-  runMigrations(client.db);
-  seedDatabase(client.db);
+  client = createDatabaseClient(":memory:");
   app = buildApp({
     db: client.db,
-    now: () => new Date("2026-05-02T09:00:00.000Z"),
-    teamIdFactory: () => "north",
   });
 });
 
 afterEach(async () => {
   await app.close();
   client.close();
-  rmSync(tmpRoot, { force: true, recursive: true });
 });
 
 describe("GET /api/health", () => {
@@ -45,186 +30,6 @@ describe("GET /api/health", () => {
       ok: true,
       service: "fantasy-sumo-api",
       domain: "core-ready",
-    });
-  });
-});
-
-describe("MVP API routes", () => {
-  it("returns the current basho", async () => {
-    const response = await app.inject({
-      method: "GET",
-      url: "/api/basho/current",
-    });
-
-    expect(response.statusCode).toBe(200);
-    expect(response.json()).toMatchObject({
-      id: "2026-05",
-      name: "May 2026 Sample Basho",
-      status: "active",
-    });
-  });
-
-  it("returns rikishi for a basho with banzuke ranks", async () => {
-    const response = await app.inject({
-      method: "GET",
-      url: "/api/basho/2026-05/rikishi",
-    });
-
-    expect(response.statusCode).toBe(200);
-    const body = response.json();
-
-    expect(body.basho).toMatchObject({
-      id: "2026-05",
-    });
-    expect(body.rikishi).toHaveLength(4);
-    expect(body.rikishi[0]).toMatchObject({
-      id: "onosato",
-      shikona: "Onosato",
-      rank: "Ozeki",
-      rankOrder: 1,
-    });
-  });
-
-  it("creates and retrieves a fantasy team", async () => {
-    const createResponse = await app.inject({
-      method: "POST",
-      url: "/api/basho/2026-05/teams",
-      payload: {
-        displayName: "North Side",
-        ownerName: "New Player",
-        rikishiIds: ["onosato", "kotozakura"],
-      },
-    });
-
-    expect(createResponse.statusCode).toBe(201);
-    expect(createResponse.json()).toEqual({
-      team: {
-        id: "team-north",
-        bashoId: "2026-05",
-        displayName: "North Side",
-        ownerName: "New Player",
-        createdAt: "2026-05-02T09:00:00.000Z",
-      },
-      picks: [
-        {
-          id: "team-north-kotozakura",
-          teamId: "team-north",
-          rikishiId: "kotozakura",
-        },
-        {
-          id: "team-north-onosato",
-          teamId: "team-north",
-          rikishiId: "onosato",
-        },
-      ],
-    });
-
-    const getResponse = await app.inject({
-      method: "GET",
-      url: "/api/basho/2026-05/teams/team-north",
-    });
-
-    expect(getResponse.statusCode).toBe(200);
-    expect(getResponse.json().team).toMatchObject({
-      id: "team-north",
-      displayName: "North Side",
-    });
-  });
-
-  it("rejects invalid team picks", async () => {
-    const response = await app.inject({
-      method: "POST",
-      url: "/api/basho/2026-05/teams",
-      payload: {
-        displayName: "Bad Team",
-        rikishiIds: ["onosato", "onosato"],
-      },
-    });
-
-    expect(response.statusCode).toBe(400);
-    expect(response.json()).toMatchObject({
-      error: "invalid-picks",
-      details: [
-        {
-          code: "duplicate-pick",
-          rikishiId: "onosato",
-        },
-      ],
-    });
-  });
-
-  it("rejects picks outside the requested basho", async () => {
-    const response = await app.inject({
-      method: "POST",
-      url: "/api/basho/2026-05/teams",
-      payload: {
-        displayName: "Bad Team",
-        rikishiIds: ["onosato", "unknown"],
-      },
-    });
-
-    expect(response.statusCode).toBe(400);
-    expect(response.json()).toMatchObject({
-      error: "invalid-picks",
-      details: [
-        {
-          code: "unknown-rikishi",
-          rikishiId: "unknown",
-        },
-      ],
-    });
-  });
-
-  it("returns a leaderboard ordered by score", async () => {
-    const response = await app.inject({
-      method: "GET",
-      url: "/api/basho/2026-05/leaderboard",
-    });
-
-    expect(response.statusCode).toBe(200);
-    expect(
-      response
-        .json()
-        .leaderboard.map(
-          (entry: { displayName: string; score: number; rank: number }) => ({
-            displayName: entry.displayName,
-            score: entry.score,
-            rank: entry.rank,
-          }),
-        ),
-    ).toEqual([
-      {
-        displayName: "East Side",
-        score: 2,
-        rank: 1,
-      },
-      {
-        displayName: "West Side",
-        score: 1,
-        rank: 2,
-      },
-    ]);
-  });
-
-  it("returns clear 404 errors for unknown basho and teams", async () => {
-    const bashoResponse = await app.inject({
-      method: "GET",
-      url: "/api/basho/unknown/rikishi",
-    });
-    const teamResponse = await app.inject({
-      method: "GET",
-      url: "/api/basho/2026-05/teams/unknown",
-    });
-
-    expect(bashoResponse.statusCode).toBe(404);
-    expect(bashoResponse.json()).toMatchObject({
-      error: "not-found",
-      message: "Basho unknown was not found.",
-    });
-    expect(teamResponse.statusCode).toBe(404);
-    expect(teamResponse.json()).toMatchObject({
-      error: "not-found",
-      message: "Team unknown was not found for basho 2026-05.",
     });
   });
 });

--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -1,15 +1,36 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { FastifyInstance } from "fastify";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createDatabaseClient,
+  runMigrations,
+  seedDatabase,
+  type DatabaseClient,
+} from "@fantasy-sumo/db";
 import { buildApp } from "./app.js";
 
 let app: FastifyInstance;
+let client: DatabaseClient;
+let tmpRoot: string;
 
 beforeEach(() => {
-  app = buildApp();
+  tmpRoot = mkdtempSync(join(tmpdir(), "fantasy-sumo-api-"));
+  client = createDatabaseClient(`file:${join(tmpRoot, "test.sqlite")}`);
+  runMigrations(client.db);
+  seedDatabase(client.db);
+  app = buildApp({
+    db: client.db,
+    now: () => new Date("2026-05-02T09:00:00.000Z"),
+    teamIdFactory: () => "north",
+  });
 });
 
 afterEach(async () => {
   await app.close();
+  client.close();
+  rmSync(tmpRoot, { force: true, recursive: true });
 });
 
 describe("GET /api/health", () => {
@@ -24,6 +45,186 @@ describe("GET /api/health", () => {
       ok: true,
       service: "fantasy-sumo-api",
       domain: "core-ready",
+    });
+  });
+});
+
+describe("MVP API routes", () => {
+  it("returns the current basho", async () => {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/basho/current",
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      id: "2026-05",
+      name: "May 2026 Sample Basho",
+      status: "active",
+    });
+  });
+
+  it("returns rikishi for a basho with banzuke ranks", async () => {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/basho/2026-05/rikishi",
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+
+    expect(body.basho).toMatchObject({
+      id: "2026-05",
+    });
+    expect(body.rikishi).toHaveLength(4);
+    expect(body.rikishi[0]).toMatchObject({
+      id: "onosato",
+      shikona: "Onosato",
+      rank: "Ozeki",
+      rankOrder: 1,
+    });
+  });
+
+  it("creates and retrieves a fantasy team", async () => {
+    const createResponse = await app.inject({
+      method: "POST",
+      url: "/api/basho/2026-05/teams",
+      payload: {
+        displayName: "North Side",
+        ownerName: "New Player",
+        rikishiIds: ["onosato", "kotozakura"],
+      },
+    });
+
+    expect(createResponse.statusCode).toBe(201);
+    expect(createResponse.json()).toEqual({
+      team: {
+        id: "team-north",
+        bashoId: "2026-05",
+        displayName: "North Side",
+        ownerName: "New Player",
+        createdAt: "2026-05-02T09:00:00.000Z",
+      },
+      picks: [
+        {
+          id: "team-north-kotozakura",
+          teamId: "team-north",
+          rikishiId: "kotozakura",
+        },
+        {
+          id: "team-north-onosato",
+          teamId: "team-north",
+          rikishiId: "onosato",
+        },
+      ],
+    });
+
+    const getResponse = await app.inject({
+      method: "GET",
+      url: "/api/basho/2026-05/teams/team-north",
+    });
+
+    expect(getResponse.statusCode).toBe(200);
+    expect(getResponse.json().team).toMatchObject({
+      id: "team-north",
+      displayName: "North Side",
+    });
+  });
+
+  it("rejects invalid team picks", async () => {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/basho/2026-05/teams",
+      payload: {
+        displayName: "Bad Team",
+        rikishiIds: ["onosato", "onosato"],
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toMatchObject({
+      error: "invalid-picks",
+      details: [
+        {
+          code: "duplicate-pick",
+          rikishiId: "onosato",
+        },
+      ],
+    });
+  });
+
+  it("rejects picks outside the requested basho", async () => {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/basho/2026-05/teams",
+      payload: {
+        displayName: "Bad Team",
+        rikishiIds: ["onosato", "unknown"],
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toMatchObject({
+      error: "invalid-picks",
+      details: [
+        {
+          code: "unknown-rikishi",
+          rikishiId: "unknown",
+        },
+      ],
+    });
+  });
+
+  it("returns a leaderboard ordered by score", async () => {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/basho/2026-05/leaderboard",
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(
+      response
+        .json()
+        .leaderboard.map(
+          (entry: { displayName: string; score: number; rank: number }) => ({
+            displayName: entry.displayName,
+            score: entry.score,
+            rank: entry.rank,
+          }),
+        ),
+    ).toEqual([
+      {
+        displayName: "East Side",
+        score: 2,
+        rank: 1,
+      },
+      {
+        displayName: "West Side",
+        score: 1,
+        rank: 2,
+      },
+    ]);
+  });
+
+  it("returns clear 404 errors for unknown basho and teams", async () => {
+    const bashoResponse = await app.inject({
+      method: "GET",
+      url: "/api/basho/unknown/rikishi",
+    });
+    const teamResponse = await app.inject({
+      method: "GET",
+      url: "/api/basho/2026-05/teams/unknown",
+    });
+
+    expect(bashoResponse.statusCode).toBe(404);
+    expect(bashoResponse.json()).toMatchObject({
+      error: "not-found",
+      message: "Basho unknown was not found.",
+    });
+    expect(teamResponse.statusCode).toBe(404);
+    expect(teamResponse.json()).toMatchObject({
+      error: "not-found",
+      message: "Team unknown was not found for basho 2026-05.",
     });
   });
 });

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,15 +1,48 @@
+import { randomUUID } from "node:crypto";
 import Fastify from "fastify";
+import {
+  createDatabaseClient,
+  createRepositories,
+  type SqliteDatabase,
+} from "@fantasy-sumo/db";
+import { registerMvpRoutes } from "./routes/mvp.js";
 
-export function buildApp() {
+const MVP_TEAM_SIZE = 2;
+
+interface AppOptions {
+  db?: SqliteDatabase;
+  now?: () => Date;
+  teamIdFactory?: () => string;
+  teamSize?: number;
+}
+
+export function buildApp(options: AppOptions = {}) {
+  const ownedClient =
+    options.db === undefined ? createDatabaseClient() : undefined;
   const app = Fastify({
     logger: true,
   });
+  const db = options.db ?? ownedClient!.db;
+  const repositories = createRepositories(db);
+
+  if (ownedClient !== undefined) {
+    app.addHook("onClose", async () => {
+      ownedClient.close();
+    });
+  }
 
   app.get("/api/health", async () => ({
     ok: true,
     service: "fantasy-sumo-api",
     domain: "core-ready",
   }));
+
+  registerMvpRoutes(app, {
+    repositories,
+    now: options.now ?? (() => new Date()),
+    teamIdFactory: options.teamIdFactory ?? randomUUID,
+    teamSize: options.teamSize ?? MVP_TEAM_SIZE,
+  });
 
   return app;
 }

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -5,9 +5,9 @@ import {
   createRepositories,
   type SqliteDatabase,
 } from "@fantasy-sumo/db";
-import { registerMvpRoutes } from "./routes/mvp.js";
+import { registerBashoRoutes } from "./routes/basho.js";
 
-const MVP_TEAM_SIZE = 2;
+const TEAM_SIZE = 2;
 
 interface AppOptions {
   db?: SqliteDatabase;
@@ -37,11 +37,11 @@ export function buildApp(options: AppOptions = {}) {
     domain: "core-ready",
   }));
 
-  registerMvpRoutes(app, {
+  registerBashoRoutes(app, {
     repositories,
     now: options.now ?? (() => new Date()),
     teamIdFactory: options.teamIdFactory ?? randomUUID,
-    teamSize: options.teamSize ?? MVP_TEAM_SIZE,
+    teamSize: options.teamSize ?? TEAM_SIZE,
   });
 
   return app;

--- a/apps/api/src/routes/basho.test.ts
+++ b/apps/api/src/routes/basho.test.ts
@@ -1,0 +1,231 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { FastifyInstance } from "fastify";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createDatabaseClient,
+  runMigrations,
+  seedDatabase,
+  type DatabaseClient,
+} from "@fantasy-sumo/db";
+import { buildApp } from "../app.js";
+
+let app: FastifyInstance;
+let client: DatabaseClient;
+let tmpRoot: string;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), "fantasy-sumo-api-"));
+  client = createDatabaseClient(`file:${join(tmpRoot, "test.sqlite")}`);
+  runMigrations(client.db);
+  seedDatabase(client.db);
+  app = buildApp({
+    db: client.db,
+    now: () => new Date("2026-05-02T09:00:00.000Z"),
+    teamIdFactory: () => "north",
+  });
+});
+
+afterEach(async () => {
+  await app.close();
+  client.close();
+  rmSync(tmpRoot, { force: true, recursive: true });
+});
+
+describe("basho routes", () => {
+  it("returns the current basho", async () => {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/basho/current",
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      id: "2026-05",
+      name: "May 2026 Sample Basho",
+      status: "active",
+    });
+  });
+
+  it("returns rikishi for a basho with banzuke ranks", async () => {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/basho/2026-05/rikishi",
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+
+    expect(body.basho).toMatchObject({
+      id: "2026-05",
+    });
+    expect(body.rikishi).toHaveLength(4);
+    expect(body.rikishi[0]).toMatchObject({
+      id: "onosato",
+      shikona: "Onosato",
+      rank: "Ozeki",
+      rankOrder: 1,
+    });
+  });
+
+  it("creates and retrieves a fantasy team", async () => {
+    const createResponse = await app.inject({
+      method: "POST",
+      url: "/api/basho/2026-05/teams",
+      payload: {
+        displayName: "North Side",
+        ownerName: "New Player",
+        rikishiIds: ["onosato", "kotozakura"],
+      },
+    });
+
+    expect(createResponse.statusCode).toBe(201);
+    expect(createResponse.json()).toEqual({
+      team: {
+        id: "team-north",
+        bashoId: "2026-05",
+        displayName: "North Side",
+        ownerName: "New Player",
+        createdAt: "2026-05-02T09:00:00.000Z",
+      },
+      picks: [
+        {
+          id: "team-north-kotozakura",
+          teamId: "team-north",
+          rikishiId: "kotozakura",
+        },
+        {
+          id: "team-north-onosato",
+          teamId: "team-north",
+          rikishiId: "onosato",
+        },
+      ],
+    });
+
+    const getResponse = await app.inject({
+      method: "GET",
+      url: "/api/basho/2026-05/teams/team-north",
+    });
+
+    expect(getResponse.statusCode).toBe(200);
+    expect(getResponse.json().team).toMatchObject({
+      id: "team-north",
+      displayName: "North Side",
+    });
+  });
+
+  it("rejects invalid team picks", async () => {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/basho/2026-05/teams",
+      payload: {
+        displayName: "Bad Team",
+        rikishiIds: ["onosato", "onosato"],
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toMatchObject({
+      error: "invalid-picks",
+      details: [
+        {
+          code: "duplicate-pick",
+          rikishiId: "onosato",
+        },
+      ],
+    });
+  });
+
+  it("rejects malformed team creation requests", async () => {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/basho/2026-05/teams",
+      payload: {
+        displayName: " ",
+        rikishiIds: "onosato",
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toMatchObject({
+      error: "invalid-request",
+      message: "Team creation request is invalid.",
+    });
+  });
+
+  it("rejects picks outside the requested basho", async () => {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/basho/2026-05/teams",
+      payload: {
+        displayName: "Bad Team",
+        rikishiIds: ["onosato", "unknown"],
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toMatchObject({
+      error: "invalid-picks",
+      details: [
+        {
+          code: "unknown-rikishi",
+          rikishiId: "unknown",
+        },
+      ],
+    });
+  });
+
+  it("returns a leaderboard ordered by score", async () => {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/basho/2026-05/leaderboard",
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(
+      response
+        .json()
+        .leaderboard.map(
+          (entry: { displayName: string; score: number; rank: number }) => ({
+            displayName: entry.displayName,
+            score: entry.score,
+            rank: entry.rank,
+          }),
+        ),
+    ).toEqual([
+      {
+        displayName: "East Side",
+        score: 2,
+        rank: 1,
+      },
+      {
+        displayName: "West Side",
+        score: 1,
+        rank: 2,
+      },
+    ]);
+  });
+
+  it("returns clear 404 errors for unknown basho and teams", async () => {
+    const bashoResponse = await app.inject({
+      method: "GET",
+      url: "/api/basho/unknown/rikishi",
+    });
+    const teamResponse = await app.inject({
+      method: "GET",
+      url: "/api/basho/2026-05/teams/unknown",
+    });
+
+    expect(bashoResponse.statusCode).toBe(404);
+    expect(bashoResponse.json()).toMatchObject({
+      error: "not-found",
+      message: "Basho unknown was not found.",
+    });
+    expect(teamResponse.statusCode).toBe(404);
+    expect(teamResponse.json()).toMatchObject({
+      error: "not-found",
+      message: "Team unknown was not found for basho 2026-05.",
+    });
+  });
+});

--- a/apps/api/src/routes/basho.ts
+++ b/apps/api/src/routes/basho.ts
@@ -1,4 +1,5 @@
 import type { FastifyInstance } from "fastify";
+import { z } from "zod";
 import type { Repositories } from "@fantasy-sumo/db";
 import type { FantasyPick, FantasyTeam } from "@fantasy-sumo/domain";
 import {
@@ -13,13 +14,16 @@ interface RouteContext {
   teamSize: number;
 }
 
-interface CreateTeamBody {
-  displayName?: string;
-  ownerName?: string;
-  rikishiIds?: string[];
-}
+const createTeamBodySchema = z.object({
+  displayName: z.string().trim().min(1),
+  ownerName: z.string().trim().optional(),
+  rikishiIds: z.array(z.string().trim().min(1)),
+});
 
-export function registerMvpRoutes(app: FastifyInstance, context: RouteContext) {
+export function registerBashoRoutes(
+  app: FastifyInstance,
+  context: RouteContext,
+) {
   app.get("/api/basho/current", async (_request, reply) => {
     const currentBasho = findCurrentBasho(context.repositories);
 
@@ -72,109 +76,88 @@ export function registerMvpRoutes(app: FastifyInstance, context: RouteContext) {
 
   app.post<{
     Params: { bashoId: string };
-    Body: CreateTeamBody;
-  }>(
-    "/api/basho/:bashoId/teams",
-    {
-      schema: {
-        body: {
-          type: "object",
-          required: ["displayName", "rikishiIds"],
-          additionalProperties: false,
-          properties: {
-            displayName: { type: "string", minLength: 1 },
-            ownerName: { type: "string" },
-            rikishiIds: {
-              type: "array",
-              items: { type: "string", minLength: 1 },
-            },
-          },
-        },
-      },
-    },
-    async (request, reply) => {
-      const basho = context.repositories.getBasho(request.params.bashoId);
+    Body: unknown;
+  }>("/api/basho/:bashoId/teams", async (request, reply) => {
+    const basho = context.repositories.getBasho(request.params.bashoId);
 
-      if (basho === undefined) {
-        return reply.code(404).send({
-          error: "not-found",
-          message: `Basho ${request.params.bashoId} was not found.`,
-        });
-      }
+    if (basho === undefined) {
+      return reply.code(404).send({
+        error: "not-found",
+        message: `Basho ${request.params.bashoId} was not found.`,
+      });
+    }
 
-      const displayName = request.body.displayName?.trim() ?? "";
-      const ownerName = request.body.ownerName?.trim();
-      const rikishiIds = request.body.rikishiIds ?? [];
+    const parsedBody = createTeamBodySchema.safeParse(request.body);
 
-      if (displayName.length === 0) {
-        return reply.code(400).send({
-          error: "invalid-request",
-          message: "displayName is required.",
-        });
-      }
+    if (!parsedBody.success) {
+      return reply.code(400).send({
+        error: "invalid-request",
+        message: "Team creation request is invalid.",
+        details: parsedBody.error.issues.map((issue) => ({
+          path: issue.path.join("."),
+          message: issue.message,
+        })),
+      });
+    }
 
-      const teamId = `team-${context.teamIdFactory()}`;
-      const picks = rikishiIds.map(
-        (rikishiId): FantasyPick => ({
-          teamId,
+    const { displayName, ownerName, rikishiIds } = parsedBody.data;
+    const teamId = `team-${context.teamIdFactory()}`;
+    const picks = rikishiIds.map(
+      (rikishiId): FantasyPick => ({
+        teamId,
+        rikishiId,
+      }),
+    );
+    const pickErrors = validateFantasyPicks(picks, {
+      teamSize: context.teamSize,
+    });
+
+    if (pickErrors.length > 0) {
+      return reply.code(400).send({
+        error: "invalid-picks",
+        message: "Fantasy team picks are invalid.",
+        details: pickErrors,
+      });
+    }
+
+    const validRikishiIds = new Set(
+      context.repositories
+        .listBanzukeEntriesForBasho(basho.id)
+        .map((entry) => entry.rikishiId),
+    );
+    const invalidRikishiIds = rikishiIds.filter(
+      (rikishiId) => !validRikishiIds.has(rikishiId),
+    );
+
+    if (invalidRikishiIds.length > 0) {
+      return reply.code(400).send({
+        error: "invalid-picks",
+        message: "Fantasy team picks include rikishi outside this basho.",
+        details: invalidRikishiIds.map((rikishiId) => ({
+          code: "unknown-rikishi",
+          message: `Rikishi ${rikishiId} is not available for basho ${basho.id}.`,
           rikishiId,
-        }),
-      );
-      const pickErrors = validateFantasyPicks(picks, {
-        teamSize: context.teamSize,
+        })),
       });
+    }
 
-      if (pickErrors.length > 0) {
-        return reply.code(400).send({
-          error: "invalid-picks",
-          message: "Fantasy team picks are invalid.",
-          details: pickErrors,
-        });
-      }
+    const team: FantasyTeam = {
+      id: teamId,
+      bashoId: basho.id,
+      displayName,
+      ...(ownerName === undefined || ownerName.length === 0
+        ? {}
+        : { ownerName }),
+      createdAt: context.now().toISOString(),
+    };
 
-      const validRikishiIds = new Set(
-        context.repositories
-          .listBanzukeEntriesForBasho(basho.id)
-          .map((entry) => entry.rikishiId),
-      );
-      const invalidRikishiIds = rikishiIds.filter(
-        (rikishiId) => !validRikishiIds.has(rikishiId),
-      );
+    context.repositories.insertFantasyTeamWithPicks(team, picks);
 
-      if (invalidRikishiIds.length > 0) {
-        return reply.code(400).send({
-          error: "invalid-picks",
-          message: "Fantasy team picks include rikishi outside this basho.",
-          details: invalidRikishiIds.map((rikishiId) => ({
-            code: "unknown-rikishi",
-            message: `Rikishi ${rikishiId} is not available for basho ${basho.id}.`,
-            rikishiId,
-          })),
-        });
-      }
-
-      const team: FantasyTeam = {
-        id: teamId,
-        bashoId: basho.id,
-        displayName,
-        ...(ownerName === undefined || ownerName.length === 0
-          ? {}
-          : { ownerName }),
-        createdAt: context.now().toISOString(),
-      };
-
-      context.repositories.insertFantasyTeam(team);
-
-      for (const pick of picks) {
-        context.repositories.insertFantasyPick(pick);
-      }
-
-      return reply.code(201).send({
-        team,
-        picks: context.repositories.listFantasyPicksForTeam(team.id),
-      });
-    },
-  );
+    return reply.code(201).send({
+      team,
+      picks: context.repositories.listFantasyPicksForTeam(team.id),
+    });
+  });
 
   app.get<{
     Params: { bashoId: string; teamId: string };

--- a/apps/api/src/routes/mvp.ts
+++ b/apps/api/src/routes/mvp.ts
@@ -1,0 +1,233 @@
+import type { FastifyInstance } from "fastify";
+import type { Repositories } from "@fantasy-sumo/db";
+import type { FantasyPick, FantasyTeam } from "@fantasy-sumo/domain";
+import {
+  calculateLeaderboard,
+  validateFantasyPicks,
+} from "@fantasy-sumo/domain";
+
+interface RouteContext {
+  repositories: Repositories;
+  now: () => Date;
+  teamIdFactory: () => string;
+  teamSize: number;
+}
+
+interface CreateTeamBody {
+  displayName?: string;
+  ownerName?: string;
+  rikishiIds?: string[];
+}
+
+export function registerMvpRoutes(app: FastifyInstance, context: RouteContext) {
+  app.get("/api/basho/current", async (_request, reply) => {
+    const currentBasho = findCurrentBasho(context.repositories);
+
+    if (currentBasho === undefined) {
+      return reply.code(404).send({
+        error: "not-found",
+        message: "No basho is available.",
+      });
+    }
+
+    return currentBasho;
+  });
+
+  app.get<{
+    Params: { bashoId: string };
+  }>("/api/basho/:bashoId/rikishi", async (request, reply) => {
+    const basho = context.repositories.getBasho(request.params.bashoId);
+
+    if (basho === undefined) {
+      return reply.code(404).send({
+        error: "not-found",
+        message: `Basho ${request.params.bashoId} was not found.`,
+      });
+    }
+
+    const rikishiById = new Map(
+      context.repositories
+        .listRikishi()
+        .map((rikishi) => [rikishi.id, rikishi]),
+    );
+    const rikishi = context.repositories
+      .listBanzukeEntriesForBasho(basho.id)
+      .map((entry) => {
+        const rikishiEntry = rikishiById.get(entry.rikishiId);
+
+        return {
+          id: entry.rikishiId,
+          shikona: rikishiEntry?.shikona ?? entry.rikishiId,
+          heya: rikishiEntry?.heya,
+          rank: entry.rank,
+          rankOrder: entry.rankOrder,
+        };
+      });
+
+    return {
+      basho,
+      rikishi,
+    };
+  });
+
+  app.post<{
+    Params: { bashoId: string };
+    Body: CreateTeamBody;
+  }>(
+    "/api/basho/:bashoId/teams",
+    {
+      schema: {
+        body: {
+          type: "object",
+          required: ["displayName", "rikishiIds"],
+          additionalProperties: false,
+          properties: {
+            displayName: { type: "string", minLength: 1 },
+            ownerName: { type: "string" },
+            rikishiIds: {
+              type: "array",
+              items: { type: "string", minLength: 1 },
+            },
+          },
+        },
+      },
+    },
+    async (request, reply) => {
+      const basho = context.repositories.getBasho(request.params.bashoId);
+
+      if (basho === undefined) {
+        return reply.code(404).send({
+          error: "not-found",
+          message: `Basho ${request.params.bashoId} was not found.`,
+        });
+      }
+
+      const displayName = request.body.displayName?.trim() ?? "";
+      const ownerName = request.body.ownerName?.trim();
+      const rikishiIds = request.body.rikishiIds ?? [];
+
+      if (displayName.length === 0) {
+        return reply.code(400).send({
+          error: "invalid-request",
+          message: "displayName is required.",
+        });
+      }
+
+      const teamId = `team-${context.teamIdFactory()}`;
+      const picks = rikishiIds.map(
+        (rikishiId): FantasyPick => ({
+          teamId,
+          rikishiId,
+        }),
+      );
+      const pickErrors = validateFantasyPicks(picks, {
+        teamSize: context.teamSize,
+      });
+
+      if (pickErrors.length > 0) {
+        return reply.code(400).send({
+          error: "invalid-picks",
+          message: "Fantasy team picks are invalid.",
+          details: pickErrors,
+        });
+      }
+
+      const validRikishiIds = new Set(
+        context.repositories
+          .listBanzukeEntriesForBasho(basho.id)
+          .map((entry) => entry.rikishiId),
+      );
+      const invalidRikishiIds = rikishiIds.filter(
+        (rikishiId) => !validRikishiIds.has(rikishiId),
+      );
+
+      if (invalidRikishiIds.length > 0) {
+        return reply.code(400).send({
+          error: "invalid-picks",
+          message: "Fantasy team picks include rikishi outside this basho.",
+          details: invalidRikishiIds.map((rikishiId) => ({
+            code: "unknown-rikishi",
+            message: `Rikishi ${rikishiId} is not available for basho ${basho.id}.`,
+            rikishiId,
+          })),
+        });
+      }
+
+      const team: FantasyTeam = {
+        id: teamId,
+        bashoId: basho.id,
+        displayName,
+        ...(ownerName === undefined || ownerName.length === 0
+          ? {}
+          : { ownerName }),
+        createdAt: context.now().toISOString(),
+      };
+
+      context.repositories.insertFantasyTeam(team);
+
+      for (const pick of picks) {
+        context.repositories.insertFantasyPick(pick);
+      }
+
+      return reply.code(201).send({
+        team,
+        picks: context.repositories.listFantasyPicksForTeam(team.id),
+      });
+    },
+  );
+
+  app.get<{
+    Params: { bashoId: string; teamId: string };
+  }>("/api/basho/:bashoId/teams/:teamId", async (request, reply) => {
+    const basho = context.repositories.getBasho(request.params.bashoId);
+
+    if (basho === undefined) {
+      return reply.code(404).send({
+        error: "not-found",
+        message: `Basho ${request.params.bashoId} was not found.`,
+      });
+    }
+
+    const team = context.repositories.getFantasyTeam(request.params.teamId);
+
+    if (team === undefined || team.bashoId !== basho.id) {
+      return reply.code(404).send({
+        error: "not-found",
+        message: `Team ${request.params.teamId} was not found for basho ${basho.id}.`,
+      });
+    }
+
+    return {
+      team,
+      picks: context.repositories.listFantasyPicksForTeam(team.id),
+    };
+  });
+
+  app.get<{
+    Params: { bashoId: string };
+  }>("/api/basho/:bashoId/leaderboard", async (request, reply) => {
+    const basho = context.repositories.getBasho(request.params.bashoId);
+
+    if (basho === undefined) {
+      return reply.code(404).send({
+        error: "not-found",
+        message: `Basho ${request.params.bashoId} was not found.`,
+      });
+    }
+
+    return {
+      bashoId: basho.id,
+      leaderboard: calculateLeaderboard(
+        context.repositories.listFantasyTeamsForBasho(basho.id),
+        context.repositories.listFantasyPicksForBasho(basho.id),
+        context.repositories.listBoutResultsForBasho(basho.id),
+      ),
+    };
+  });
+}
+
+function findCurrentBasho(repositories: Repositories) {
+  const bashos = repositories.listBashos();
+
+  return bashos.find((basho) => basho.status === "active") ?? bashos.at(-1);
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -54,12 +54,26 @@ Current routes:
 
 - `GET /api/health`
   - Returns a small JSON health payload.
+- `GET /api/basho/current`
+  - Returns the active basho, falling back to the latest available basho when none is active.
+- `GET /api/basho/:bashoId/rikishi`
+  - Returns a basho and its rikishi with banzuke rank data.
+- `POST /api/basho/:bashoId/teams`
+  - Creates a display-name-based fantasy team for the basho.
+  - Request body: `displayName`, optional `ownerName`, and `rikishiIds`.
+  - The temporary local MVP team size is 2 rikishi.
+  - Validates duplicate picks, exact team size, and whether each picked rikishi is on that basho's banzuke.
+- `GET /api/basho/:bashoId/teams/:teamId`
+  - Returns a fantasy team and its picks.
+- `GET /api/basho/:bashoId/leaderboard`
+  - Returns leaderboard entries calculated with the domain scoring module.
 
 Current limitations:
 
 - No auth.
-- No typed API contracts.
-- No fantasy team, tournament, scoring, result, or leaderboard endpoints yet.
+- No dedicated API client package.
+- No result import or manual result entry endpoints yet.
+- No pick-locking rules yet.
 
 ## Domain package
 
@@ -104,7 +118,6 @@ pnpm --filter @fantasy-sumo/db db:generate
 
 Current limitations:
 
-- No API routes use the repositories yet.
 - No live banzuke/results import yet.
 - No production database configuration yet.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -61,7 +61,7 @@ Current routes:
 - `POST /api/basho/:bashoId/teams`
   - Creates a display-name-based fantasy team for the basho.
   - Request body: `displayName`, optional `ownerName`, and `rikishiIds`.
-  - The temporary local MVP team size is 2 rikishi.
+  - The current team size is 2 rikishi.
   - Validates duplicate picks, exact team size, and whether each picked rikishi is on that basho's banzuke.
 - `GET /api/basho/:bashoId/teams/:teamId`
   - Returns a fantasy team and its picks.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -37,6 +37,7 @@ Goal: make the core game loop work locally.
 - [x] Model basho/tournament data.
 - [x] Model rikishi/banzuke entries.
 - [x] Model fantasy teams and picks.
+- [x] Expose MVP basho, rikishi, team, and leaderboard API routes.
 - [ ] Add team selection flow.
 - [ ] Add result import or manual result entry.
 - [x] Add leaderboard calculation.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -37,7 +37,7 @@ Goal: make the core game loop work locally.
 - [x] Model basho/tournament data.
 - [x] Model rikishi/banzuke entries.
 - [x] Model fantasy teams and picks.
-- [x] Expose MVP basho, rikishi, team, and leaderboard API routes.
+- [x] Expose basho, rikishi, team, and leaderboard API routes.
 - [ ] Add team selection flow.
 - [ ] Add result import or manual result entry.
 - [x] Add leaderboard calculation.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "packageManager": "pnpm@11.0.9",
   "scripts": {
-    "dev": "pnpm --filter @fantasy-sumo/domain build && concurrently -n api,web -c blue,green \"pnpm --filter @fantasy-sumo/api dev\" \"pnpm --filter @fantasy-sumo/web dev\"",
+    "dev": "pnpm --filter @fantasy-sumo/domain build && pnpm --filter @fantasy-sumo/db build && concurrently -n api,web -c blue,green \"pnpm --filter @fantasy-sumo/api dev\" \"pnpm --filter @fantasy-sumo/web dev\"",
     "build": "pnpm -r --if-present build",
     "db:migrate": "pnpm --filter @fantasy-sumo/db db:migrate",
     "db:seed": "pnpm --filter @fantasy-sumo/db db:seed",

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -8,6 +8,7 @@ export { createDatabaseClient } from "./client.js";
 export type { DatabaseClient, SqliteDatabase } from "./client.js";
 export { migrateDatabase, runMigrations } from "./migrate.js";
 export { createRepositories } from "./repositories.js";
+export type { Repositories } from "./repositories.js";
 export {
   sampleBanzukeEntries,
   sampleBasho,

--- a/packages/db/src/repositories.test.ts
+++ b/packages/db/src/repositories.test.ts
@@ -90,4 +90,32 @@ describe("repositories", () => {
         .map((team) => team.id),
     ).toContain("team-north");
   });
+
+  it("rolls back team creation when a pick insert fails", () => {
+    seedDatabase(client.db);
+    const repositories = createRepositories(client.db);
+
+    expect(() =>
+      repositories.insertFantasyTeamWithPicks(
+        {
+          id: "team-rollback",
+          bashoId: sampleBasho.id,
+          displayName: "Rollback Team",
+        },
+        [
+          {
+            teamId: "team-rollback",
+            rikishiId: "onosato",
+          },
+          {
+            teamId: "team-rollback",
+            rikishiId: "onosato",
+          },
+        ],
+      ),
+    ).toThrow();
+
+    expect(repositories.getFantasyTeam("team-rollback")).toBeUndefined();
+    expect(repositories.listFantasyPicksForTeam("team-rollback")).toEqual([]);
+  });
 });

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -18,7 +18,7 @@ import {
 } from "./schema.js";
 
 export function createRepositories(db: SqliteDatabase) {
-  return {
+  const repositories = {
     insertBasho: (entry: Basho) => db.insert(basho).values(entry).run(),
     listBashos: () => db.select().from(basho).orderBy(basho.startDate).all(),
     getBasho: (id: Basho["id"]) =>
@@ -41,6 +41,15 @@ export function createRepositories(db: SqliteDatabase) {
 
     insertFantasyTeam: (entry: FantasyTeam) =>
       db.insert(fantasyTeams).values(toFantasyTeamRow(entry)).run(),
+    getFantasyTeam: (id: FantasyTeam["id"]) => {
+      const row = db
+        .select()
+        .from(fantasyTeams)
+        .where(eq(fantasyTeams.id, id))
+        .get();
+
+      return row === undefined ? undefined : toFantasyTeam(row);
+    },
     listFantasyTeamsForBasho: (bashoId: Basho["id"]) =>
       db
         .select()
@@ -60,6 +69,10 @@ export function createRepositories(db: SqliteDatabase) {
         .orderBy(fantasyPicks.id)
         .all()
         .map(toFantasyPick),
+    listFantasyPicksForBasho: (bashoId: Basho["id"]) =>
+      repositories
+        .listFantasyTeamsForBasho(bashoId)
+        .flatMap((team) => repositories.listFantasyPicksForTeam(team.id)),
 
     insertBoutResult: (entry: BoutResult) =>
       db.insert(boutResults).values(toBoutResultRow(entry)).run(),
@@ -72,7 +85,11 @@ export function createRepositories(db: SqliteDatabase) {
         .all()
         .map(toBoutResult),
   };
+
+  return repositories;
 }
+
+export type Repositories = ReturnType<typeof createRepositories>;
 
 function toRikishiRow(entry: Rikishi) {
   return {

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -41,6 +41,17 @@ export function createRepositories(db: SqliteDatabase) {
 
     insertFantasyTeam: (entry: FantasyTeam) =>
       db.insert(fantasyTeams).values(toFantasyTeamRow(entry)).run(),
+    insertFantasyTeamWithPicks: (
+      team: FantasyTeam,
+      picks: readonly FantasyPick[],
+    ) =>
+      db.transaction((transaction) => {
+        transaction.insert(fantasyTeams).values(toFantasyTeamRow(team)).run();
+
+        for (const pick of picks) {
+          transaction.insert(fantasyPicks).values(toFantasyPickRow(pick)).run();
+        }
+      }),
     getFantasyTeam: (id: FantasyTeam["id"]) => {
       const row = db
         .select()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       fastify:
         specifier: ^5.6.2
         version: 5.8.5
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/node':
         specifier: ^24.10.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
 
   apps/api:
     dependencies:
+      '@fantasy-sumo/db':
+        specifier: workspace:*
+        version: link:../../packages/db
       '@fantasy-sumo/domain':
         specifier: workspace:*
         version: link:../../packages/domain


### PR DESCRIPTION
## Summary
- Adds Fastify MVP routes for current basho, basho rikishi, fantasy team creation/retrieval, and leaderboard data.
- Wires the API to the local SQLite/Drizzle repositories and domain leaderboard scoring.
- Adds request body validation, useful 400/404 error responses, and route tests using a temporary seeded SQLite database.
- Updates docs and setup scripts so the DB package is built before API dev/build/test commands need its exports.

## Notes
- Keeps authentication, result import/manual entry, pick locking, and front-end integration out of scope.
- Uses the current local MVP team size of 2 rikishi, documented in the architecture notes.

## Validation
- pnpm build
- pnpm test
- pnpm lint
- pnpm format:check

Closes #8