### PR TITLE
Add Makefile commands for development workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ Avoid overbuilding. A working single-user/local MVP is preferable to a half-fini
 3. Read `docs/ARCHITECTURE.md` for current implementation notes.
 4. Read `docs/MODERNISATION_PLAN.md` before upgrading dependencies.
 5. Read `docs/ROADMAP.md` before adding features.
-6. Run tests/build before and after code changes where possible.
+6. Prefer the Makefile command layer for common workflows: `make test`, `make lint`, `make build`, and `make check`.
 7. Keep PRs focused on the next MVP slice; do not rebuild the full product in one change.
 
 ## Definition of done for future changes

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,52 @@
+.DEFAULT_GOAL := help
+PNPM ?= $(shell if command -v pnpm >/dev/null 2>&1; then command -v pnpm; elif [ -x /opt/homebrew/bin/pnpm ]; then echo /opt/homebrew/bin/pnpm; else echo pnpm; fi)
+export PATH := $(dir $(PNPM)):$(PATH)
+
+.PHONY: help install dev dev-client dev-server build test lint format format-check check db-migrate db-seed clean
+
+help: ## Show available make targets.
+	@awk 'BEGIN {FS = ":.*## "; printf "Fantasy Sumo development commands:\n\n"} /^[a-zA-Z0-9_-]+:.*## / {printf "  %-14s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+install: ## Install dependencies with pnpm.
+	CI=true $(PNPM) install --frozen-lockfile
+
+dev: ## Start the API and Vite web app together.
+	$(PNPM) dev
+
+dev-client: ## Start only the Vite web client.
+	$(PNPM) --filter @fantasy-sumo/domain build
+	$(PNPM) --filter @fantasy-sumo/web dev
+
+dev-server: ## Start only the Fastify API server.
+	$(PNPM) --filter @fantasy-sumo/domain build
+	$(PNPM) --filter @fantasy-sumo/api dev
+
+build: ## Build all workspace packages and apps.
+	$(PNPM) build
+
+test: ## Run all tests.
+	$(PNPM) test
+
+lint: ## Run ESLint.
+	$(PNPM) lint
+
+format: ## Format files with Prettier.
+	$(PNPM) format
+
+format-check: ## Check Prettier formatting.
+	$(PNPM) format:check
+
+check: ## Run the main pre-PR validation suite.
+	$(PNPM) lint
+	$(PNPM) format:check
+	$(PNPM) test
+	$(PNPM) build
+
+db-migrate: ## Apply local database migrations.
+	$(PNPM) db:migrate
+
+db-seed: ## Seed the local database.
+	$(PNPM) db:seed
+
+clean: ## Remove generated build artifacts.
+	rm -rf apps/api/dist apps/web/dist packages/db/dist packages/domain/dist

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 .DEFAULT_GOAL := help
 PNPM ?= $(shell if command -v pnpm >/dev/null 2>&1; then command -v pnpm; elif [ -x /opt/homebrew/bin/pnpm ]; then echo /opt/homebrew/bin/pnpm; else echo pnpm; fi)
-export PATH := $(dir $(PNPM)):$(PATH)
+PNPM_DIR := $(if $(filter /%,$(PNPM)),$(dir $(PNPM)))
+ifneq ($(PNPM_DIR),)
+export PATH := $(PNPM_DIR):$(PATH)
+endif
 
 .PHONY: help install dev dev-client dev-server build test lint format format-check check db-migrate db-seed clean
 

--- a/README.md
+++ b/README.md
@@ -49,20 +49,20 @@ Use Node 24 and pnpm. The repo declares its Node version in `.nvmrc` and its pac
 Install dependencies:
 
 ```bash
-pnpm install
+make install
 ```
 
 Create a local database and seed sample MVP data:
 
 ```bash
-pnpm db:migrate
-pnpm db:seed
+make db-migrate
+make db-seed
 ```
 
 Run both the API and web dev servers:
 
 ```bash
-pnpm dev
+make dev
 ```
 
 Local URLs:
@@ -81,10 +81,7 @@ Useful API endpoints:
 Useful checks:
 
 ```bash
-pnpm build
-pnpm test
-pnpm lint
-pnpm format:check
+make check
 ```
 
 By default, the database package writes local SQLite data to `packages/db/data/fantasy-sumo.sqlite` when run through the pnpm scripts. Override this with `DATABASE_URL` using a `file:` SQLite URL, for example:
@@ -94,6 +91,21 @@ DATABASE_URL=file:./data/dev.sqlite pnpm db:seed
 ```
 
 The local team size defaults to `2`. Override it for the API with `TEAM_SIZE`.
+
+## Makefile commands
+
+Use `make help` to list the stable development commands. The Makefile is a thin wrapper over the existing pnpm scripts.
+It uses `pnpm` from `PATH` when available and can be overridden with `PNPM=/path/to/pnpm`.
+
+Common targets:
+
+- `make dev` - start the API and web client together.
+- `make dev-client` - start only the Vite web client.
+- `make dev-server` - start only the Fastify API.
+- `make test` - run all tests.
+- `make lint` - run ESLint.
+- `make build` - build all packages/apps.
+- `make check` - run lint, format check, tests, and build before a PR.
 
 ## Security note
 


### PR DESCRIPTION
## Summary
- Add a top-level Makefile wrapping the existing pnpm workflows for setup, dev, validation, database seeding, and cleanup.
- Add make help output for discoverable commands and support PNPM override/path fallback for agent shells.
- Update README and AGENTS.md to document the Makefile workflow for humans and future agents.

## Validation
- make help
- make install (rerun with network access after sandbox registry fetch failed)
- make check
- make db-migrate (requires sandbox escalation for tsx IPC)
- make db-seed (requires sandbox escalation for tsx IPC)
- make dev-server starts the Fastify API on port 3000, stopped with Ctrl-C
- make dev starts API and web on ports 3000/5173, stopped with Ctrl-C

Closes #19