### PR TITLE
Build leaderboard UI and team results view

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ The original app was an unfinished barebones prototype. Treat the removed legacy
 - Back end: Fastify, TypeScript, Node.
 - Shared code: `packages/domain` for framework-free domain boundaries.
 - Data: SQLite via `packages/db`, with Drizzle schema, migration SQL, repositories, and seed data.
-- Existing behaviour: displays a team selection page and exposes local game API routes for health, basho, rikishi, team creation/retrieval, and leaderboard data.
+- Existing behaviour: displays team selection and leaderboard views, and exposes local game API routes for health, basho, rikishi, team creation/retrieval, and leaderboard data.
 
 ## Intended MVP direction
 

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ The current codebase has been reset onto the clean rebuild foundation described 
 
 At present, the app has the first local playable foundations:
 
-- A Vite + React front end for creating a fantasy team from seeded basho data.
+- A Vite + React front end for creating a fantasy team from seeded basho data and viewing leaderboard standings.
 - A Fastify API with health, basho, rikishi, team, and leaderboard endpoints.
 - A shared TypeScript domain package with MVP types, validation, scoring, and leaderboard logic.
 - A local SQLite + Drizzle database package with schema, migration, repositories, and sample seed data.
 - Vitest, ESLint, and Prettier wired through pnpm scripts.
 
-It is not yet a playable fantasy game.
+It is close to a local playable loop, but still needs a result entry/import path before it is useful during a real basho.
 
 ## Tech Stack
 
@@ -101,6 +101,6 @@ The local database uses a file path only and does not require credentials. Keep 
 
 ## Recommended next steps
 
-1. Add result entry/import and make the leaderboard visible in the web app.
+1. Add result entry/import so standings can be updated during a basho.
 2. Persist or retrieve the latest submitted team for follow-up views.
 3. Decide pick locking and whether the configured team size should move into database-backed basho settings.

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -138,6 +138,61 @@ describe("App", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows leaderboard loading before the initial standings request settles", async () => {
+    const leaderboardRequest = createDeferred<Response>();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(mockSlowInitialLeaderboardFetch(leaderboardRequest)),
+    );
+    render(<App />);
+
+    await screen.findByRole("heading", { name: "May 2026 Sample Basho" });
+    fireEvent.click(screen.getByRole("button", { name: "Leaderboard" }));
+
+    expect(screen.getByText("Loading leaderboard...")).toBeInTheDocument();
+    expect(
+      screen.queryByText("No teams have joined this basho yet."),
+    ).not.toBeInTheDocument();
+
+    leaderboardRequest.resolve(
+      createJsonResponse({
+        bashoId: currentBasho.id,
+        leaderboard,
+      }),
+    );
+  });
+
+  it("keeps newer submitted standings when the initial leaderboard request resolves late", async () => {
+    const initialLeaderboardRequest = createDeferred<Response>();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(mockStaleInitialLeaderboardFetch(initialLeaderboardRequest)),
+    );
+    render(<App />);
+
+    await screen.findByRole("button", { name: /Onosato/ });
+    fireEvent.change(screen.getByLabelText("Team name"), {
+      target: { value: "East Stand Heroes" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Onosato/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Kotozakura/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Submit team" }));
+
+    expect(await screen.findByText("4 pts")).toBeInTheDocument();
+
+    initialLeaderboardRequest.resolve(
+      createJsonResponse({
+        bashoId: currentBasho.id,
+        leaderboard,
+      }),
+    );
+    await initialLeaderboardRequest.promise;
+    await flushPromises();
+
+    expect(screen.getByText("4 pts")).toBeInTheDocument();
+    expect(screen.queryByText("East Side")).not.toBeInTheDocument();
+  });
+
   it("allows selecting and removing rikishi up to the team size", async () => {
     render(<App />);
 
@@ -312,6 +367,64 @@ function mockInitialLeaderboardErrorFetch(
   );
 }
 
+function mockSlowInitialLeaderboardFetch(
+  leaderboardRequest: Deferred<Response>,
+): (input: RequestInfo | URL) => Promise<Response> {
+  return (input: RequestInfo | URL) => {
+    const url = String(input);
+
+    if (url !== "/api/basho/2026-05/leaderboard") {
+      return mockSuccessfulFetch(input);
+    }
+
+    return leaderboardRequest.promise;
+  };
+}
+
+function mockStaleInitialLeaderboardFetch(
+  initialLeaderboardRequest: Deferred<Response>,
+): (input: RequestInfo | URL) => Promise<Response> {
+  let leaderboardRequestCount = 0;
+
+  return (input: RequestInfo | URL) => {
+    const url = String(input);
+
+    if (url !== "/api/basho/2026-05/leaderboard") {
+      return mockSuccessfulFetch(input);
+    }
+
+    leaderboardRequestCount += 1;
+
+    if (leaderboardRequestCount === 1) {
+      return initialLeaderboardRequest.promise;
+    }
+
+    return jsonResponse({
+      bashoId: currentBasho.id,
+      leaderboard: [
+        {
+          rank: 1,
+          teamId: "team-east-stand",
+          displayName: "East Stand Heroes",
+          score: 4,
+          rikishiScores: [
+            {
+              rikishiId: "onosato",
+              wins: 2,
+              score: 2,
+            },
+            {
+              rikishiId: "kotozakura",
+              wins: 2,
+              score: 2,
+            },
+          ],
+        },
+      ],
+    });
+  };
+}
+
 function mockSubmitLeaderboardErrorFetch(): (
   input: RequestInfo | URL,
 ) => Promise<Response> {
@@ -363,12 +476,41 @@ function jsonResponse(
   body: unknown,
   init: ResponseInit = {},
 ): Promise<Response> {
-  return Promise.resolve(
-    new Response(JSON.stringify(body), {
-      headers: {
-        "Content-Type": "application/json",
-      },
-      status: init.status ?? 200,
-    }),
-  );
+  return Promise.resolve(createJsonResponse(body, init));
+}
+
+function createJsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    headers: {
+      "Content-Type": "application/json",
+    },
+    status: init.status ?? 200,
+  });
+}
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve: (value: T) => void = () => undefined;
+  let reject: (error: unknown) => void = () => undefined;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return {
+    promise,
+    reject,
+    resolve,
+  };
+}
+
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
 }

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -119,6 +119,25 @@ describe("App", () => {
     expect(screen.getAllByText("1 win")).toHaveLength(2);
   });
 
+  it("keeps team selection available when the initial leaderboard load fails", async () => {
+    vi.stubGlobal("fetch", vi.fn(mockInitialLeaderboardErrorFetch));
+    render(<App />);
+
+    expect(
+      await screen.findByRole("heading", { name: "May 2026 Sample Basho" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Onosato/ })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Leaderboard" }));
+
+    expect(
+      screen.getByText("Leaderboard unavailable right now."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("No teams have joined this basho yet."),
+    ).toBeInTheDocument();
+  });
+
   it("allows selecting and removing rikishi up to the team size", async () => {
     render(<App />);
 
@@ -166,6 +185,29 @@ describe("App", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole("heading", { name: "Leaderboard" }),
+    ).toBeInTheDocument();
+  });
+
+  it("stays on team selection and shows the refresh error when standings fail after submit", async () => {
+    vi.stubGlobal("fetch", vi.fn(mockSubmitLeaderboardErrorFetch()));
+    render(<App />);
+
+    await screen.findByRole("button", { name: /Onosato/ });
+    fireEvent.change(screen.getByLabelText("Team name"), {
+      target: { value: "East Stand Heroes" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Onosato/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Kotozakura/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Submit team" }));
+
+    expect(
+      await screen.findByText("East Stand Heroes submitted."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Unable to refresh leaderboard."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Selection" }),
     ).toBeInTheDocument();
   });
 
@@ -251,6 +293,50 @@ function mockEmptyLeaderboardFetch(
     bashoId: currentBasho.id,
     leaderboard: [],
   });
+}
+
+function mockInitialLeaderboardErrorFetch(
+  input: RequestInfo | URL,
+): Promise<Response> {
+  const url = String(input);
+
+  if (url !== "/api/basho/2026-05/leaderboard") {
+    return mockSuccessfulFetch(input);
+  }
+
+  return jsonResponse(
+    {
+      message: "Leaderboard unavailable right now.",
+    },
+    { status: 503 },
+  );
+}
+
+function mockSubmitLeaderboardErrorFetch(): (
+  input: RequestInfo | URL,
+) => Promise<Response> {
+  let leaderboardRequestCount = 0;
+
+  return (input: RequestInfo | URL) => {
+    const url = String(input);
+
+    if (url !== "/api/basho/2026-05/leaderboard") {
+      return mockSuccessfulFetch(input);
+    }
+
+    leaderboardRequestCount += 1;
+
+    if (leaderboardRequestCount === 1) {
+      return mockSuccessfulFetch(input);
+    }
+
+    return jsonResponse(
+      {
+        message: "Unable to refresh leaderboard.",
+      },
+      { status: 503 },
+    );
+  };
 }
 
 function mockValidationErrorFetch(input: RequestInfo | URL): Promise<Response> {

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -35,6 +35,52 @@ const rankedRikishi = [
   },
 ];
 
+const leaderboard = [
+  {
+    rank: 1,
+    teamId: "team-east",
+    displayName: "East Side",
+    score: 2,
+    rikishiScores: [
+      {
+        rikishiId: "onosato",
+        wins: 1,
+        score: 1,
+      },
+      {
+        rikishiId: "kirishima",
+        wins: 1,
+        score: 1,
+      },
+    ],
+  },
+  {
+    rank: 2,
+    teamId: "team-west",
+    displayName: "West Side",
+    score: 1,
+    rikishiScores: [
+      {
+        rikishiId: "kotozakura",
+        wins: 1,
+        score: 1,
+      },
+      {
+        rikishiId: "hoshoryu",
+        wins: 0,
+        score: 0,
+      },
+    ],
+  },
+  {
+    rank: 3,
+    teamId: "team-tie",
+    displayName: "Tie Side",
+    score: 1,
+    rikishiScores: [],
+  },
+];
+
 beforeEach(() => {
   vi.stubGlobal("fetch", vi.fn(mockSuccessfulFetch));
 });
@@ -55,6 +101,22 @@ describe("App", () => {
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Onosato/ })).toBeInTheDocument();
     expect(screen.getByText("0 of 2 selected")).toBeInTheDocument();
+  });
+
+  it("displays leaderboard standings and team score details", async () => {
+    render(<App />);
+
+    await screen.findByRole("button", { name: "Leaderboard" });
+    fireEvent.click(screen.getByRole("button", { name: "Leaderboard" }));
+
+    expect(
+      screen.getByRole("heading", { name: "Leaderboard" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("East Side")).toBeInTheDocument();
+    expect(screen.getByText("2 pts")).toBeInTheDocument();
+    expect(screen.getAllByText("Tied on score")).toHaveLength(2);
+    expect(screen.getByText("Onosato")).toBeInTheDocument();
+    expect(screen.getAllByText("1 win")).toHaveLength(2);
   });
 
   it("allows selecting and removing rikishi up to the team size", async () => {
@@ -102,6 +164,9 @@ describe("App", () => {
     expect(
       await screen.findByText("East Stand Heroes submitted."),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Leaderboard" }),
+    ).toBeInTheDocument();
   });
 
   it("displays API validation errors", async () => {
@@ -122,6 +187,18 @@ describe("App", () => {
       ),
     ).toBeInTheDocument();
   });
+
+  it("shows an empty leaderboard state", async () => {
+    vi.stubGlobal("fetch", vi.fn(mockEmptyLeaderboardFetch));
+    render(<App />);
+
+    await screen.findByRole("button", { name: "Leaderboard" });
+    fireEvent.click(screen.getByRole("button", { name: "Leaderboard" }));
+
+    expect(
+      screen.getByText("No teams have joined this basho yet."),
+    ).toBeInTheDocument();
+  });
 });
 
 function mockSuccessfulFetch(input: RequestInfo | URL): Promise<Response> {
@@ -135,6 +212,13 @@ function mockSuccessfulFetch(input: RequestInfo | URL): Promise<Response> {
     return jsonResponse({
       basho: currentBasho,
       rikishi: rankedRikishi,
+    });
+  }
+
+  if (url === "/api/basho/2026-05/leaderboard") {
+    return jsonResponse({
+      bashoId: currentBasho.id,
+      leaderboard,
     });
   }
 
@@ -152,6 +236,21 @@ function mockSuccessfulFetch(input: RequestInfo | URL): Promise<Response> {
   }
 
   return jsonResponse({ message: "Not found" }, { status: 404 });
+}
+
+function mockEmptyLeaderboardFetch(
+  input: RequestInfo | URL,
+): Promise<Response> {
+  const url = String(input);
+
+  if (url !== "/api/basho/2026-05/leaderboard") {
+    return mockSuccessfulFetch(input);
+  }
+
+  return jsonResponse({
+    bashoId: currentBasho.id,
+    leaderboard: [],
+  });
 }
 
 function mockValidationErrorFetch(input: RequestInfo | URL): Promise<Response> {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,6 +1,12 @@
 import type { FormEvent } from "react";
 import { useEffect, useMemo, useState } from "react";
-import { getErrorMessage, getJson, postJson } from "./api";
+import {
+  createFantasyTeam,
+  fetchBashoRikishi,
+  fetchCurrentBasho,
+  fetchLeaderboard,
+  getErrorMessage,
+} from "./api";
 import { BashoPanel } from "./components/BashoPanel";
 import { LeaderboardPanel } from "./components/LeaderboardPanel";
 import { PageHeader } from "./components/PageHeader";
@@ -9,7 +15,6 @@ import { ViewSwitch } from "./components/ViewSwitch";
 import type {
   ActiveView,
   Basho,
-  BashoRikishiResponse,
   CreatedTeamResponse,
   LeaderboardEntry,
   LeaderboardResponse,
@@ -40,10 +45,8 @@ export function App() {
 
     async function loadBasho() {
       try {
-        const currentBasho = await getJson<Basho>("/api/basho/current");
-        const bashoRikishi = await getJson<BashoRikishiResponse>(
-          `/api/basho/${currentBasho.id}/rikishi`,
-        );
+        const currentBasho = await fetchCurrentBasho();
+        const bashoRikishi = await fetchBashoRikishi(currentBasho.id);
 
         if (!isCurrent) {
           return;
@@ -57,9 +60,7 @@ export function App() {
         setLoadState(bashoRikishi.rikishi.length === 0 ? "empty" : "ready");
 
         try {
-          const leaderboardResponse = await getJson<LeaderboardResponse>(
-            `/api/basho/${currentBasho.id}/leaderboard`,
-          );
+          const leaderboardResponse = await fetchLeaderboard(currentBasho.id);
 
           if (!isCurrent) {
             return;
@@ -137,20 +138,15 @@ export function App() {
     setCreatedTeam(null);
 
     try {
-      const response = await postJson<CreatedTeamResponse>(
-        `/api/basho/${basho.id}/teams`,
-        {
-          displayName: displayName.trim(),
-          rikishiIds: selectedIds,
-        },
-      );
+      const response = await createFantasyTeam(basho.id, {
+        displayName: displayName.trim(),
+        rikishiIds: selectedIds,
+      });
 
       setCreatedTeam(response);
 
       try {
-        const leaderboardResponse = await getJson<LeaderboardResponse>(
-          `/api/basho/${basho.id}/leaderboard`,
-        );
+        const leaderboardResponse = await fetchLeaderboard(basho.id);
 
         setLeaderboard(leaderboardResponse.leaderboard);
         setExpandedTeamId(getExpandedTeamId(leaderboardResponse, response));

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,5 @@
-import type { FormEvent } from "react";
-import { useEffect, useMemo, useState } from "react";
+import type { FormEvent, MutableRefObject } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   createFantasyTeam,
   fetchBashoRikishi,
@@ -17,6 +17,7 @@ import type {
   Basho,
   CreatedTeamResponse,
   LeaderboardEntry,
+  LeaderboardLoadState,
   LeaderboardResponse,
   LoadState,
   RankedRikishi,
@@ -30,6 +31,8 @@ export function App() {
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [expandedTeamId, setExpandedTeamId] = useState<string | null>(null);
   const [activeView, setActiveView] = useState<ActiveView>("selection");
+  const [leaderboardLoadState, setLeaderboardLoadState] =
+    useState<LeaderboardLoadState>("loading");
   const [displayName, setDisplayName] = useState("");
   const [submitState, setSubmitState] = useState<"idle" | "submitting">("idle");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -39,6 +42,7 @@ export function App() {
   const [createdTeam, setCreatedTeam] = useState<CreatedTeamResponse | null>(
     null,
   );
+  const leaderboardRequestIdRef = useRef(0);
 
   useEffect(() => {
     let isCurrent = true;
@@ -59,24 +63,35 @@ export function App() {
         setRikishi(bashoRikishi.rikishi);
         setLoadState(bashoRikishi.rikishi.length === 0 ? "empty" : "ready");
 
+        const requestId = nextLeaderboardRequestId(leaderboardRequestIdRef);
+        setLeaderboardLoadState("loading");
+
         try {
           const leaderboardResponse = await fetchLeaderboard(currentBasho.id);
 
-          if (!isCurrent) {
+          if (
+            !isCurrent ||
+            !isCurrentLeaderboardRequest(leaderboardRequestIdRef, requestId)
+          ) {
             return;
           }
 
           setLeaderboard(leaderboardResponse.leaderboard);
           setExpandedTeamId(leaderboardResponse.leaderboard[0]?.teamId ?? null);
           setLeaderboardErrorMessage(null);
+          setLeaderboardLoadState("ready");
         } catch (error) {
-          if (!isCurrent) {
+          if (
+            !isCurrent ||
+            !isCurrentLeaderboardRequest(leaderboardRequestIdRef, requestId)
+          ) {
             return;
           }
 
           setLeaderboard([]);
           setExpandedTeamId(null);
           setLeaderboardErrorMessage(getErrorMessage(error));
+          setLeaderboardLoadState("ready");
         }
       } catch (error) {
         if (!isCurrent) {
@@ -145,13 +160,26 @@ export function App() {
 
       setCreatedTeam(response);
 
+      const requestId = nextLeaderboardRequestId(leaderboardRequestIdRef);
+      setLeaderboardLoadState("loading");
+
       try {
         const leaderboardResponse = await fetchLeaderboard(basho.id);
 
+        if (!isCurrentLeaderboardRequest(leaderboardRequestIdRef, requestId)) {
+          return;
+        }
+
         setLeaderboard(leaderboardResponse.leaderboard);
         setExpandedTeamId(getExpandedTeamId(leaderboardResponse, response));
+        setLeaderboardLoadState("ready");
         setActiveView("leaderboard");
       } catch (error) {
+        if (!isCurrentLeaderboardRequest(leaderboardRequestIdRef, requestId)) {
+          return;
+        }
+
+        setLeaderboardLoadState("ready");
         setErrorMessage(getErrorMessage(error));
       }
     } catch (error) {
@@ -186,7 +214,11 @@ export function App() {
       {loadState === "ready" && basho !== null && (
         <>
           <BashoPanel basho={basho} selectedCount={selectedIds.length} />
-          <ViewSwitch activeView={activeView} onChange={setActiveView} />
+          <ViewSwitch
+            activeView={activeView}
+            disabled={submitState === "submitting"}
+            onChange={setActiveView}
+          />
 
           {activeView === "selection" && (
             <TeamSelection
@@ -214,6 +246,7 @@ export function App() {
               errorMessage={leaderboardErrorMessage}
               expandedTeamId={expandedTeamId}
               leaderboard={leaderboard}
+              loadState={leaderboardLoadState}
               onToggleTeam={(teamId) =>
                 setExpandedTeamId(expandedTeamId === teamId ? null : teamId)
               }
@@ -239,4 +272,18 @@ function getExpandedTeamId(
   }
 
   return leaderboardResponse.leaderboard[0]?.teamId ?? null;
+}
+
+function nextLeaderboardRequestId(
+  requestIdRef: MutableRefObject<number>,
+): number {
+  requestIdRef.current += 1;
+  return requestIdRef.current;
+}
+
+function isCurrentLeaderboardRequest(
+  requestIdRef: MutableRefObject<number>,
+  requestId: number,
+): boolean {
+  return requestIdRef.current === requestId;
 }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,66 +1,21 @@
 import type { FormEvent } from "react";
 import { useEffect, useMemo, useState } from "react";
-
-interface Basho {
-  id: string;
-  name: string;
-  startDate: string;
-  endDate: string;
-  status: "upcoming" | "active" | "complete";
-  teamSize: number;
-}
-
-interface RankedRikishi {
-  id: string;
-  shikona: string;
-  heya?: string;
-  rank: string;
-  rankOrder: number;
-}
-
-interface BashoRikishiResponse {
-  basho: Omit<Basho, "teamSize">;
-  rikishi: RankedRikishi[];
-}
-
-interface CreatedTeamResponse {
-  team: {
-    id: string;
-    displayName: string;
-  };
-  picks: Array<{
-    rikishiId: string;
-  }>;
-}
-
-interface LeaderboardResponse {
-  bashoId: string;
-  leaderboard: LeaderboardEntry[];
-}
-
-interface LeaderboardEntry {
-  rank: number;
-  teamId: string;
-  displayName: string;
-  score: number;
-  rikishiScores: RikishiScore[];
-}
-
-interface RikishiScore {
-  rikishiId: string;
-  wins: number;
-  score: number;
-}
-
-interface ApiErrorBody {
-  message?: string;
-  details?: Array<{
-    message?: string;
-  }>;
-}
-
-type LoadState = "loading" | "ready" | "empty" | "error";
-type ActiveView = "selection" | "leaderboard";
+import { getErrorMessage, getJson, postJson } from "./api";
+import { BashoPanel } from "./components/BashoPanel";
+import { LeaderboardPanel } from "./components/LeaderboardPanel";
+import { PageHeader } from "./components/PageHeader";
+import { TeamSelection } from "./components/TeamSelection";
+import { ViewSwitch } from "./components/ViewSwitch";
+import type {
+  ActiveView,
+  Basho,
+  BashoRikishiResponse,
+  CreatedTeamResponse,
+  LeaderboardEntry,
+  LeaderboardResponse,
+  LoadState,
+  RankedRikishi,
+} from "./types";
 
 export function App() {
   const [loadState, setLoadState] = useState<LoadState>("loading");
@@ -73,6 +28,9 @@ export function App() {
   const [displayName, setDisplayName] = useState("");
   const [submitState, setSubmitState] = useState<"idle" | "submitting">("idle");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [leaderboardErrorMessage, setLeaderboardErrorMessage] = useState<
+    string | null
+  >(null);
   const [createdTeam, setCreatedTeam] = useState<CreatedTeamResponse | null>(
     null,
   );
@@ -86,9 +44,6 @@ export function App() {
         const bashoRikishi = await getJson<BashoRikishiResponse>(
           `/api/basho/${currentBasho.id}/rikishi`,
         );
-        const leaderboardResponse = await getJson<LeaderboardResponse>(
-          `/api/basho/${currentBasho.id}/leaderboard`,
-        );
 
         if (!isCurrent) {
           return;
@@ -99,9 +54,29 @@ export function App() {
           teamSize: currentBasho.teamSize,
         });
         setRikishi(bashoRikishi.rikishi);
-        setLeaderboard(leaderboardResponse.leaderboard);
-        setExpandedTeamId(leaderboardResponse.leaderboard[0]?.teamId ?? null);
         setLoadState(bashoRikishi.rikishi.length === 0 ? "empty" : "ready");
+
+        try {
+          const leaderboardResponse = await getJson<LeaderboardResponse>(
+            `/api/basho/${currentBasho.id}/leaderboard`,
+          );
+
+          if (!isCurrent) {
+            return;
+          }
+
+          setLeaderboard(leaderboardResponse.leaderboard);
+          setExpandedTeamId(leaderboardResponse.leaderboard[0]?.teamId ?? null);
+          setLeaderboardErrorMessage(null);
+        } catch (error) {
+          if (!isCurrent) {
+            return;
+          }
+
+          setLeaderboard([]);
+          setExpandedTeamId(null);
+          setLeaderboardErrorMessage(getErrorMessage(error));
+        }
       } catch (error) {
         if (!isCurrent) {
           return;
@@ -126,21 +101,7 @@ export function App() {
         .filter((entry): entry is RankedRikishi => entry !== undefined),
     [rikishi, selectedIds],
   );
-  const rikishiById = useMemo(
-    () => new Map(rikishi.map((entry) => [entry.id, entry])),
-    [rikishi],
-  );
-  const tiedScoreCounts = useMemo(() => {
-    const scoreCounts = new Map<number, number>();
-
-    for (const entry of leaderboard) {
-      scoreCounts.set(entry.score, (scoreCounts.get(entry.score) ?? 0) + 1);
-    }
-
-    return scoreCounts;
-  }, [leaderboard]);
   const teamSize = basho?.teamSize ?? 0;
-  const picksRemaining = Math.max(teamSize - selectedIds.length, 0);
   const canSubmit =
     loadState === "ready" &&
     submitState === "idle" &&
@@ -172,6 +133,7 @@ export function App() {
 
     setSubmitState("submitting");
     setErrorMessage(null);
+    setLeaderboardErrorMessage(null);
     setCreatedTeam(null);
 
     try {
@@ -184,18 +146,18 @@ export function App() {
       );
 
       setCreatedTeam(response);
-      setActiveView("leaderboard");
-      const leaderboardResponse = await getJson<LeaderboardResponse>(
-        `/api/basho/${basho.id}/leaderboard`,
-      );
-      setLeaderboard(leaderboardResponse.leaderboard);
-      setExpandedTeamId(
-        leaderboardResponse.leaderboard.some(
-          (entry) => entry.teamId === response.team.id,
-        )
-          ? response.team.id
-          : (leaderboardResponse.leaderboard[0]?.teamId ?? null),
-      );
+
+      try {
+        const leaderboardResponse = await getJson<LeaderboardResponse>(
+          `/api/basho/${basho.id}/leaderboard`,
+        );
+
+        setLeaderboard(leaderboardResponse.leaderboard);
+        setExpandedTeamId(getExpandedTeamId(leaderboardResponse, response));
+        setActiveView("leaderboard");
+      } catch (error) {
+        setErrorMessage(getErrorMessage(error));
+      }
     } catch (error) {
       setErrorMessage(getErrorMessage(error));
     } finally {
@@ -205,16 +167,7 @@ export function App() {
 
   return (
     <main className="app-shell">
-      <section className="page-header" aria-labelledby="page-title">
-        <p className="eyebrow">Fantasy Sumo</p>
-        <div>
-          <h1 id="page-title">Build your basho team</h1>
-          <p className="lede">
-            Pick rikishi from the current banzuke and enter a team name to join
-            the local leaderboard.
-          </p>
-        </div>
-      </section>
+      <PageHeader />
 
       {loadState === "loading" && (
         <section className="state-panel" aria-live="polite">
@@ -236,239 +189,40 @@ export function App() {
 
       {loadState === "ready" && basho !== null && (
         <>
-          <section className="basho-panel" aria-labelledby="basho-title">
-            <div className="section-heading">
-              <p className="eyebrow">Current basho</p>
-              <h2 id="basho-title">{basho.name}</h2>
-            </div>
-            <p className="basho-dates">
-              {formatDate(basho.startDate)} to {formatDate(basho.endDate)}
-            </p>
-            <div className="progress-wrap" aria-label="Pick progress">
-              <span>
-                {selectedIds.length} of {teamSize} selected
-              </span>
-              <strong>
-                {picksRemaining === 0
-                  ? "Team full"
-                  : `${picksRemaining} pick${picksRemaining === 1 ? "" : "s"} left`}
-              </strong>
-            </div>
-          </section>
-
-          <div className="view-switch" aria-label="View switcher">
-            <button
-              type="button"
-              className={activeView === "selection" ? "active" : ""}
-              onClick={() => setActiveView("selection")}
-            >
-              Team selection
-            </button>
-            <button
-              type="button"
-              className={activeView === "leaderboard" ? "active" : ""}
-              onClick={() => setActiveView("leaderboard")}
-            >
-              Leaderboard
-            </button>
-          </div>
+          <BashoPanel basho={basho} selectedCount={selectedIds.length} />
+          <ViewSwitch activeView={activeView} onChange={setActiveView} />
 
           {activeView === "selection" && (
-            <form className="selection-layout" onSubmit={handleSubmit}>
-              <section
-                className="rikishi-section"
-                aria-labelledby="rikishi-title"
-              >
-                <div className="section-heading">
-                  <p className="eyebrow">Banzuke</p>
-                  <h2 id="rikishi-title">Choose rikishi</h2>
-                </div>
-                <div className="rikishi-list">
-                  {rikishi.map((entry) => {
-                    const isSelected = selectedIds.includes(entry.id);
-                    const isDisabled =
-                      !isSelected && selectedIds.length >= teamSize;
-
-                    return (
-                      <button
-                        className="rikishi-row"
-                        disabled={isDisabled}
-                        key={entry.id}
-                        onClick={() => toggleRikishi(entry.id)}
-                        type="button"
-                        aria-pressed={isSelected}
-                      >
-                        <span className="rank-pill">{entry.rank}</span>
-                        <span>
-                          <strong>{entry.shikona}</strong>
-                          {entry.heya !== undefined && (
-                            <small>{entry.heya}</small>
-                          )}
-                        </span>
-                        <span
-                          className={
-                            isSelected ? "pick-mark selected" : "pick-mark"
-                          }
-                        >
-                          {isSelected ? "Selected" : "Pick"}
-                        </span>
-                      </button>
-                    );
-                  })}
-                </div>
-              </section>
-
-              <aside className="summary-panel" aria-labelledby="summary-title">
-                <div className="section-heading">
-                  <p className="eyebrow">Your team</p>
-                  <h2 id="summary-title">Selection</h2>
-                </div>
-
-                <label className="field-label" htmlFor="displayName">
-                  Team name
-                </label>
-                <input
-                  id="displayName"
-                  name="displayName"
-                  value={displayName}
-                  onChange={(event) => {
-                    setDisplayName(event.target.value);
-                    setCreatedTeam(null);
-                  }}
-                  placeholder="East Stand Heroes"
-                />
-
-                <ol className="selected-list" aria-label="Selected rikishi">
-                  {selectedRikishi.map((entry) => (
-                    <li key={entry.id}>
-                      <span>{entry.shikona}</span>
-                      <button
-                        type="button"
-                        onClick={() => toggleRikishi(entry.id)}
-                        aria-label={`Remove ${entry.shikona}`}
-                      >
-                        Remove
-                      </button>
-                    </li>
-                  ))}
-                  {Array.from({ length: picksRemaining }).map((_, index) => (
-                    <li className="empty-pick" key={`empty-${index}`}>
-                      Pick slot
-                    </li>
-                  ))}
-                </ol>
-
-                <button
-                  className="submit-button"
-                  disabled={!canSubmit}
-                  type="submit"
-                >
-                  {submitState === "submitting"
-                    ? "Submitting..."
-                    : "Submit team"}
-                </button>
-
-                {errorMessage !== null && (
-                  <p className="form-message error-state" role="alert">
-                    {errorMessage}
-                  </p>
-                )}
-              </aside>
-            </form>
+            <TeamSelection
+              canSubmit={canSubmit}
+              createdTeam={createdTeam}
+              displayName={displayName}
+              errorMessage={errorMessage}
+              onDisplayNameChange={(nextDisplayName) => {
+                setDisplayName(nextDisplayName);
+                setCreatedTeam(null);
+              }}
+              onSubmit={handleSubmit}
+              onToggleRikishi={toggleRikishi}
+              rikishi={rikishi}
+              selectedIds={selectedIds}
+              selectedRikishi={selectedRikishi}
+              submitState={submitState}
+              teamSize={teamSize}
+            />
           )}
 
           {activeView === "leaderboard" && (
-            <section
-              className="leaderboard-section"
-              aria-labelledby="standings-title"
-            >
-              <div className="section-heading">
-                <p className="eyebrow">Standings</p>
-                <h2 id="standings-title">Leaderboard</h2>
-              </div>
-
-              {createdTeam !== null && (
-                <div className="confirmation" role="status">
-                  <strong>{createdTeam.team.displayName} submitted.</strong>
-                  <span>
-                    {createdTeam.picks.length} rikishi selected for this basho.
-                  </span>
-                </div>
-              )}
-
-              {leaderboard.length === 0 ? (
-                <div className="state-panel leaderboard-empty">
-                  No teams have joined this basho yet.
-                </div>
-              ) : (
-                <ol className="leaderboard-list">
-                  {leaderboard.map((entry) => {
-                    const isTied = (tiedScoreCounts.get(entry.score) ?? 0) > 1;
-                    const isExpanded = expandedTeamId === entry.teamId;
-
-                    return (
-                      <li className="leaderboard-entry" key={entry.teamId}>
-                        <button
-                          type="button"
-                          className="leaderboard-summary"
-                          onClick={() =>
-                            setExpandedTeamId(isExpanded ? null : entry.teamId)
-                          }
-                          aria-expanded={isExpanded}
-                        >
-                          <span className="leaderboard-rank">
-                            #{entry.rank}
-                          </span>
-                          <span className="leaderboard-team">
-                            <strong>{entry.displayName}</strong>
-                            {isTied && <small>Tied on score</small>}
-                          </span>
-                          <span className="leaderboard-score">
-                            {entry.score} pts
-                          </span>
-                        </button>
-
-                        {isExpanded && (
-                          <div className="score-breakdown">
-                            {entry.rikishiScores.length === 0 ? (
-                              <p>No picks recorded for this team.</p>
-                            ) : (
-                              <ul>
-                                {entry.rikishiScores.map((score) => {
-                                  const pickedRikishi = rikishiById.get(
-                                    score.rikishiId,
-                                  );
-
-                                  return (
-                                    <li key={score.rikishiId}>
-                                      <span>
-                                        <strong>
-                                          {pickedRikishi?.shikona ??
-                                            score.rikishiId}
-                                        </strong>
-                                        <small>
-                                          {pickedRikishi?.rank ??
-                                            "Unranked pick"}
-                                        </small>
-                                      </span>
-                                      <span>
-                                        {score.wins} win
-                                        {score.wins === 1 ? "" : "s"}
-                                      </span>
-                                      <span>{score.score} pts</span>
-                                    </li>
-                                  );
-                                })}
-                              </ul>
-                            )}
-                          </div>
-                        )}
-                      </li>
-                    );
-                  })}
-                </ol>
-              )}
-            </section>
+            <LeaderboardPanel
+              createdTeam={createdTeam}
+              errorMessage={leaderboardErrorMessage}
+              expandedTeamId={expandedTeamId}
+              leaderboard={leaderboard}
+              onToggleTeam={(teamId) =>
+                setExpandedTeamId(expandedTeamId === teamId ? null : teamId)
+              }
+              rikishi={rikishi}
+            />
           )}
         </>
       )}
@@ -476,64 +230,17 @@ export function App() {
   );
 }
 
-async function getJson<T>(url: string): Promise<T> {
-  const response = await fetch(url);
+function getExpandedTeamId(
+  leaderboardResponse: LeaderboardResponse,
+  createdTeam: CreatedTeamResponse,
+): string | null {
+  const createdTeamIsRanked = leaderboardResponse.leaderboard.some(
+    (entry) => entry.teamId === createdTeam.team.id,
+  );
 
-  if (!response.ok) {
-    throw new Error(await readApiError(response));
+  if (createdTeamIsRanked) {
+    return createdTeam.team.id;
   }
 
-  return response.json() as Promise<T>;
-}
-
-async function postJson<T>(url: string, body: unknown): Promise<T> {
-  const response = await fetch(url, {
-    body: JSON.stringify(body),
-    headers: {
-      "Content-Type": "application/json",
-    },
-    method: "POST",
-  });
-
-  if (!response.ok) {
-    throw new Error(await readApiError(response));
-  }
-
-  return response.json() as Promise<T>;
-}
-
-async function readApiError(response: Response): Promise<string> {
-  try {
-    const body = (await response.json()) as ApiErrorBody;
-    const details = body.details
-      ?.map((detail) => detail.message)
-      .filter((message): message is string => message !== undefined);
-
-    if (details !== undefined && details.length > 0) {
-      return `${body.message ?? "Request failed"} ${details.join(" ")}`;
-    }
-
-    return body.message ?? `Request failed with status ${response.status}.`;
-  } catch {
-    return `Request failed with status ${response.status}.`;
-  }
-}
-
-function getErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : "Something went wrong.";
-}
-
-function formatDate(value: string): string {
-  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
-
-  if (match === null) {
-    return value;
-  }
-
-  const [, year, month, day] = match;
-
-  return new Intl.DateTimeFormat("en-GB", {
-    day: "numeric",
-    month: "short",
-  }).format(new Date(Number(year), Number(month) - 1, Number(day)));
+  return leaderboardResponse.leaderboard[0]?.teamId ?? null;
 }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -33,6 +33,25 @@ interface CreatedTeamResponse {
   }>;
 }
 
+interface LeaderboardResponse {
+  bashoId: string;
+  leaderboard: LeaderboardEntry[];
+}
+
+interface LeaderboardEntry {
+  rank: number;
+  teamId: string;
+  displayName: string;
+  score: number;
+  rikishiScores: RikishiScore[];
+}
+
+interface RikishiScore {
+  rikishiId: string;
+  wins: number;
+  score: number;
+}
+
 interface ApiErrorBody {
   message?: string;
   details?: Array<{
@@ -41,12 +60,16 @@ interface ApiErrorBody {
 }
 
 type LoadState = "loading" | "ready" | "empty" | "error";
+type ActiveView = "selection" | "leaderboard";
 
 export function App() {
   const [loadState, setLoadState] = useState<LoadState>("loading");
   const [basho, setBasho] = useState<Basho | null>(null);
   const [rikishi, setRikishi] = useState<RankedRikishi[]>([]);
+  const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[]>([]);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [expandedTeamId, setExpandedTeamId] = useState<string | null>(null);
+  const [activeView, setActiveView] = useState<ActiveView>("selection");
   const [displayName, setDisplayName] = useState("");
   const [submitState, setSubmitState] = useState<"idle" | "submitting">("idle");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -63,6 +86,9 @@ export function App() {
         const bashoRikishi = await getJson<BashoRikishiResponse>(
           `/api/basho/${currentBasho.id}/rikishi`,
         );
+        const leaderboardResponse = await getJson<LeaderboardResponse>(
+          `/api/basho/${currentBasho.id}/leaderboard`,
+        );
 
         if (!isCurrent) {
           return;
@@ -73,6 +99,8 @@ export function App() {
           teamSize: currentBasho.teamSize,
         });
         setRikishi(bashoRikishi.rikishi);
+        setLeaderboard(leaderboardResponse.leaderboard);
+        setExpandedTeamId(leaderboardResponse.leaderboard[0]?.teamId ?? null);
         setLoadState(bashoRikishi.rikishi.length === 0 ? "empty" : "ready");
       } catch (error) {
         if (!isCurrent) {
@@ -98,6 +126,19 @@ export function App() {
         .filter((entry): entry is RankedRikishi => entry !== undefined),
     [rikishi, selectedIds],
   );
+  const rikishiById = useMemo(
+    () => new Map(rikishi.map((entry) => [entry.id, entry])),
+    [rikishi],
+  );
+  const tiedScoreCounts = useMemo(() => {
+    const scoreCounts = new Map<number, number>();
+
+    for (const entry of leaderboard) {
+      scoreCounts.set(entry.score, (scoreCounts.get(entry.score) ?? 0) + 1);
+    }
+
+    return scoreCounts;
+  }, [leaderboard]);
   const teamSize = basho?.teamSize ?? 0;
   const picksRemaining = Math.max(teamSize - selectedIds.length, 0);
   const canSubmit =
@@ -143,6 +184,18 @@ export function App() {
       );
 
       setCreatedTeam(response);
+      setActiveView("leaderboard");
+      const leaderboardResponse = await getJson<LeaderboardResponse>(
+        `/api/basho/${basho.id}/leaderboard`,
+      );
+      setLeaderboard(leaderboardResponse.leaderboard);
+      setExpandedTeamId(
+        leaderboardResponse.leaderboard.some(
+          (entry) => entry.teamId === response.team.id,
+        )
+          ? response.team.id
+          : (leaderboardResponse.leaderboard[0]?.teamId ?? null),
+      );
     } catch (error) {
       setErrorMessage(getErrorMessage(error));
     } finally {
@@ -182,7 +235,7 @@ export function App() {
       )}
 
       {loadState === "ready" && basho !== null && (
-        <form className="selection-layout" onSubmit={handleSubmit}>
+        <>
           <section className="basho-panel" aria-labelledby="basho-title">
             <div className="section-heading">
               <p className="eyebrow">Current basho</p>
@@ -203,108 +256,221 @@ export function App() {
             </div>
           </section>
 
-          <section className="rikishi-section" aria-labelledby="rikishi-title">
-            <div className="section-heading">
-              <p className="eyebrow">Banzuke</p>
-              <h2 id="rikishi-title">Choose rikishi</h2>
-            </div>
-            <div className="rikishi-list">
-              {rikishi.map((entry) => {
-                const isSelected = selectedIds.includes(entry.id);
-                const isDisabled =
-                  !isSelected && selectedIds.length >= teamSize;
-
-                return (
-                  <button
-                    className="rikishi-row"
-                    disabled={isDisabled}
-                    key={entry.id}
-                    onClick={() => toggleRikishi(entry.id)}
-                    type="button"
-                    aria-pressed={isSelected}
-                  >
-                    <span className="rank-pill">{entry.rank}</span>
-                    <span>
-                      <strong>{entry.shikona}</strong>
-                      {entry.heya !== undefined && <small>{entry.heya}</small>}
-                    </span>
-                    <span
-                      className={
-                        isSelected ? "pick-mark selected" : "pick-mark"
-                      }
-                    >
-                      {isSelected ? "Selected" : "Pick"}
-                    </span>
-                  </button>
-                );
-              })}
-            </div>
-          </section>
-
-          <aside className="summary-panel" aria-labelledby="summary-title">
-            <div className="section-heading">
-              <p className="eyebrow">Your team</p>
-              <h2 id="summary-title">Selection</h2>
-            </div>
-
-            <label className="field-label" htmlFor="displayName">
-              Team name
-            </label>
-            <input
-              id="displayName"
-              name="displayName"
-              value={displayName}
-              onChange={(event) => {
-                setDisplayName(event.target.value);
-                setCreatedTeam(null);
-              }}
-              placeholder="East Stand Heroes"
-            />
-
-            <ol className="selected-list" aria-label="Selected rikishi">
-              {selectedRikishi.map((entry) => (
-                <li key={entry.id}>
-                  <span>{entry.shikona}</span>
-                  <button
-                    type="button"
-                    onClick={() => toggleRikishi(entry.id)}
-                    aria-label={`Remove ${entry.shikona}`}
-                  >
-                    Remove
-                  </button>
-                </li>
-              ))}
-              {Array.from({ length: picksRemaining }).map((_, index) => (
-                <li className="empty-pick" key={`empty-${index}`}>
-                  Pick slot
-                </li>
-              ))}
-            </ol>
-
+          <div className="view-switch" aria-label="View switcher">
             <button
-              className="submit-button"
-              disabled={!canSubmit}
-              type="submit"
+              type="button"
+              className={activeView === "selection" ? "active" : ""}
+              onClick={() => setActiveView("selection")}
             >
-              {submitState === "submitting" ? "Submitting..." : "Submit team"}
+              Team selection
             </button>
+            <button
+              type="button"
+              className={activeView === "leaderboard" ? "active" : ""}
+              onClick={() => setActiveView("leaderboard")}
+            >
+              Leaderboard
+            </button>
+          </div>
 
-            {errorMessage !== null && (
-              <p className="form-message error-state" role="alert">
-                {errorMessage}
-              </p>
-            )}
+          {activeView === "selection" && (
+            <form className="selection-layout" onSubmit={handleSubmit}>
+              <section
+                className="rikishi-section"
+                aria-labelledby="rikishi-title"
+              >
+                <div className="section-heading">
+                  <p className="eyebrow">Banzuke</p>
+                  <h2 id="rikishi-title">Choose rikishi</h2>
+                </div>
+                <div className="rikishi-list">
+                  {rikishi.map((entry) => {
+                    const isSelected = selectedIds.includes(entry.id);
+                    const isDisabled =
+                      !isSelected && selectedIds.length >= teamSize;
 
-            {createdTeam !== null && (
-              <div className="confirmation" role="status">
-                <strong>{createdTeam.team.displayName} submitted.</strong>
-                <span>
-                  {createdTeam.picks.length} rikishi selected for this basho.
-                </span>
+                    return (
+                      <button
+                        className="rikishi-row"
+                        disabled={isDisabled}
+                        key={entry.id}
+                        onClick={() => toggleRikishi(entry.id)}
+                        type="button"
+                        aria-pressed={isSelected}
+                      >
+                        <span className="rank-pill">{entry.rank}</span>
+                        <span>
+                          <strong>{entry.shikona}</strong>
+                          {entry.heya !== undefined && (
+                            <small>{entry.heya}</small>
+                          )}
+                        </span>
+                        <span
+                          className={
+                            isSelected ? "pick-mark selected" : "pick-mark"
+                          }
+                        >
+                          {isSelected ? "Selected" : "Pick"}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </section>
+
+              <aside className="summary-panel" aria-labelledby="summary-title">
+                <div className="section-heading">
+                  <p className="eyebrow">Your team</p>
+                  <h2 id="summary-title">Selection</h2>
+                </div>
+
+                <label className="field-label" htmlFor="displayName">
+                  Team name
+                </label>
+                <input
+                  id="displayName"
+                  name="displayName"
+                  value={displayName}
+                  onChange={(event) => {
+                    setDisplayName(event.target.value);
+                    setCreatedTeam(null);
+                  }}
+                  placeholder="East Stand Heroes"
+                />
+
+                <ol className="selected-list" aria-label="Selected rikishi">
+                  {selectedRikishi.map((entry) => (
+                    <li key={entry.id}>
+                      <span>{entry.shikona}</span>
+                      <button
+                        type="button"
+                        onClick={() => toggleRikishi(entry.id)}
+                        aria-label={`Remove ${entry.shikona}`}
+                      >
+                        Remove
+                      </button>
+                    </li>
+                  ))}
+                  {Array.from({ length: picksRemaining }).map((_, index) => (
+                    <li className="empty-pick" key={`empty-${index}`}>
+                      Pick slot
+                    </li>
+                  ))}
+                </ol>
+
+                <button
+                  className="submit-button"
+                  disabled={!canSubmit}
+                  type="submit"
+                >
+                  {submitState === "submitting"
+                    ? "Submitting..."
+                    : "Submit team"}
+                </button>
+
+                {errorMessage !== null && (
+                  <p className="form-message error-state" role="alert">
+                    {errorMessage}
+                  </p>
+                )}
+              </aside>
+            </form>
+          )}
+
+          {activeView === "leaderboard" && (
+            <section
+              className="leaderboard-section"
+              aria-labelledby="standings-title"
+            >
+              <div className="section-heading">
+                <p className="eyebrow">Standings</p>
+                <h2 id="standings-title">Leaderboard</h2>
               </div>
-            )}
-          </aside>
-        </form>
+
+              {createdTeam !== null && (
+                <div className="confirmation" role="status">
+                  <strong>{createdTeam.team.displayName} submitted.</strong>
+                  <span>
+                    {createdTeam.picks.length} rikishi selected for this basho.
+                  </span>
+                </div>
+              )}
+
+              {leaderboard.length === 0 ? (
+                <div className="state-panel leaderboard-empty">
+                  No teams have joined this basho yet.
+                </div>
+              ) : (
+                <ol className="leaderboard-list">
+                  {leaderboard.map((entry) => {
+                    const isTied = (tiedScoreCounts.get(entry.score) ?? 0) > 1;
+                    const isExpanded = expandedTeamId === entry.teamId;
+
+                    return (
+                      <li className="leaderboard-entry" key={entry.teamId}>
+                        <button
+                          type="button"
+                          className="leaderboard-summary"
+                          onClick={() =>
+                            setExpandedTeamId(isExpanded ? null : entry.teamId)
+                          }
+                          aria-expanded={isExpanded}
+                        >
+                          <span className="leaderboard-rank">
+                            #{entry.rank}
+                          </span>
+                          <span className="leaderboard-team">
+                            <strong>{entry.displayName}</strong>
+                            {isTied && <small>Tied on score</small>}
+                          </span>
+                          <span className="leaderboard-score">
+                            {entry.score} pts
+                          </span>
+                        </button>
+
+                        {isExpanded && (
+                          <div className="score-breakdown">
+                            {entry.rikishiScores.length === 0 ? (
+                              <p>No picks recorded for this team.</p>
+                            ) : (
+                              <ul>
+                                {entry.rikishiScores.map((score) => {
+                                  const pickedRikishi = rikishiById.get(
+                                    score.rikishiId,
+                                  );
+
+                                  return (
+                                    <li key={score.rikishiId}>
+                                      <span>
+                                        <strong>
+                                          {pickedRikishi?.shikona ??
+                                            score.rikishiId}
+                                        </strong>
+                                        <small>
+                                          {pickedRikishi?.rank ??
+                                            "Unranked pick"}
+                                        </small>
+                                      </span>
+                                      <span>
+                                        {score.wins} win
+                                        {score.wins === 1 ? "" : "s"}
+                                      </span>
+                                      <span>{score.score} pts</span>
+                                    </li>
+                                  );
+                                })}
+                              </ul>
+                            )}
+                          </div>
+                        )}
+                      </li>
+                    );
+                  })}
+                </ol>
+              )}
+            </section>
+          )}
+        </>
       )}
     </main>
   );

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1,3 +1,10 @@
+import type {
+  Basho,
+  BashoRikishiResponse,
+  CreatedTeamResponse,
+  LeaderboardResponse,
+} from "./types";
+
 interface ApiErrorBody {
   message?: string;
   details?: Array<{
@@ -5,7 +12,33 @@ interface ApiErrorBody {
   }>;
 }
 
-export async function getJson<T>(url: string): Promise<T> {
+export async function fetchCurrentBasho(): Promise<Basho> {
+  return getJson<Basho>("/api/basho/current");
+}
+
+export async function fetchBashoRikishi(
+  bashoId: string,
+): Promise<BashoRikishiResponse> {
+  return getJson<BashoRikishiResponse>(`/api/basho/${bashoId}/rikishi`);
+}
+
+export async function fetchLeaderboard(
+  bashoId: string,
+): Promise<LeaderboardResponse> {
+  return getJson<LeaderboardResponse>(`/api/basho/${bashoId}/leaderboard`);
+}
+
+export async function createFantasyTeam(
+  bashoId: string,
+  body: {
+    displayName: string;
+    rikishiIds: string[];
+  },
+): Promise<CreatedTeamResponse> {
+  return postJson<CreatedTeamResponse>(`/api/basho/${bashoId}/teams`, body);
+}
+
+async function getJson<T>(url: string): Promise<T> {
   const response = await fetch(url);
 
   if (!response.ok) {
@@ -15,7 +48,7 @@ export async function getJson<T>(url: string): Promise<T> {
   return response.json() as Promise<T>;
 }
 
-export async function postJson<T>(url: string, body: unknown): Promise<T> {
+async function postJson<T>(url: string, body: unknown): Promise<T> {
   const response = await fetch(url, {
     body: JSON.stringify(body),
     headers: {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1,0 +1,53 @@
+interface ApiErrorBody {
+  message?: string;
+  details?: Array<{
+    message?: string;
+  }>;
+}
+
+export async function getJson<T>(url: string): Promise<T> {
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(await readApiError(response));
+  }
+
+  return response.json() as Promise<T>;
+}
+
+export async function postJson<T>(url: string, body: unknown): Promise<T> {
+  const response = await fetch(url, {
+    body: JSON.stringify(body),
+    headers: {
+      "Content-Type": "application/json",
+    },
+    method: "POST",
+  });
+
+  if (!response.ok) {
+    throw new Error(await readApiError(response));
+  }
+
+  return response.json() as Promise<T>;
+}
+
+export function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Something went wrong.";
+}
+
+async function readApiError(response: Response): Promise<string> {
+  try {
+    const body = (await response.json()) as ApiErrorBody;
+    const details = body.details
+      ?.map((detail) => detail.message)
+      .filter((message): message is string => message !== undefined);
+
+    if (details !== undefined && details.length > 0) {
+      return `${body.message ?? "Request failed"} ${details.join(" ")}`;
+    }
+
+    return body.message ?? `Request failed with status ${response.status}.`;
+  } catch {
+    return `Request failed with status ${response.status}.`;
+  }
+}

--- a/apps/web/src/components/BashoPanel.test.tsx
+++ b/apps/web/src/components/BashoPanel.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { BashoPanel } from "./BashoPanel";
+import type { Basho } from "../types";
+
+const basho: Basho = {
+  id: "2026-05",
+  name: "May 2026 Sample Basho",
+  startDate: "2026-05-10",
+  endDate: "2026-05-24",
+  status: "active",
+  teamSize: 2,
+};
+
+describe("BashoPanel", () => {
+  it("shows basho dates and pick progress", () => {
+    render(<BashoPanel basho={basho} selectedCount={1} />);
+
+    expect(
+      screen.getByRole("heading", { name: "May 2026 Sample Basho" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("10 May to 24 May")).toBeInTheDocument();
+    expect(screen.getByText("1 of 2 selected")).toBeInTheDocument();
+    expect(screen.getByText("1 pick left")).toBeInTheDocument();
+  });
+
+  it("shows when the team is full", () => {
+    render(<BashoPanel basho={basho} selectedCount={2} />);
+
+    expect(screen.getByText("Team full")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/BashoPanel.tsx
+++ b/apps/web/src/components/BashoPanel.tsx
@@ -1,0 +1,47 @@
+import type { Basho } from "../types";
+
+interface BashoPanelProps {
+  basho: Basho;
+  selectedCount: number;
+}
+
+export function BashoPanel({ basho, selectedCount }: BashoPanelProps) {
+  const picksRemaining = Math.max(basho.teamSize - selectedCount, 0);
+
+  return (
+    <section className="basho-panel" aria-labelledby="basho-title">
+      <div className="section-heading">
+        <p className="eyebrow">Current basho</p>
+        <h2 id="basho-title">{basho.name}</h2>
+      </div>
+      <p className="basho-dates">
+        {formatDate(basho.startDate)} to {formatDate(basho.endDate)}
+      </p>
+      <div className="progress-wrap" aria-label="Pick progress">
+        <span>
+          {selectedCount} of {basho.teamSize} selected
+        </span>
+        <strong>
+          {picksRemaining === 0
+            ? "Team full"
+            : `${picksRemaining} pick${picksRemaining === 1 ? "" : "s"} left`}
+        </strong>
+      </div>
+    </section>
+  );
+}
+
+function formatDate(value: string): string {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+
+  if (match === null) {
+    return value;
+  }
+
+  const [, year, month, day] = match;
+
+  return new Intl.DateTimeFormat("en-GB", {
+    day: "numeric",
+    month: "short",
+  }).format(new Date(Number(year), Number(month) - 1, Number(day)));
+}

--- a/apps/web/src/components/LeaderboardPanel.test.tsx
+++ b/apps/web/src/components/LeaderboardPanel.test.tsx
@@ -1,0 +1,81 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { LeaderboardPanel } from "./LeaderboardPanel";
+import type { LeaderboardEntry, RankedRikishi } from "../types";
+
+const rikishi: RankedRikishi[] = [
+  {
+    id: "onosato",
+    shikona: "Onosato",
+    heya: "Nishonoseki",
+    rank: "Ozeki",
+    rankOrder: 1,
+  },
+  {
+    id: "kirishima",
+    shikona: "Kirishima",
+    heya: "Oitekaze",
+    rank: "Komusubi",
+    rankOrder: 4,
+  },
+];
+
+const leaderboard: LeaderboardEntry[] = [
+  {
+    rank: 1,
+    teamId: "team-east",
+    displayName: "East Side",
+    score: 2,
+    rikishiScores: [
+      {
+        rikishiId: "onosato",
+        wins: 1,
+        score: 1,
+      },
+      {
+        rikishiId: "kirishima",
+        wins: 1,
+        score: 1,
+      },
+    ],
+  },
+];
+
+describe("LeaderboardPanel", () => {
+  it("shows expanded rikishi score details for the selected team", () => {
+    render(
+      <LeaderboardPanel
+        createdTeam={null}
+        errorMessage={null}
+        expandedTeamId="team-east"
+        leaderboard={leaderboard}
+        onToggleTeam={vi.fn()}
+        rikishi={rikishi}
+      />,
+    );
+
+    expect(screen.getByText("East Side")).toBeInTheDocument();
+    expect(screen.getByText("Onosato")).toBeInTheDocument();
+    expect(screen.getByText("Kirishima")).toBeInTheDocument();
+    expect(screen.getAllByText("1 win")).toHaveLength(2);
+  });
+
+  it("requests expansion changes when a team row is clicked", () => {
+    const onToggleTeam = vi.fn();
+
+    render(
+      <LeaderboardPanel
+        createdTeam={null}
+        errorMessage={null}
+        expandedTeamId={null}
+        leaderboard={leaderboard}
+        onToggleTeam={onToggleTeam}
+        rikishi={rikishi}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /East Side/ }));
+
+    expect(onToggleTeam).toHaveBeenCalledWith("team-east");
+  });
+});

--- a/apps/web/src/components/LeaderboardPanel.test.tsx
+++ b/apps/web/src/components/LeaderboardPanel.test.tsx
@@ -49,6 +49,7 @@ describe("LeaderboardPanel", () => {
         errorMessage={null}
         expandedTeamId="team-east"
         leaderboard={leaderboard}
+        loadState="ready"
         onToggleTeam={vi.fn()}
         rikishi={rikishi}
       />,
@@ -69,6 +70,7 @@ describe("LeaderboardPanel", () => {
         errorMessage={null}
         expandedTeamId={null}
         leaderboard={leaderboard}
+        loadState="ready"
         onToggleTeam={onToggleTeam}
         rikishi={rikishi}
       />,
@@ -77,5 +79,24 @@ describe("LeaderboardPanel", () => {
     fireEvent.click(screen.getByRole("button", { name: /East Side/ }));
 
     expect(onToggleTeam).toHaveBeenCalledWith("team-east");
+  });
+
+  it("shows a loading state before leaderboard data settles", () => {
+    render(
+      <LeaderboardPanel
+        createdTeam={null}
+        errorMessage={null}
+        expandedTeamId={null}
+        leaderboard={[]}
+        loadState="loading"
+        onToggleTeam={vi.fn()}
+        rikishi={rikishi}
+      />,
+    );
+
+    expect(screen.getByText("Loading leaderboard...")).toBeInTheDocument();
+    expect(
+      screen.queryByText("No teams have joined this basho yet."),
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/LeaderboardPanel.tsx
+++ b/apps/web/src/components/LeaderboardPanel.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import type {
   CreatedTeamResponse,
   LeaderboardEntry,
+  LeaderboardLoadState,
   RankedRikishi,
 } from "../types";
 
@@ -10,6 +11,7 @@ interface LeaderboardPanelProps {
   errorMessage: string | null;
   expandedTeamId: string | null;
   leaderboard: LeaderboardEntry[];
+  loadState: LeaderboardLoadState;
   onToggleTeam: (teamId: string) => void;
   rikishi: RankedRikishi[];
 }
@@ -19,6 +21,7 @@ export function LeaderboardPanel({
   errorMessage,
   expandedTeamId,
   leaderboard,
+  loadState,
   onToggleTeam,
   rikishi,
 }: LeaderboardPanelProps) {
@@ -58,7 +61,11 @@ export function LeaderboardPanel({
         </div>
       )}
 
-      {leaderboard.length === 0 ? (
+      {loadState === "loading" ? (
+        <div className="state-panel leaderboard-empty" aria-live="polite">
+          Loading leaderboard...
+        </div>
+      ) : leaderboard.length === 0 ? (
         <div className="state-panel leaderboard-empty">
           No teams have joined this basho yet.
         </div>

--- a/apps/web/src/components/LeaderboardPanel.tsx
+++ b/apps/web/src/components/LeaderboardPanel.tsx
@@ -1,0 +1,126 @@
+import { useMemo } from "react";
+import type {
+  CreatedTeamResponse,
+  LeaderboardEntry,
+  RankedRikishi,
+} from "../types";
+
+interface LeaderboardPanelProps {
+  createdTeam: CreatedTeamResponse | null;
+  errorMessage: string | null;
+  expandedTeamId: string | null;
+  leaderboard: LeaderboardEntry[];
+  onToggleTeam: (teamId: string) => void;
+  rikishi: RankedRikishi[];
+}
+
+export function LeaderboardPanel({
+  createdTeam,
+  errorMessage,
+  expandedTeamId,
+  leaderboard,
+  onToggleTeam,
+  rikishi,
+}: LeaderboardPanelProps) {
+  const rikishiById = useMemo(
+    () => new Map(rikishi.map((entry) => [entry.id, entry])),
+    [rikishi],
+  );
+  const tiedScoreCounts = useMemo(() => {
+    const scoreCounts = new Map<number, number>();
+
+    for (const entry of leaderboard) {
+      scoreCounts.set(entry.score, (scoreCounts.get(entry.score) ?? 0) + 1);
+    }
+
+    return scoreCounts;
+  }, [leaderboard]);
+
+  return (
+    <section className="leaderboard-section" aria-labelledby="standings-title">
+      <div className="section-heading">
+        <p className="eyebrow">Standings</p>
+        <h2 id="standings-title">Leaderboard</h2>
+      </div>
+
+      {errorMessage !== null && (
+        <p className="form-message error-state" role="alert">
+          {errorMessage}
+        </p>
+      )}
+
+      {createdTeam !== null && (
+        <div className="confirmation" role="status">
+          <strong>{createdTeam.team.displayName} submitted.</strong>
+          <span>
+            {createdTeam.picks.length} rikishi selected for this basho.
+          </span>
+        </div>
+      )}
+
+      {leaderboard.length === 0 ? (
+        <div className="state-panel leaderboard-empty">
+          No teams have joined this basho yet.
+        </div>
+      ) : (
+        <ol className="leaderboard-list">
+          {leaderboard.map((entry) => {
+            const isTied = (tiedScoreCounts.get(entry.score) ?? 0) > 1;
+            const isExpanded = expandedTeamId === entry.teamId;
+
+            return (
+              <li className="leaderboard-entry" key={entry.teamId}>
+                <button
+                  type="button"
+                  className="leaderboard-summary"
+                  onClick={() => onToggleTeam(entry.teamId)}
+                  aria-expanded={isExpanded}
+                >
+                  <span className="leaderboard-rank">#{entry.rank}</span>
+                  <span className="leaderboard-team">
+                    <strong>{entry.displayName}</strong>
+                    {isTied && <small>Tied on score</small>}
+                  </span>
+                  <span className="leaderboard-score">{entry.score} pts</span>
+                </button>
+
+                {isExpanded && (
+                  <div className="score-breakdown">
+                    {entry.rikishiScores.length === 0 ? (
+                      <p>No picks recorded for this team.</p>
+                    ) : (
+                      <ul>
+                        {entry.rikishiScores.map((score) => {
+                          const pickedRikishi = rikishiById.get(
+                            score.rikishiId,
+                          );
+
+                          return (
+                            <li key={score.rikishiId}>
+                              <span>
+                                <strong>
+                                  {pickedRikishi?.shikona ?? score.rikishiId}
+                                </strong>
+                                <small>
+                                  {pickedRikishi?.rank ?? "Unranked pick"}
+                                </small>
+                              </span>
+                              <span>
+                                {score.wins} win{score.wins === 1 ? "" : "s"}
+                              </span>
+                              <span>{score.score} pts</span>
+                            </li>
+                          );
+                        })}
+                      </ul>
+                    )}
+                  </div>
+                )}
+              </li>
+            );
+          })}
+        </ol>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/PageHeader.test.tsx
+++ b/apps/web/src/components/PageHeader.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { PageHeader } from "./PageHeader";
+
+describe("PageHeader", () => {
+  it("shows the app title and team-building prompt", () => {
+    render(<PageHeader />);
+
+    expect(
+      screen.getByRole("heading", { name: "Build your basho team" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Fantasy Sumo")).toBeInTheDocument();
+    expect(screen.getByText(/Pick rikishi/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/PageHeader.tsx
+++ b/apps/web/src/components/PageHeader.tsx
@@ -1,0 +1,14 @@
+export function PageHeader() {
+  return (
+    <section className="page-header" aria-labelledby="page-title">
+      <p className="eyebrow">Fantasy Sumo</p>
+      <div>
+        <h1 id="page-title">Build your basho team</h1>
+        <p className="lede">
+          Pick rikishi from the current banzuke and enter a team name to join
+          the local leaderboard.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/TeamSelection.test.tsx
+++ b/apps/web/src/components/TeamSelection.test.tsx
@@ -1,0 +1,129 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import type { FormEvent } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { TeamSelection } from "./TeamSelection";
+import type { CreatedTeamResponse, RankedRikishi } from "../types";
+
+const rikishi: RankedRikishi[] = [
+  {
+    id: "onosato",
+    shikona: "Onosato",
+    heya: "Nishonoseki",
+    rank: "Ozeki",
+    rankOrder: 1,
+  },
+  {
+    id: "kotozakura",
+    shikona: "Kotozakura",
+    heya: "Sadogatake",
+    rank: "Ozeki",
+    rankOrder: 2,
+  },
+  {
+    id: "hoshoryu",
+    shikona: "Hoshoryu",
+    heya: "Tatsunami",
+    rank: "Sekiwake",
+    rankOrder: 3,
+  },
+];
+
+const onosato = rikishi[0] as RankedRikishi;
+const kotozakura = rikishi[1] as RankedRikishi;
+
+const createdTeam: CreatedTeamResponse = {
+  team: {
+    id: "team-east",
+    displayName: "East Stand Heroes",
+  },
+  picks: [{ rikishiId: "onosato" }, { rikishiId: "kotozakura" }],
+};
+
+describe("TeamSelection", () => {
+  it("shows selection state and disables extra picks when the team is full", () => {
+    renderTeamSelection({
+      selectedIds: ["onosato", "kotozakura"],
+      selectedRikishi: [onosato, kotozakura],
+    });
+
+    const banzuke = screen.getByRole("region", { name: "Choose rikishi" });
+
+    expect(
+      within(banzuke).getByRole("button", { name: /Onosato/ }),
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(
+      within(banzuke).getByRole("button", { name: /Kotozakura/ }),
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(
+      within(banzuke).getByRole("button", { name: /Hoshoryu/ }),
+    ).toBeDisabled();
+  });
+
+  it("emits input, pick, remove, and submit events", () => {
+    const onDisplayNameChange = vi.fn();
+    const onSubmit = vi.fn((event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+    });
+    const onToggleRikishi = vi.fn();
+
+    renderTeamSelection({
+      displayName: "",
+      onDisplayNameChange,
+      onSubmit,
+      onToggleRikishi,
+    });
+
+    fireEvent.change(screen.getByLabelText("Team name"), {
+      target: { value: "East Stand Heroes" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Onosato/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Remove Kotozakura" }));
+    fireEvent.click(screen.getByRole("button", { name: "Submit team" }));
+
+    expect(onDisplayNameChange).toHaveBeenCalledWith("East Stand Heroes");
+    expect(onToggleRikishi).toHaveBeenCalledWith("onosato");
+    expect(onToggleRikishi).toHaveBeenCalledWith("kotozakura");
+    expect(onSubmit).toHaveBeenCalledOnce();
+  });
+
+  it("shows form errors and submission confirmation", () => {
+    renderTeamSelection({
+      createdTeam,
+      errorMessage: "Unable to refresh leaderboard.",
+    });
+
+    expect(
+      screen.getByText("Unable to refresh leaderboard."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("East Stand Heroes submitted."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("2 rikishi selected for this basho."),
+    ).toBeInTheDocument();
+  });
+});
+
+function renderTeamSelection(
+  props: Partial<Parameters<typeof TeamSelection>[0]> = {},
+) {
+  const selectedIds = props.selectedIds ?? ["kotozakura"];
+  const selectedRikishi = props.selectedRikishi ?? [kotozakura];
+
+  return render(
+    <TeamSelection
+      canSubmit={props.canSubmit ?? true}
+      createdTeam={props.createdTeam ?? null}
+      displayName={props.displayName ?? "East Stand Heroes"}
+      errorMessage={props.errorMessage ?? null}
+      onDisplayNameChange={props.onDisplayNameChange ?? vi.fn()}
+      onSubmit={props.onSubmit ?? vi.fn()}
+      onToggleRikishi={props.onToggleRikishi ?? vi.fn()}
+      rikishi={props.rikishi ?? rikishi}
+      selectedIds={selectedIds}
+      selectedRikishi={selectedRikishi}
+      submitState={props.submitState ?? "idle"}
+      teamSize={props.teamSize ?? 2}
+    />,
+  );
+}

--- a/apps/web/src/components/TeamSelection.tsx
+++ b/apps/web/src/components/TeamSelection.tsx
@@ -1,0 +1,130 @@
+import type { FormEvent } from "react";
+import type { CreatedTeamResponse, RankedRikishi } from "../types";
+
+interface TeamSelectionProps {
+  canSubmit: boolean;
+  createdTeam: CreatedTeamResponse | null;
+  displayName: string;
+  errorMessage: string | null;
+  onDisplayNameChange: (displayName: string) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  onToggleRikishi: (rikishiId: string) => void;
+  rikishi: RankedRikishi[];
+  selectedIds: string[];
+  selectedRikishi: RankedRikishi[];
+  submitState: "idle" | "submitting";
+  teamSize: number;
+}
+
+export function TeamSelection({
+  canSubmit,
+  createdTeam,
+  displayName,
+  errorMessage,
+  onDisplayNameChange,
+  onSubmit,
+  onToggleRikishi,
+  rikishi,
+  selectedIds,
+  selectedRikishi,
+  submitState,
+  teamSize,
+}: TeamSelectionProps) {
+  const picksRemaining = Math.max(teamSize - selectedIds.length, 0);
+
+  return (
+    <form className="selection-layout" onSubmit={onSubmit}>
+      <section className="rikishi-section" aria-labelledby="rikishi-title">
+        <div className="section-heading">
+          <p className="eyebrow">Banzuke</p>
+          <h2 id="rikishi-title">Choose rikishi</h2>
+        </div>
+        <div className="rikishi-list">
+          {rikishi.map((entry) => {
+            const isSelected = selectedIds.includes(entry.id);
+            const isDisabled = !isSelected && selectedIds.length >= teamSize;
+
+            return (
+              <button
+                className="rikishi-row"
+                disabled={isDisabled}
+                key={entry.id}
+                onClick={() => onToggleRikishi(entry.id)}
+                type="button"
+                aria-pressed={isSelected}
+              >
+                <span className="rank-pill">{entry.rank}</span>
+                <span>
+                  <strong>{entry.shikona}</strong>
+                  {entry.heya !== undefined && <small>{entry.heya}</small>}
+                </span>
+                <span
+                  className={isSelected ? "pick-mark selected" : "pick-mark"}
+                >
+                  {isSelected ? "Selected" : "Pick"}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </section>
+
+      <aside className="summary-panel" aria-labelledby="summary-title">
+        <div className="section-heading">
+          <p className="eyebrow">Your team</p>
+          <h2 id="summary-title">Selection</h2>
+        </div>
+
+        <label className="field-label" htmlFor="displayName">
+          Team name
+        </label>
+        <input
+          id="displayName"
+          name="displayName"
+          value={displayName}
+          onChange={(event) => onDisplayNameChange(event.target.value)}
+          placeholder="East Stand Heroes"
+        />
+
+        <ol className="selected-list" aria-label="Selected rikishi">
+          {selectedRikishi.map((entry) => (
+            <li key={entry.id}>
+              <span>{entry.shikona}</span>
+              <button
+                type="button"
+                onClick={() => onToggleRikishi(entry.id)}
+                aria-label={`Remove ${entry.shikona}`}
+              >
+                Remove
+              </button>
+            </li>
+          ))}
+          {Array.from({ length: picksRemaining }).map((_, index) => (
+            <li className="empty-pick" key={`empty-${index}`}>
+              Pick slot
+            </li>
+          ))}
+        </ol>
+
+        <button className="submit-button" disabled={!canSubmit} type="submit">
+          {submitState === "submitting" ? "Submitting..." : "Submit team"}
+        </button>
+
+        {errorMessage !== null && (
+          <p className="form-message error-state" role="alert">
+            {errorMessage}
+          </p>
+        )}
+
+        {createdTeam !== null && (
+          <div className="confirmation" role="status">
+            <strong>{createdTeam.team.displayName} submitted.</strong>
+            <span>
+              {createdTeam.picks.length} rikishi selected for this basho.
+            </span>
+          </div>
+        )}
+      </aside>
+    </form>
+  );
+}

--- a/apps/web/src/components/ViewSwitch.test.tsx
+++ b/apps/web/src/components/ViewSwitch.test.tsx
@@ -19,4 +19,15 @@ describe("ViewSwitch", () => {
 
     expect(onChange).toHaveBeenCalledWith("leaderboard");
   });
+
+  it("disables view changes while requested", () => {
+    const onChange = vi.fn();
+
+    render(<ViewSwitch activeView="selection" disabled onChange={onChange} />);
+
+    expect(
+      screen.getByRole("button", { name: "Team selection" }),
+    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Leaderboard" })).toBeDisabled();
+  });
 });

--- a/apps/web/src/components/ViewSwitch.test.tsx
+++ b/apps/web/src/components/ViewSwitch.test.tsx
@@ -1,0 +1,22 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ViewSwitch } from "./ViewSwitch";
+
+describe("ViewSwitch", () => {
+  it("marks the active view and emits view changes", () => {
+    const onChange = vi.fn();
+
+    render(<ViewSwitch activeView="selection" onChange={onChange} />);
+
+    expect(screen.getByRole("button", { name: "Team selection" })).toHaveClass(
+      "active",
+    );
+    expect(screen.getByRole("button", { name: "Leaderboard" })).not.toHaveClass(
+      "active",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Leaderboard" }));
+
+    expect(onChange).toHaveBeenCalledWith("leaderboard");
+  });
+});

--- a/apps/web/src/components/ViewSwitch.tsx
+++ b/apps/web/src/components/ViewSwitch.tsx
@@ -2,15 +2,21 @@ import type { ActiveView } from "../types";
 
 interface ViewSwitchProps {
   activeView: ActiveView;
+  disabled?: boolean;
   onChange: (view: ActiveView) => void;
 }
 
-export function ViewSwitch({ activeView, onChange }: ViewSwitchProps) {
+export function ViewSwitch({
+  activeView,
+  disabled = false,
+  onChange,
+}: ViewSwitchProps) {
   return (
     <div className="view-switch" aria-label="View switcher">
       <button
         type="button"
         className={activeView === "selection" ? "active" : ""}
+        disabled={disabled}
         onClick={() => onChange("selection")}
       >
         Team selection
@@ -18,6 +24,7 @@ export function ViewSwitch({ activeView, onChange }: ViewSwitchProps) {
       <button
         type="button"
         className={activeView === "leaderboard" ? "active" : ""}
+        disabled={disabled}
         onClick={() => onChange("leaderboard")}
       >
         Leaderboard

--- a/apps/web/src/components/ViewSwitch.tsx
+++ b/apps/web/src/components/ViewSwitch.tsx
@@ -1,0 +1,27 @@
+import type { ActiveView } from "../types";
+
+interface ViewSwitchProps {
+  activeView: ActiveView;
+  onChange: (view: ActiveView) => void;
+}
+
+export function ViewSwitch({ activeView, onChange }: ViewSwitchProps) {
+  return (
+    <div className="view-switch" aria-label="View switcher">
+      <button
+        type="button"
+        className={activeView === "selection" ? "active" : ""}
+        onClick={() => onChange("selection")}
+      >
+        Team selection
+      </button>
+      <button
+        type="button"
+        className={activeView === "leaderboard" ? "active" : ""}
+        onClick={() => onChange("leaderboard")}
+      >
+        Leaderboard
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -95,6 +95,31 @@ h2 {
   align-items: start;
 }
 
+.view-switch {
+  display: inline-flex;
+  gap: 4px;
+  margin: 18px 0;
+  padding: 4px;
+  border: 1px solid #d4c9b8;
+  border-radius: 8px;
+  background: #fffaf2;
+}
+
+.view-switch button {
+  min-height: 40px;
+  padding: 8px 14px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: #516069;
+  font-weight: 800;
+}
+
+.view-switch button.active {
+  background: #18333d;
+  color: #ffffff;
+}
+
 .basho-panel {
   grid-column: 1 / -1;
   display: grid;
@@ -243,7 +268,9 @@ input {
 }
 
 input:focus,
+.view-switch button:focus-visible,
 .rikishi-row:focus-visible,
+.leaderboard-summary:focus-visible,
 .selected-list button:focus-visible,
 .submit-button:focus-visible {
   outline: 3px solid #4a8f9f;
@@ -322,6 +349,119 @@ input:focus,
   color: #21332f;
 }
 
+.leaderboard-section {
+  padding: 20px;
+  border: 1px solid #d4c9b8;
+  border-radius: 8px;
+  background: #fffaf2;
+}
+
+.leaderboard-empty {
+  border-style: dashed;
+  background: transparent;
+}
+
+.leaderboard-list {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.leaderboard-entry {
+  overflow: hidden;
+  border: 1px solid #d9d0c2;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.leaderboard-summary {
+  display: grid;
+  grid-template-columns: 78px minmax(0, 1fr) 100px;
+  gap: 14px;
+  align-items: center;
+  width: 100%;
+  min-height: 68px;
+  padding: 12px;
+  border: 0;
+  background: transparent;
+  color: #1f2b31;
+  text-align: left;
+}
+
+.leaderboard-summary:hover,
+.leaderboard-summary[aria-expanded="true"] {
+  box-shadow: inset 4px 0 0 #a93431;
+}
+
+.leaderboard-rank {
+  color: #a93431;
+  font-size: 1.2rem;
+  font-weight: 900;
+}
+
+.leaderboard-team strong,
+.leaderboard-team small {
+  display: block;
+}
+
+.leaderboard-team small {
+  color: #60717a;
+  margin-top: 2px;
+}
+
+.leaderboard-score {
+  justify-self: end;
+  color: #17333e;
+  font-size: 1.1rem;
+  font-weight: 900;
+}
+
+.score-breakdown {
+  padding: 0 12px 12px;
+}
+
+.score-breakdown p {
+  margin-bottom: 0;
+  color: #60717a;
+}
+
+.score-breakdown ul {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.score-breakdown li {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 92px 72px;
+  gap: 12px;
+  align-items: center;
+  min-height: 48px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: #eef4f1;
+  color: #1f2b31;
+}
+
+.score-breakdown strong,
+.score-breakdown small {
+  display: block;
+}
+
+.score-breakdown small {
+  color: #60717a;
+}
+
+.score-breakdown li > span:nth-child(2),
+.score-breakdown li > span:nth-child(3) {
+  justify-self: end;
+  font-weight: 800;
+}
+
 @media (max-width: 860px) {
   .app-shell {
     padding: 24px;
@@ -329,12 +469,20 @@ input:focus,
 
   .page-header,
   .selection-layout,
-  .basho-panel {
+  .basho-panel,
+  .leaderboard-summary,
+  .score-breakdown li {
     grid-template-columns: 1fr;
   }
 
   .basho-dates {
     white-space: normal;
+  }
+
+  .leaderboard-score,
+  .score-breakdown li > span:nth-child(2),
+  .score-breakdown li > span:nth-child(3) {
+    justify-self: start;
   }
 }
 

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -1,0 +1,53 @@
+export interface Basho {
+  id: string;
+  name: string;
+  startDate: string;
+  endDate: string;
+  status: "upcoming" | "active" | "complete";
+  teamSize: number;
+}
+
+export interface RankedRikishi {
+  id: string;
+  shikona: string;
+  heya?: string;
+  rank: string;
+  rankOrder: number;
+}
+
+export interface BashoRikishiResponse {
+  basho: Omit<Basho, "teamSize">;
+  rikishi: RankedRikishi[];
+}
+
+export interface CreatedTeamResponse {
+  team: {
+    id: string;
+    displayName: string;
+  };
+  picks: Array<{
+    rikishiId: string;
+  }>;
+}
+
+export interface LeaderboardResponse {
+  bashoId: string;
+  leaderboard: LeaderboardEntry[];
+}
+
+export interface LeaderboardEntry {
+  rank: number;
+  teamId: string;
+  displayName: string;
+  score: number;
+  rikishiScores: RikishiScore[];
+}
+
+export interface RikishiScore {
+  rikishiId: string;
+  wins: number;
+  score: number;
+}
+
+export type LoadState = "loading" | "ready" | "empty" | "error";
+export type ActiveView = "selection" | "leaderboard";

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -50,4 +50,5 @@ export interface RikishiScore {
 }
 
 export type LoadState = "loading" | "ready" | "empty" | "error";
+export type LeaderboardLoadState = "loading" | "ready";
 export type ActiveView = "selection" | "leaderboard";

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -12,7 +12,7 @@ Fantasy Sumo now uses a small pnpm workspace:
 
 ```text
 apps/
-  web/          Vite + React smoke app
+  web/          Vite + React app shell
   api/          Fastify API
 packages/
   domain/       Shared TypeScript domain types, validation, scoring
@@ -34,15 +34,16 @@ The front end entry point is `apps/web/src/main.tsx`.
 Current behaviour:
 
 - Fetches the current basho and its ranked rikishi from the Fastify API.
+- Fetches leaderboard standings from the Fastify API.
 - Lets a player select and deselect rikishi up to the API-configured team size.
 - Captures a display/team name and submits the team to the API.
+- Shows ordered team standings with expandable picked-rikishi score breakdowns.
 - Shows loading, empty, success, and API error states.
 - Has Vitest coverage through React Testing Library.
 
 Current limitations:
 
 - No routing.
-- No leaderboard UI yet.
 - No result entry/import UI yet.
 - No persistence of the last created team in browser storage yet.
 

--- a/docs/MODERNISATION_PLAN.md
+++ b/docs/MODERNISATION_PLAN.md
@@ -29,6 +29,8 @@ Update: the rebuild foundation now exists as a pnpm workspace with Vite + React,
 
 Update: the local MVP persistence layer now uses SQLite with Drizzle schema definitions, migration SQL, repository functions, and seed data in `packages/db`.
 
+Update: the web app now supports team selection plus a leaderboard view backed by the local API.
+
 ### Phase 0: Preserve current knowledge
 
 - Add docs describing product intent, current architecture, and roadmap.
@@ -126,8 +128,7 @@ The app currently imports banzuke data from sumo.or.jp. Before relying on this:
 1. Add a pure scoring module with tests.
 2. Add a minimal domain model for basho, rikishi, teams, picks, and results.
 3. Create a first team selection screen using seeded data.
-4. Add API routes backed by database repositories.
-5. Add a result import or manual result entry path.
+4. Add a result import or manual result entry path.
 
 ## Avoid initially
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -41,7 +41,7 @@ Goal: make the core game loop work locally.
 - [x] Add team selection flow.
 - [ ] Add result import or manual result entry.
 - [x] Add leaderboard calculation.
-- [ ] Add leaderboard UI.
+- [x] Add leaderboard UI.
 
 ## Stage 4: Friendly single-league version
 
@@ -52,7 +52,7 @@ Goal: make it usable by a small group of friends.
 - [ ] Add pick-locking before basho starts.
 - [ ] Add basic admin flow for importing data.
 - [ ] Improve responsive UI.
-- [ ] Add error/loading/empty states.
+- [x] Add error/loading/empty states.
 
 ## Stage 5: Public-ready version
 


### PR DESCRIPTION
## Summary
- Add a web leaderboard view wired to the existing basho leaderboard API.
- Show ordered teams, tied-score labels, and expandable picked-rikishi score breakdowns.
- Refresh standings after team submission and keep the submission confirmation visible on the leaderboard.
- Update README and project docs so the next MVP gap is result entry/import.

## Validation
- pnpm lint
- pnpm format:check
- pnpm build
- pnpm test
- Browser smoke test on http://localhost:5173/ against seeded data; leaderboard and score details rendered with no console errors.

Closes #10