### PR TITLE
Build fantasy team selection UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 DATABASE_URL=file:./data/fantasy-sumo.sqlite
+TEAM_SIZE=2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ The original app was an unfinished barebones prototype. Treat the removed legacy
 - Back end: Fastify, TypeScript, Node.
 - Shared code: `packages/domain` for framework-free domain boundaries.
 - Data: SQLite via `packages/db`, with Drizzle schema, migration SQL, repositories, and seed data.
-- Existing behaviour: displays a foundation smoke page and exposes local game API routes for health, basho, rikishi, team creation/retrieval, and leaderboard data.
+- Existing behaviour: displays a team selection page and exposes local game API routes for health, basho, rikishi, team creation/retrieval, and leaderboard data.
 
 ## Intended MVP direction
 

--- a/README.md
+++ b/README.md
@@ -93,12 +93,14 @@ By default, the database package writes local SQLite data to `packages/db/data/f
 DATABASE_URL=file:./data/dev.sqlite pnpm db:seed
 ```
 
+The local team size defaults to `2`. Override it for the API with `TEAM_SIZE`.
+
 ## Security note
 
 The local database uses a file path only and does not require credentials. Keep future secrets out of source control.
 
 ## Recommended next steps
 
-1. Wire API routes to the database repositories.
-2. Build the first team selection flow against seeded data.
-3. Add result entry/import and make the leaderboard visible in the web app.
+1. Add result entry/import and make the leaderboard visible in the web app.
+2. Persist or retrieve the latest submitted team for follow-up views.
+3. Decide pick locking and whether the configured team size should move into database-backed basho settings.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The current codebase has been reset onto the clean rebuild foundation described 
 
 At present, the app has the first local playable foundations:
 
-- A Vite + React front-end smoke page.
+- A Vite + React front end for creating a fantasy team from seeded basho data.
 - A Fastify API with health, basho, rikishi, team, and leaderboard endpoints.
 - A shared TypeScript domain package with MVP types, validation, scoring, and leaderboard logic.
 - A local SQLite + Drizzle database package with schema, migration, repositories, and sample seed data.
@@ -101,4 +101,4 @@ The local database uses a file path only and does not require credentials. Keep 
 
 1. Wire API routes to the database repositories.
 2. Build the first team selection flow against seeded data.
-3. Implement the smallest playable MVP: pick a team, enter/import results, calculate scores, show leaderboard.
+3. Add result entry/import and make the leaderboard visible in the web app.

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -5,9 +5,8 @@ import {
   createRepositories,
   type SqliteDatabase,
 } from "@fantasy-sumo/db";
+import { getTeamSize } from "./config.js";
 import { registerBashoRoutes } from "./routes/basho.js";
-
-const TEAM_SIZE = 2;
 
 interface AppOptions {
   db?: SqliteDatabase;
@@ -41,7 +40,7 @@ export function buildApp(options: AppOptions = {}) {
     repositories,
     now: options.now ?? (() => new Date()),
     teamIdFactory: options.teamIdFactory ?? randomUUID,
-    teamSize: options.teamSize ?? TEAM_SIZE,
+    teamSize: options.teamSize ?? getTeamSize(),
   });
 
   return app;

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -1,0 +1,11 @@
+const DEFAULT_TEAM_SIZE = 2;
+
+export function getTeamSize(): number {
+  const configuredTeamSize = Number(process.env.TEAM_SIZE);
+
+  if (Number.isInteger(configuredTeamSize) && configuredTeamSize > 0) {
+    return configuredTeamSize;
+  }
+
+  return DEFAULT_TEAM_SIZE;
+}

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -1,6 +1,7 @@
 const DEFAULT_TEAM_SIZE = 2;
 
 export function getTeamSize(): number {
+  // TODO - This should come from a DB config table, possibly allowing for different team sizes configurable for each event, defined by the users running the fantasy basho. For now, we'll just use an environment variable with a default fallback.
   const configuredTeamSize = Number(process.env.TEAM_SIZE);
 
   if (Number.isInteger(configuredTeamSize) && configuredTeamSize > 0) {

--- a/apps/api/src/routes/basho.test.ts
+++ b/apps/api/src/routes/basho.test.ts
@@ -45,6 +45,7 @@ describe("basho routes", () => {
       id: "2026-05",
       name: "May 2026 Sample Basho",
       status: "active",
+      teamSize: 2,
     });
   });
 

--- a/apps/api/src/routes/basho.ts
+++ b/apps/api/src/routes/basho.ts
@@ -34,7 +34,10 @@ export function registerBashoRoutes(
       });
     }
 
-    return currentBasho;
+    return {
+      ...currentBasho,
+      teamSize: context.teamSize,
+    };
   });
 
   app.get<{

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -8,6 +8,7 @@ const currentBasho = {
   startDate: "2026-05-10",
   endDate: "2026-05-24",
   status: "active",
+  teamSize: 2,
 };
 
 const rankedRikishi = [

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -1,16 +1,188 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "./App";
 
+const currentBasho = {
+  id: "2026-05",
+  name: "May 2026 Sample Basho",
+  startDate: "2026-05-10",
+  endDate: "2026-05-24",
+  status: "active",
+};
+
+const rankedRikishi = [
+  {
+    id: "onosato",
+    shikona: "Onosato",
+    heya: "Nishonoseki",
+    rank: "Ozeki",
+    rankOrder: 1,
+  },
+  {
+    id: "kotozakura",
+    shikona: "Kotozakura",
+    heya: "Sadogatake",
+    rank: "Ozeki",
+    rankOrder: 2,
+  },
+  {
+    id: "hoshoryu",
+    shikona: "Hoshoryu",
+    heya: "Tatsunami",
+    rank: "Sekiwake",
+    rankOrder: 3,
+  },
+];
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn(mockSuccessfulFetch));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
 describe("App", () => {
-  it("renders the foundation smoke page", () => {
+  it("loads the current basho and rikishi", async () => {
     render(<App />);
 
     expect(
-      screen.getByRole("heading", { name: "Fantasy Sumo" }),
+      screen.getByText("Loading the current basho..."),
     ).toBeInTheDocument();
-    expect(screen.getByText("Vite + React")).toBeInTheDocument();
-    expect(screen.getByText("Fastify")).toBeInTheDocument();
-    expect(screen.getByText("Domain core")).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { name: "May 2026 Sample Basho" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Onosato/ })).toBeInTheDocument();
+    expect(screen.getByText("0 of 2 selected")).toBeInTheDocument();
+  });
+
+  it("allows selecting and removing rikishi up to the team size", async () => {
+    render(<App />);
+
+    await screen.findByRole("button", { name: /Onosato/ });
+    fireEvent.click(screen.getByRole("button", { name: /Onosato/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Kotozakura/ }));
+
+    expect(screen.getByText("2 of 2 selected")).toBeInTheDocument();
+    expect(screen.getByText("Team full")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Hoshoryu/ })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove Onosato" }));
+
+    expect(screen.getByText("1 of 2 selected")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Hoshoryu/ })).not.toBeDisabled();
+  });
+
+  it("submits a selected team and shows confirmation", async () => {
+    const fetchMock = vi.fn(mockSuccessfulFetch);
+    vi.stubGlobal("fetch", fetchMock);
+    render(<App />);
+
+    await screen.findByRole("button", { name: /Onosato/ });
+    fireEvent.change(screen.getByLabelText("Team name"), {
+      target: { value: "East Stand Heroes" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Onosato/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Kotozakura/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Submit team" }));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith("/api/basho/2026-05/teams", {
+        body: JSON.stringify({
+          displayName: "East Stand Heroes",
+          rikishiIds: ["onosato", "kotozakura"],
+        }),
+        headers: {
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+      }),
+    );
+    expect(
+      await screen.findByText("East Stand Heroes submitted."),
+    ).toBeInTheDocument();
+  });
+
+  it("displays API validation errors", async () => {
+    vi.stubGlobal("fetch", vi.fn(mockValidationErrorFetch));
+    render(<App />);
+
+    await screen.findByRole("button", { name: /Onosato/ });
+    fireEvent.change(screen.getByLabelText("Team name"), {
+      target: { value: "East Stand Heroes" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Onosato/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Kotozakura/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Submit team" }));
+
+    expect(
+      await screen.findByText(
+        "Fantasy team picks are invalid. Expected 2 picks, received 1.",
+      ),
+    ).toBeInTheDocument();
   });
 });
+
+function mockSuccessfulFetch(input: RequestInfo | URL): Promise<Response> {
+  const url = String(input);
+
+  if (url === "/api/basho/current") {
+    return jsonResponse(currentBasho);
+  }
+
+  if (url === "/api/basho/2026-05/rikishi") {
+    return jsonResponse({
+      basho: currentBasho,
+      rikishi: rankedRikishi,
+    });
+  }
+
+  if (url === "/api/basho/2026-05/teams") {
+    return jsonResponse(
+      {
+        team: {
+          id: "team-east-stand",
+          displayName: "East Stand Heroes",
+        },
+        picks: [{ rikishiId: "onosato" }, { rikishiId: "kotozakura" }],
+      },
+      { status: 201 },
+    );
+  }
+
+  return jsonResponse({ message: "Not found" }, { status: 404 });
+}
+
+function mockValidationErrorFetch(input: RequestInfo | URL): Promise<Response> {
+  const url = String(input);
+
+  if (url !== "/api/basho/2026-05/teams") {
+    return mockSuccessfulFetch(input);
+  }
+
+  return jsonResponse(
+    {
+      message: "Fantasy team picks are invalid.",
+      details: [
+        {
+          message: "Expected 2 picks, received 1.",
+        },
+      ],
+    },
+    { status: 400 },
+  );
+}
+
+function jsonResponse(
+  body: unknown,
+  init: ResponseInit = {},
+): Promise<Response> {
+  return Promise.resolve(
+    new Response(JSON.stringify(body), {
+      headers: {
+        "Content-Type": "application/json",
+      },
+      status: init.status ?? 200,
+    }),
+  );
+}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,28 +1,362 @@
+import type { FormEvent } from "react";
+import { useEffect, useMemo, useState } from "react";
+
+const TEAM_SIZE = 2;
+
+interface Basho {
+  id: string;
+  name: string;
+  startDate: string;
+  endDate: string;
+  status: "upcoming" | "active" | "complete";
+}
+
+interface RankedRikishi {
+  id: string;
+  shikona: string;
+  heya?: string;
+  rank: string;
+  rankOrder: number;
+}
+
+interface BashoRikishiResponse {
+  basho: Basho;
+  rikishi: RankedRikishi[];
+}
+
+interface CreatedTeamResponse {
+  team: {
+    id: string;
+    displayName: string;
+  };
+  picks: Array<{
+    rikishiId: string;
+  }>;
+}
+
+interface ApiErrorBody {
+  message?: string;
+  details?: Array<{
+    message?: string;
+  }>;
+}
+
+type LoadState = "loading" | "ready" | "empty" | "error";
+
 export function App() {
+  const [loadState, setLoadState] = useState<LoadState>("loading");
+  const [basho, setBasho] = useState<Basho | null>(null);
+  const [rikishi, setRikishi] = useState<RankedRikishi[]>([]);
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [displayName, setDisplayName] = useState("");
+  const [submitState, setSubmitState] = useState<"idle" | "submitting">("idle");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [createdTeam, setCreatedTeam] = useState<CreatedTeamResponse | null>(
+    null,
+  );
+
+  useEffect(() => {
+    let isCurrent = true;
+
+    async function loadBasho() {
+      try {
+        const currentBasho = await getJson<Basho>("/api/basho/current");
+        const bashoRikishi = await getJson<BashoRikishiResponse>(
+          `/api/basho/${currentBasho.id}/rikishi`,
+        );
+
+        if (!isCurrent) {
+          return;
+        }
+
+        setBasho(bashoRikishi.basho);
+        setRikishi(bashoRikishi.rikishi);
+        setLoadState(bashoRikishi.rikishi.length === 0 ? "empty" : "ready");
+      } catch (error) {
+        if (!isCurrent) {
+          return;
+        }
+
+        setErrorMessage(getErrorMessage(error));
+        setLoadState("error");
+      }
+    }
+
+    void loadBasho();
+
+    return () => {
+      isCurrent = false;
+    };
+  }, []);
+
+  const selectedRikishi = useMemo(
+    () =>
+      selectedIds
+        .map((id) => rikishi.find((entry) => entry.id === id))
+        .filter((entry): entry is RankedRikishi => entry !== undefined),
+    [rikishi, selectedIds],
+  );
+  const picksRemaining = TEAM_SIZE - selectedIds.length;
+  const canSubmit =
+    loadState === "ready" &&
+    submitState === "idle" &&
+    displayName.trim().length > 0 &&
+    selectedIds.length === TEAM_SIZE;
+
+  function toggleRikishi(rikishiId: string) {
+    setErrorMessage(null);
+    setCreatedTeam(null);
+    setSelectedIds((current) => {
+      if (current.includes(rikishiId)) {
+        return current.filter((id) => id !== rikishiId);
+      }
+
+      if (current.length >= TEAM_SIZE) {
+        return current;
+      }
+
+      return [...current, rikishiId];
+    });
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (basho === null || !canSubmit) {
+      return;
+    }
+
+    setSubmitState("submitting");
+    setErrorMessage(null);
+    setCreatedTeam(null);
+
+    try {
+      const response = await postJson<CreatedTeamResponse>(
+        `/api/basho/${basho.id}/teams`,
+        {
+          displayName: displayName.trim(),
+          rikishiIds: selectedIds,
+        },
+      );
+
+      setCreatedTeam(response);
+    } catch (error) {
+      setErrorMessage(getErrorMessage(error));
+    } finally {
+      setSubmitState("idle");
+    }
+  }
+
   return (
     <main className="app-shell">
-      <section className="hero" aria-labelledby="page-title">
-        <p className="eyebrow">Basho-ready foundation</p>
-        <h1 id="page-title">Fantasy Sumo</h1>
-        <p className="lede">
-          A clean TypeScript web app foundation for building the first playable
-          fantasy sumo MVP.
-        </p>
-        <dl className="status-grid" aria-label="Foundation status">
-          <div>
-            <dt>Web</dt>
-            <dd>Vite + React</dd>
-          </div>
-          <div>
-            <dt>API</dt>
-            <dd>Fastify</dd>
-          </div>
-          <div>
-            <dt>Package</dt>
-            <dd>Domain core</dd>
-          </div>
-        </dl>
+      <section className="page-header" aria-labelledby="page-title">
+        <p className="eyebrow">Fantasy Sumo</p>
+        <div>
+          <h1 id="page-title">Build your basho team</h1>
+          <p className="lede">
+            Pick {TEAM_SIZE} rikishi from the current banzuke and enter a team
+            name to join the local leaderboard.
+          </p>
+        </div>
       </section>
+
+      {loadState === "loading" && (
+        <section className="state-panel" aria-live="polite">
+          Loading the current basho...
+        </section>
+      )}
+
+      {loadState === "error" && (
+        <section className="state-panel error-state" role="alert">
+          {errorMessage ?? "Unable to load basho data."}
+        </section>
+      )}
+
+      {loadState === "empty" && (
+        <section className="state-panel">
+          No rikishi are available for the current basho yet.
+        </section>
+      )}
+
+      {loadState === "ready" && basho !== null && (
+        <form className="selection-layout" onSubmit={handleSubmit}>
+          <section className="basho-panel" aria-labelledby="basho-title">
+            <div className="section-heading">
+              <p className="eyebrow">Current basho</p>
+              <h2 id="basho-title">{basho.name}</h2>
+            </div>
+            <p className="basho-dates">
+              {formatDate(basho.startDate)} to {formatDate(basho.endDate)}
+            </p>
+            <div className="progress-wrap" aria-label="Pick progress">
+              <span>
+                {selectedIds.length} of {TEAM_SIZE} selected
+              </span>
+              <strong>
+                {picksRemaining === 0
+                  ? "Team full"
+                  : `${picksRemaining} pick${picksRemaining === 1 ? "" : "s"} left`}
+              </strong>
+            </div>
+          </section>
+
+          <section className="rikishi-section" aria-labelledby="rikishi-title">
+            <div className="section-heading">
+              <p className="eyebrow">Banzuke</p>
+              <h2 id="rikishi-title">Choose rikishi</h2>
+            </div>
+            <div className="rikishi-list">
+              {rikishi.map((entry) => {
+                const isSelected = selectedIds.includes(entry.id);
+                const isDisabled =
+                  !isSelected && selectedIds.length >= TEAM_SIZE;
+
+                return (
+                  <button
+                    className="rikishi-row"
+                    disabled={isDisabled}
+                    key={entry.id}
+                    onClick={() => toggleRikishi(entry.id)}
+                    type="button"
+                    aria-pressed={isSelected}
+                  >
+                    <span className="rank-pill">{entry.rank}</span>
+                    <span>
+                      <strong>{entry.shikona}</strong>
+                      {entry.heya !== undefined && <small>{entry.heya}</small>}
+                    </span>
+                    <span
+                      className={
+                        isSelected ? "pick-mark selected" : "pick-mark"
+                      }
+                    >
+                      {isSelected ? "Selected" : "Pick"}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+
+          <aside className="summary-panel" aria-labelledby="summary-title">
+            <div className="section-heading">
+              <p className="eyebrow">Your team</p>
+              <h2 id="summary-title">Selection</h2>
+            </div>
+
+            <label className="field-label" htmlFor="displayName">
+              Team name
+            </label>
+            <input
+              id="displayName"
+              name="displayName"
+              value={displayName}
+              onChange={(event) => {
+                setDisplayName(event.target.value);
+                setCreatedTeam(null);
+              }}
+              placeholder="East Stand Heroes"
+            />
+
+            <ol className="selected-list" aria-label="Selected rikishi">
+              {selectedRikishi.map((entry) => (
+                <li key={entry.id}>
+                  <span>{entry.shikona}</span>
+                  <button
+                    type="button"
+                    onClick={() => toggleRikishi(entry.id)}
+                    aria-label={`Remove ${entry.shikona}`}
+                  >
+                    Remove
+                  </button>
+                </li>
+              ))}
+              {Array.from({ length: picksRemaining }).map((_, index) => (
+                <li className="empty-pick" key={`empty-${index}`}>
+                  Pick slot
+                </li>
+              ))}
+            </ol>
+
+            <button
+              className="submit-button"
+              disabled={!canSubmit}
+              type="submit"
+            >
+              {submitState === "submitting" ? "Submitting..." : "Submit team"}
+            </button>
+
+            {errorMessage !== null && (
+              <p className="form-message error-state" role="alert">
+                {errorMessage}
+              </p>
+            )}
+
+            {createdTeam !== null && (
+              <div className="confirmation" role="status">
+                <strong>{createdTeam.team.displayName} submitted.</strong>
+                <span>
+                  {createdTeam.picks.length} rikishi selected for this basho.
+                </span>
+              </div>
+            )}
+          </aside>
+        </form>
+      )}
     </main>
   );
+}
+
+async function getJson<T>(url: string): Promise<T> {
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(await readApiError(response));
+  }
+
+  return response.json() as Promise<T>;
+}
+
+async function postJson<T>(url: string, body: unknown): Promise<T> {
+  const response = await fetch(url, {
+    body: JSON.stringify(body),
+    headers: {
+      "Content-Type": "application/json",
+    },
+    method: "POST",
+  });
+
+  if (!response.ok) {
+    throw new Error(await readApiError(response));
+  }
+
+  return response.json() as Promise<T>;
+}
+
+async function readApiError(response: Response): Promise<string> {
+  try {
+    const body = (await response.json()) as ApiErrorBody;
+    const details = body.details
+      ?.map((detail) => detail.message)
+      .filter((message): message is string => message !== undefined);
+
+    if (details !== undefined && details.length > 0) {
+      return `${body.message ?? "Request failed"} ${details.join(" ")}`;
+    }
+
+    return body.message ?? `Request failed with status ${response.status}.`;
+  } catch {
+    return `Request failed with status ${response.status}.`;
+  }
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Something went wrong.";
+}
+
+function formatDate(value: string): string {
+  return new Intl.DateTimeFormat("en-GB", {
+    day: "numeric",
+    month: "short",
+  }).format(new Date(value));
 }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,14 +1,13 @@
 import type { FormEvent } from "react";
 import { useEffect, useMemo, useState } from "react";
 
-const TEAM_SIZE = 2;
-
 interface Basho {
   id: string;
   name: string;
   startDate: string;
   endDate: string;
   status: "upcoming" | "active" | "complete";
+  teamSize: number;
 }
 
 interface RankedRikishi {
@@ -20,7 +19,7 @@ interface RankedRikishi {
 }
 
 interface BashoRikishiResponse {
-  basho: Basho;
+  basho: Omit<Basho, "teamSize">;
   rikishi: RankedRikishi[];
 }
 
@@ -69,7 +68,10 @@ export function App() {
           return;
         }
 
-        setBasho(bashoRikishi.basho);
+        setBasho({
+          ...bashoRikishi.basho,
+          teamSize: currentBasho.teamSize,
+        });
         setRikishi(bashoRikishi.rikishi);
         setLoadState(bashoRikishi.rikishi.length === 0 ? "empty" : "ready");
       } catch (error) {
@@ -96,12 +98,13 @@ export function App() {
         .filter((entry): entry is RankedRikishi => entry !== undefined),
     [rikishi, selectedIds],
   );
-  const picksRemaining = TEAM_SIZE - selectedIds.length;
+  const teamSize = basho?.teamSize ?? 0;
+  const picksRemaining = Math.max(teamSize - selectedIds.length, 0);
   const canSubmit =
     loadState === "ready" &&
     submitState === "idle" &&
     displayName.trim().length > 0 &&
-    selectedIds.length === TEAM_SIZE;
+    selectedIds.length === teamSize;
 
   function toggleRikishi(rikishiId: string) {
     setErrorMessage(null);
@@ -111,7 +114,7 @@ export function App() {
         return current.filter((id) => id !== rikishiId);
       }
 
-      if (current.length >= TEAM_SIZE) {
+      if (current.length >= teamSize) {
         return current;
       }
 
@@ -154,8 +157,8 @@ export function App() {
         <div>
           <h1 id="page-title">Build your basho team</h1>
           <p className="lede">
-            Pick {TEAM_SIZE} rikishi from the current banzuke and enter a team
-            name to join the local leaderboard.
+            Pick rikishi from the current banzuke and enter a team name to join
+            the local leaderboard.
           </p>
         </div>
       </section>
@@ -190,7 +193,7 @@ export function App() {
             </p>
             <div className="progress-wrap" aria-label="Pick progress">
               <span>
-                {selectedIds.length} of {TEAM_SIZE} selected
+                {selectedIds.length} of {teamSize} selected
               </span>
               <strong>
                 {picksRemaining === 0
@@ -209,7 +212,7 @@ export function App() {
               {rikishi.map((entry) => {
                 const isSelected = selectedIds.includes(entry.id);
                 const isDisabled =
-                  !isSelected && selectedIds.length >= TEAM_SIZE;
+                  !isSelected && selectedIds.length >= teamSize;
 
                 return (
                   <button
@@ -355,8 +358,16 @@ function getErrorMessage(error: unknown): string {
 }
 
 function formatDate(value: string): string {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+
+  if (match === null) {
+    return value;
+  }
+
+  const [, year, month, day] = match;
+
   return new Intl.DateTimeFormat("en-GB", {
     day: "numeric",
     month: "short",
-  }).format(new Date(value));
+  }).format(new Date(Number(year), Number(month) - 1, Number(day)));
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1,6 +1,6 @@
 :root {
-  color: #1d2428;
-  background: #f6f1e8;
+  color: #1e272c;
+  background: #f4f0e8;
   font-family:
     Inter,
     ui-sans-serif,
@@ -14,86 +14,345 @@
   text-rendering: optimizeLegibility;
 }
 
+* {
+  box-sizing: border-box;
+}
+
 body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
 }
 
+button,
+input {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: not-allowed;
+}
+
 .app-shell {
+  width: min(1180px, 100%);
   min-height: 100vh;
-  display: grid;
-  place-items: center;
+  margin: 0 auto;
   padding: 32px;
 }
 
-.hero {
-  width: min(100%, 920px);
+.page-header {
+  display: grid;
+  grid-template-columns: 180px minmax(0, 1fr);
+  gap: 24px;
+  align-items: end;
+  padding: 16px 0 28px;
 }
 
 .eyebrow {
-  color: #a1302f;
-  font-size: 0.82rem;
-  font-weight: 700;
+  color: #a93431;
+  font-size: 0.78rem;
+  font-weight: 800;
   letter-spacing: 0;
-  margin: 0 0 12px;
+  margin: 0 0 8px;
   text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
 }
 
 h1 {
   color: #102c38;
-  font-size: clamp(3rem, 9vw, 6.5rem);
-  line-height: 0.95;
-  margin: 0;
+  font-size: 3rem;
+  line-height: 1;
+  margin-bottom: 16px;
+}
+
+h2 {
+  color: #17333e;
+  font-size: 1.25rem;
+  line-height: 1.2;
+  margin-bottom: 0;
 }
 
 .lede {
-  color: #425058;
-  font-size: 1.18rem;
-  max-width: 620px;
-  margin: 24px 0 0;
+  color: #516069;
+  font-size: 1.08rem;
+  max-width: 720px;
+  margin-bottom: 0;
 }
 
-.status-grid {
+.selection-layout {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 1px;
-  margin: 40px 0 0;
-  overflow: hidden;
-  border: 1px solid #cfc5b5;
-  border-radius: 8px;
-  background: #cfc5b5;
+  grid-template-columns: minmax(0, 1fr) 340px;
+  gap: 24px;
+  align-items: start;
 }
 
-.status-grid div {
-  min-width: 0;
+.basho-panel {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: 20px;
+  align-items: center;
   padding: 20px;
-  background: #fffaf1;
+  border: 1px solid #d4c9b8;
+  border-radius: 8px;
+  background: #fffaf2;
 }
 
-.status-grid dt {
-  color: #66747c;
-  font-size: 0.78rem;
-  font-weight: 700;
-  margin: 0 0 6px;
-  text-transform: uppercase;
-}
-
-.status-grid dd {
-  color: #193641;
-  font-size: 1.05rem;
-  font-weight: 700;
+.basho-dates {
+  color: #516069;
   margin: 0;
-  overflow-wrap: anywhere;
+  white-space: nowrap;
 }
 
-@media (max-width: 700px) {
+.progress-wrap {
+  min-width: 200px;
+  padding: 12px 14px;
+  border-radius: 8px;
+  background: #e8f0ec;
+  color: #21332f;
+}
+
+.progress-wrap span,
+.progress-wrap strong {
+  display: block;
+}
+
+.progress-wrap span {
+  font-size: 0.85rem;
+}
+
+.progress-wrap strong {
+  font-size: 1rem;
+}
+
+.rikishi-section,
+.summary-panel,
+.state-panel {
+  border: 1px solid #d4c9b8;
+  border-radius: 8px;
+  background: #fffaf2;
+}
+
+.rikishi-section,
+.summary-panel {
+  padding: 20px;
+}
+
+.state-panel {
+  padding: 24px;
+}
+
+.section-heading {
+  margin-bottom: 18px;
+}
+
+.rikishi-list {
+  display: grid;
+  gap: 10px;
+}
+
+.rikishi-row {
+  display: grid;
+  grid-template-columns: 92px minmax(0, 1fr) 86px;
+  gap: 14px;
+  align-items: center;
+  width: 100%;
+  min-height: 72px;
+  padding: 12px;
+  border: 1px solid #d9d0c2;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #1f2b31;
+  text-align: left;
+}
+
+.rikishi-row:hover:not(:disabled),
+.rikishi-row[aria-pressed="true"] {
+  border-color: #a93431;
+  box-shadow: inset 4px 0 0 #a93431;
+}
+
+.rikishi-row:disabled {
+  opacity: 0.48;
+}
+
+.rank-pill {
+  display: inline-flex;
+  justify-content: center;
+  min-width: 78px;
+  padding: 6px 8px;
+  border-radius: 999px;
+  background: #18333d;
+  color: #ffffff;
+  font-size: 0.8rem;
+  font-weight: 800;
+}
+
+.rikishi-row strong,
+.rikishi-row small {
+  display: block;
+}
+
+.rikishi-row small {
+  color: #60717a;
+  margin-top: 2px;
+}
+
+.pick-mark {
+  justify-self: end;
+  min-width: 70px;
+  padding: 7px 8px;
+  border-radius: 8px;
+  background: #e5ebe8;
+  color: #2f4740;
+  font-size: 0.82rem;
+  font-weight: 800;
+  text-align: center;
+}
+
+.pick-mark.selected {
+  background: #a93431;
+  color: #ffffff;
+}
+
+.field-label {
+  display: block;
+  color: #3e4a50;
+  font-size: 0.9rem;
+  font-weight: 800;
+  margin-bottom: 8px;
+}
+
+input {
+  width: 100%;
+  min-height: 44px;
+  padding: 10px 12px;
+  border: 1px solid #c9bdac;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #1f2b31;
+}
+
+input:focus,
+.rikishi-row:focus-visible,
+.selected-list button:focus-visible,
+.submit-button:focus-visible {
+  outline: 3px solid #4a8f9f;
+  outline-offset: 2px;
+}
+
+.selected-list {
+  display: grid;
+  gap: 8px;
+  min-height: 116px;
+  margin: 18px 0;
+  padding: 0;
+  list-style: none;
+}
+
+.selected-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-height: 48px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: #eef4f1;
+  color: #1f2b31;
+  font-weight: 800;
+}
+
+.selected-list button {
+  min-width: 78px;
+  border: 0;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #8e2e2b;
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.selected-list .empty-pick {
+  border: 1px dashed #c8bcaa;
+  background: transparent;
+  color: #7a6f62;
+  font-weight: 700;
+}
+
+.submit-button {
+  width: 100%;
+  min-height: 48px;
+  border: 0;
+  border-radius: 8px;
+  background: #a93431;
+  color: #ffffff;
+  font-weight: 900;
+}
+
+.submit-button:disabled {
+  background: #c9beb3;
+  color: #6f665e;
+}
+
+.form-message,
+.confirmation {
+  margin: 16px 0 0;
+}
+
+.error-state {
+  color: #8e2e2b;
+}
+
+.confirmation {
+  display: grid;
+  gap: 4px;
+  padding: 12px;
+  border-radius: 8px;
+  background: #e8f0ec;
+  color: #21332f;
+}
+
+@media (max-width: 860px) {
   .app-shell {
-    place-items: start;
     padding: 24px;
   }
 
-  .status-grid {
+  .page-header,
+  .selection-layout,
+  .basho-panel {
     grid-template-columns: 1fr;
+  }
+
+  .basho-dates {
+    white-space: normal;
+  }
+}
+
+@media (max-width: 560px) {
+  .app-shell {
+    padding: 18px;
+  }
+
+  h1 {
+    font-size: 2.25rem;
+  }
+
+  .rikishi-row {
+    grid-template-columns: 1fr;
+  }
+
+  .rank-pill,
+  .pick-mark {
+    justify-self: start;
   }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -34,7 +34,7 @@ The front end entry point is `apps/web/src/main.tsx`.
 Current behaviour:
 
 - Fetches the current basho and its ranked rikishi from the Fastify API.
-- Lets a player select and deselect rikishi up to the current team size of 2.
+- Lets a player select and deselect rikishi up to the API-configured team size.
 - Captures a display/team name and submits the team to the API.
 - Shows loading, empty, success, and API error states.
 - Has Vitest coverage through React Testing Library.
@@ -57,13 +57,13 @@ Current routes:
 - `GET /api/health`
   - Returns a small JSON health payload.
 - `GET /api/basho/current`
-  - Returns the active basho, falling back to the latest available basho when none is active.
+  - Returns the active basho and configured team size, falling back to the latest available basho when none is active.
 - `GET /api/basho/:bashoId/rikishi`
   - Returns a basho and its rikishi with banzuke rank data.
 - `POST /api/basho/:bashoId/teams`
   - Creates a display-name-based fantasy team for the basho.
   - Request body: `displayName`, optional `ownerName`, and `rikishiIds`.
-  - The current team size is 2 rikishi.
+  - The current team size defaults to 2 rikishi and can be changed with `TEAM_SIZE`.
   - Validates duplicate picks, exact team size, and whether each picked rikishi is on that basho's banzuke.
 - `GET /api/basho/:bashoId/teams/:teamId`
   - Returns a fantasy team and its picks.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -33,16 +33,18 @@ The front end entry point is `apps/web/src/main.tsx`.
 
 Current behaviour:
 
-- Renders a basic Fantasy Sumo smoke page.
-- Shows the foundation choices: Vite + React, Fastify, and shared package boundary.
-- Has a Vitest smoke test through React Testing Library.
+- Fetches the current basho and its ranked rikishi from the Fastify API.
+- Lets a player select and deselect rikishi up to the current team size of 2.
+- Captures a display/team name and submits the team to the API.
+- Shows loading, empty, success, and API error states.
+- Has Vitest coverage through React Testing Library.
 
 Current limitations:
 
 - No routing.
-- No fantasy team selection flow yet.
 - No leaderboard UI yet.
-- No API-backed data display yet.
+- No result entry/import UI yet.
+- No persistence of the last created team in browser storage yet.
 
 ## Back end
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -38,7 +38,7 @@ Goal: make the core game loop work locally.
 - [x] Model rikishi/banzuke entries.
 - [x] Model fantasy teams and picks.
 - [x] Expose basho, rikishi, team, and leaderboard API routes.
-- [ ] Add team selection flow.
+- [x] Add team selection flow.
 - [ ] Add result import or manual result entry.
 - [x] Add leaderboard calculation.
 - [ ] Add leaderboard UI.


### PR DESCRIPTION
## Summary
- Replaces the web smoke page with a basho team selection flow backed by the existing API.
- Fetches the current basho and rikishi, supports select/deselect, blocks duplicate and over-limit picks, and shows picks remaining.
- Adds team name input, team submission, confirmation, loading, empty, and API error states.
- Updates web tests and docs to describe the new front-end behavior.

## Notes
- Uses the current documented/API team size of 2 rikishi.
- Authentication, pick locking, result entry/import, and leaderboard UI remain out of scope.

## Validation
- pnpm build
- pnpm test
- pnpm lint
- pnpm format:check
- Browser checked locally with pnpm dev against seeded SQLite data

Closes #9