### PR TITLE
Document sumo data import strategy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,9 +56,10 @@ Avoid overbuilding. A working single-user/local MVP is preferable to a half-fini
 3. Read `docs/ARCHITECTURE.md` for current implementation notes.
 4. Read `docs/MODERNISATION_PLAN.md` before upgrading dependencies.
 5. Read `docs/ROADMAP.md` before adding features.
-6. Read `docs/E2E_TESTING.md` before adding browser end-to-end tests.
-7. Prefer the Makefile command layer for common workflows: `make test`, `make lint`, `make build`, and `make check`.
-8. Keep PRs focused on the next MVP slice; do not rebuild the full product in one change.
+6. Read `docs/DATA_IMPORT_STRATEGY.md` before adding or changing banzuke/result import behaviour.
+7. Read `docs/E2E_TESTING.md` before adding browser end-to-end tests.
+8. Prefer the Makefile command layer for common workflows: `make test`, `make lint`, `make build`, and `make check`.
+9. Keep PRs focused on the next MVP slice; do not rebuild the full product in one change.
 
 ## Definition of done for future changes
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Start here:
 - `docs/PROJECT_BRIEF.md` - product intent and MVP definition.
 - `docs/ARCHITECTURE.md` - current architecture and suggested future boundaries.
 - `docs/adr/0001-rebuild-architecture.md` - accepted rebuild architecture decision.
+- `docs/DATA_IMPORT_STRATEGY.md` - MVP data-source investigation and import recommendation.
 - `docs/E2E_TESTING.md` - intended Playwright E2E strategy for the MVP game loop.
 - `docs/MODERNISATION_PLAN.md` - safe path for updating or rebuilding the app.
 - `docs/ROADMAP.md` - staged product/engineering roadmap.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -121,8 +121,10 @@ pnpm --filter @fantasy-sumo/db db:generate
 
 Current limitations:
 
-- No live banzuke/results import yet.
+- No banzuke/results import UI or endpoints yet.
 - No production database configuration yet.
+
+The accepted MVP import direction is documented in [Data Import Strategy](DATA_IMPORT_STRATEGY.md). Prefer manual JSON/CSV imports first, then optional live source adapters later.
 
 ## Legacy stack snapshot
 
@@ -271,6 +273,8 @@ POST   /api/admin/basho/:bashoId/import-results
 ```
 
 Admin endpoints can be protected later. For early local development, they can remain local-only but should be clearly marked as unsafe for production.
+
+The first import implementation should follow [Data Import Strategy](DATA_IMPORT_STRATEGY.md): validate source-agnostic JSON import files, write them transactionally, and keep live source adapters separate from core import parsing.
 
 ## Testing priorities
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -75,7 +75,7 @@ Current limitations:
 
 - No auth.
 - No dedicated API client package.
-- No result import or manual result entry endpoints yet.
+- No result import endpoints or job trigger yet.
 - No pick-locking rules yet.
 
 ## Domain package
@@ -124,7 +124,7 @@ Current limitations:
 - No banzuke/results import UI or endpoints yet.
 - No production database configuration yet.
 
-The accepted MVP import direction is documented in [Data Import Strategy](DATA_IMPORT_STRATEGY.md). Prefer manual JSON/CSV imports first, then optional live source adapters later.
+The accepted MVP import direction is documented in [Data Import Strategy](DATA_IMPORT_STRATEGY.md). Prefer automated source-backed imports first, with manual triggers, dry runs, and JSON fixtures available for testing and emergency fallback.
 
 ## Legacy stack snapshot
 
@@ -274,7 +274,7 @@ POST   /api/admin/basho/:bashoId/import-results
 
 Admin endpoints can be protected later. For early local development, they can remain local-only but should be clearly marked as unsafe for production.
 
-The first import implementation should follow [Data Import Strategy](DATA_IMPORT_STRATEGY.md): validate source-agnostic JSON import files, write them transactionally, and keep live source adapters separate from core import parsing.
+The first import implementation should follow [Data Import Strategy](DATA_IMPORT_STRATEGY.md): fetch through source-specific adapters, validate source-agnostic import commands, write them transactionally, and keep import adapters separate from scoring.
 
 ## Testing priorities
 

--- a/docs/DATA_IMPORT_STRATEGY.md
+++ b/docs/DATA_IMPORT_STRATEGY.md
@@ -8,16 +8,27 @@ Last checked: 2026-05-30.
 
 ## Recommendation
 
-Use manual JSON/CSV import as the first MVP data path for banzuke and bout results.
+Use automated source-backed import as the MVP data path for banzuke and bout results.
 
-Do not make the MVP depend on live scraping or a third-party API. A small admin/import workflow backed by deterministic files is lower maintenance, easier to test, and enough to run a local or small-group Fantasy Sumo game during a basho.
+Manual entry was the pain point this app is intended to remove. Even if the available source endpoints are undocumented or third-party, maintaining source adapters is a better trade-off than asking an admin to hand-enter daily tournament data. A broken adapter should be fixed when source URLs or payloads change; those changes should be infrequent and easier to repair than manually running the game.
+
+Recommended MVP approach:
+
+- import banzuke from the Japan Sumo Association `indexAjax` endpoint first because it is official and currently machine-readable;
+- import daily results from Sumo API first because it provides documented torikumi/result-style endpoints;
+- keep an adapter boundary so JSA results, Sumo API, and future sources can produce the same internal import model;
+- support a manual trigger for an admin to run or rerun imports;
+- design the import service so it can later run from a scheduled job, e.g. once per day during a basho;
+- use manual JSON fixtures only as a fallback/debug/test path, not as the expected product workflow.
 
 Keep the import boundary source-agnostic:
 
-- parse and validate Fantasy Sumo import files first;
-- map validated imports into the existing `Basho`, `Rikishi`, `BanzukeEntry`, and `BoutResult` model;
-- keep source-specific adapters separate from the importer, so official or third-party sources can be added later without changing scoring;
-- support dry-run validation before writing to the database.
+- fetch source payloads in small source-specific adapters;
+- map source payloads into validated Fantasy Sumo import commands;
+- apply validated imports into the existing `Basho`, `Rikishi`, `BanzukeEntry`, and `BoutResult` model;
+- keep source-specific adapters separate from scoring and database writes;
+- support dry-run validation before writing to the database;
+- allow fallback between sources where practical.
 
 ## Source Investigation
 
@@ -52,7 +63,7 @@ Cons:
 - URL parameters are not self-describing;
 - result availability and backward compatibility are not guaranteed.
 
-Use this as a candidate adapter later, not as the MVP's only path.
+Use this as the first MVP banzuke adapter. Because it is not documented as a public API, isolate it behind an adapter and keep reduced fixtures that make payload changes easy to spot in tests.
 
 ### Japan Sumo Association results pages
 
@@ -82,7 +93,7 @@ Cons:
 - the official app result timing is useful for fans, but not a direct public data integration;
 - endpoint changes would break imports without warning.
 
-Do not build the first MVP around scraping official results pages.
+Do not build the first MVP around scraping official results pages unless Sumo API proves unsuitable. If a clean JSA results Ajax payload is confirmed later, add it as a higher-priority results adapter because it is official.
 
 ### Sumo API
 
@@ -110,7 +121,7 @@ Cons:
 - availability, schema, rate limits, and long-term maintenance are outside this repo's control;
 - should not be required for local tests or deterministic seed data.
 
-Use this as the first optional live adapter after manual import exists.
+Use this as the first MVP results adapter, and optionally as a backup banzuke adapter. It should map into the same internal import commands as the JSA banzuke adapter.
 
 ### SumoDB
 
@@ -147,11 +158,11 @@ Cons:
 
 Do not use a paid provider for MVP import work.
 
-## MVP Import Shape
+## Internal Import Shape
 
-Import files should be small, explicit, and easy to create by hand from a reliable source.
+Source adapters should emit small, explicit internal import commands. These commands can also be represented as JSON fixtures for tests, dry runs, and emergency debugging, but they are not the primary user workflow.
 
-Prefer JSON for the first implementation because it preserves types and nested data more clearly than CSV. CSV can be added once the JSON path is working, especially for result entry from spreadsheets.
+Prefer JSON for fixtures because it preserves types and nested data more clearly than CSV. CSV can be added later only if it is useful for debugging or emergency fallback.
 
 ### Banzuke import
 
@@ -260,17 +271,19 @@ For the first local MVP, a failed import can return a structured API error and l
 
 ## Proposed Implementation Path
 
-1. Add JSON import parser and validation functions for banzuke and results.
-2. Add repository/service functions that apply validated imports transactionally.
-3. Add local-only admin endpoints or scripts for importing JSON files.
-4. Add small sample import fixtures for tests.
-5. Add CSV support only if it makes manual operation easier after JSON works.
-6. Add optional source adapters later:
-   - JSA banzuke adapter using the currently working `indexAjax` endpoint;
-   - Sumo API adapter for banzuke and torikumi;
-   - no SumoDB scraper unless manual/API paths prove inadequate.
+1. Add internal import command types and validation functions for banzuke and results.
+2. Add a JSA banzuke source adapter using the currently working `indexAjax` endpoint.
+3. Add a Sumo API results source adapter using documented basho/torikumi endpoints.
+4. Add repository/service functions that apply validated imports transactionally.
+5. Add local-only admin endpoints or scripts to manually trigger source imports and dry runs.
+6. Add small reduced source fixtures for adapter tests and internal JSON fixtures for import-service tests.
+7. Add fallback source support:
+   - Sumo API banzuke as backup if JSA banzuke fails;
+   - JSA results adapter if a stable machine-readable result endpoint is confirmed;
+   - no SumoDB scraper unless API paths prove inadequate.
+8. Add scheduled execution later, e.g. once per day during active basho, after the triggerable import path is stable.
 
 ## Follow-Up Tickets
 
-- GitHub issue #25: implement manual JSON import for banzuke and results.
-- GitHub issue #26: investigate optional live source adapters after manual import exists.
+- GitHub issue #25: implement automated source-backed import for banzuke and results.
+- GitHub issue #26: add redundant/fallback source adapters after the first automated import path exists.

--- a/docs/DATA_IMPORT_STRATEGY.md
+++ b/docs/DATA_IMPORT_STRATEGY.md
@@ -1,0 +1,276 @@
+# Data Import Strategy
+
+## Status
+
+Accepted for the MVP import path.
+
+Last checked: 2026-05-30.
+
+## Recommendation
+
+Use manual JSON/CSV import as the first MVP data path for banzuke and bout results.
+
+Do not make the MVP depend on live scraping or a third-party API. A small admin/import workflow backed by deterministic files is lower maintenance, easier to test, and enough to run a local or small-group Fantasy Sumo game during a basho.
+
+Keep the import boundary source-agnostic:
+
+- parse and validate Fantasy Sumo import files first;
+- map validated imports into the existing `Basho`, `Rikishi`, `BanzukeEntry`, and `BoutResult` model;
+- keep source-specific adapters separate from the importer, so official or third-party sources can be added later without changing scoring;
+- support dry-run validation before writing to the database.
+
+## Source Investigation
+
+### Japan Sumo Association banzuke endpoint
+
+Legacy code referenced:
+
+```text
+http://sumo.or.jp/EnHonbashoBanzuke/index_ajax/1/1/
+```
+
+That exact lowercase `index_ajax` URL is not suitable to reuse. On 2026-05-30 it redirected to `/Mischief/`.
+
+The current mixed-case endpoint works:
+
+```text
+https://www.sumo.or.jp/EnHonbashoBanzuke/indexAjax/1/1/
+```
+
+It returns JSON containing a `BanzukeTable`, `BashoInfo`, `basho_name`, `basho_id`, division metadata, and rows with fields such as `rikishi_id`, `shikona`, `banzuke_name`, `banzuke_id`, `rank`, `ew`, `heya_name`, and `pref_name`.
+
+Pros:
+
+- official source;
+- currently returns machine-readable banzuke JSON;
+- contains stable-looking identifiers and enough fields for Fantasy Sumo's banzuke model.
+
+Cons:
+
+- not documented as a public API;
+- endpoint casing changed from the old prototype reference;
+- URL parameters are not self-describing;
+- result availability and backward compatibility are not guaranteed.
+
+Use this as a candidate adapter later, not as the MVP's only path.
+
+### Japan Sumo Association results pages
+
+The official site exposes results pages such as:
+
+```text
+https://www.sumo.or.jp/EnHonbashoMain/torikumi/1/15/
+```
+
+and Ajax-shaped URLs such as:
+
+```text
+https://www.sumo.or.jp/EnHonbashoMain/torikumiAjax/1/15/
+```
+
+On 2026-05-30, the visible English results page loaded but did not provide a clean reusable JSON result payload in the same way as the banzuke endpoint. The Ajax endpoint shape may still be useful to investigate later, but should be treated as website internals rather than an import contract.
+
+Pros:
+
+- official source;
+- the public site and official app publish current basho results.
+
+Cons:
+
+- no documented public API contract found;
+- scraping HTML would be brittle;
+- the official app result timing is useful for fans, but not a direct public data integration;
+- endpoint changes would break imports without warning.
+
+Do not build the first MVP around scraping official results pages.
+
+### Sumo API
+
+[sumo-api.com](https://sumo-api.com/) is a third-party sumo data API. Its API guide documents endpoints for rikishi, basho, banzuke, torikumi, kimarite, ranks, and shikona, including:
+
+```text
+GET /api/basho/:bashoId
+GET /api/basho/:bashoId/banzuke/:division
+GET /api/basho/:bashoId/torikumi/:division/:day
+```
+
+The site describes itself as free to access, asks users to use it responsibly, and notes that it costs money to run and maintain.
+
+Pros:
+
+- directly matches the data Fantasy Sumo needs;
+- documented endpoints for banzuke and daily torikumi;
+- likely much easier than scraping;
+- used by other fantasy sumo and sumo-stat projects.
+
+Cons:
+
+- third-party hobby/service dependency;
+- not official;
+- availability, schema, rate limits, and long-term maintenance are outside this repo's control;
+- should not be required for local tests or deterministic seed data.
+
+Use this as the first optional live adapter after manual import exists.
+
+### SumoDB
+
+[Sumo Reference / SumoDB](https://sumodb.sumogames.de/) is a long-running historical sumo database with banzuke, torikumi, kimarite, rikishi, and query pages.
+
+Pros:
+
+- broad historical coverage;
+- useful for checking historical banzuke and bout data;
+- public pages are easy for humans to inspect.
+
+Cons:
+
+- primarily an HTML website, not a documented JSON API;
+- scraping would add parser maintenance;
+- page shape is optimised for human browsing and historical research, not daily MVP operation.
+
+Use SumoDB as a manual verification/reference source, not as the first automated importer.
+
+### Paid sports data APIs
+
+Commercial sports-data providers advertise sumo coverage, but they are not appropriate for the first MVP.
+
+Pros:
+
+- potentially stronger uptime and support contracts;
+- may provide structured pre-match and post-match data.
+
+Cons:
+
+- likely paid and overbuilt for a hobby MVP;
+- introduces vendor setup before the local game loop needs it;
+- conflicts with the project's low-maintenance local-first direction.
+
+Do not use a paid provider for MVP import work.
+
+## MVP Import Shape
+
+Import files should be small, explicit, and easy to create by hand from a reliable source.
+
+Prefer JSON for the first implementation because it preserves types and nested data more clearly than CSV. CSV can be added once the JSON path is working, especially for result entry from spreadsheets.
+
+### Banzuke import
+
+Minimum required fields:
+
+```json
+{
+  "basho": {
+    "id": "2026-05",
+    "name": "2026 May Basho",
+    "startDate": "2026-05-10",
+    "endDate": "2026-05-24",
+    "status": "active"
+  },
+  "rikishi": [
+    {
+      "id": "onosato",
+      "shikona": "Onosato",
+      "heya": "Nishonoseki"
+    }
+  ],
+  "banzuke": [
+    {
+      "bashoId": "2026-05",
+      "rikishiId": "onosato",
+      "rank": "Yokozuna",
+      "rankOrder": 2
+    }
+  ]
+}
+```
+
+Recommended optional fields for future adapters:
+
+- `source`;
+- `sourceBashoId`;
+- `sourceRikishiId`;
+- `division`;
+- `side`: `east` or `west`;
+- `rankGroup`;
+- `rankNumber`;
+- `countryOrPrefecture`.
+
+Validation rules:
+
+- `basho.id` must match the import target;
+- each banzuke row must reference an imported or existing rikishi;
+- `rankOrder` must be unique within the imported basho;
+- duplicate `(bashoId, rikishiId)` rows must be rejected;
+- unknown extra fields should be ignored or captured as source metadata, not written into core domain objects.
+
+### Bout result import
+
+Minimum required fields:
+
+```json
+{
+  "bashoId": "2026-05",
+  "results": [
+    {
+      "id": "2026-05-01-onosato-kotozakura",
+      "day": 1,
+      "winnerRikishiId": "onosato",
+      "loserRikishiId": "kotozakura",
+      "kimarite": "oshidashi",
+      "winnerAbsent": false,
+      "loserAbsent": false
+    }
+  ]
+}
+```
+
+Recommended optional fields:
+
+- `division`;
+- `boutOrder`;
+- `eastRikishiId`;
+- `westRikishiId`;
+- `source`;
+- `sourceBoutId`;
+- `fusen`: explicit flag for default/forfeit wins;
+- `playoff`: explicit flag for playoff bouts.
+
+Validation rules:
+
+- `day` must be 1-15 for a standard basho;
+- winner and loser must be different rikishi;
+- winner and loser should exist in the local rikishi table;
+- winner and loser should normally be on the target basho's banzuke unless the import explicitly allows cross-division bouts;
+- importing the same result twice should be idempotent or fail with a clear duplicate-result error;
+- absent/default wins should preserve enough data for scoring to keep absences at 0 points unless rules change later.
+
+## Failure Handling
+
+Import should be explicit and reversible enough for local operation:
+
+- validate the whole file before writing any rows;
+- report line/item-level errors with the source row id or array index;
+- support dry-run mode that returns created/updated/skipped counts;
+- write imports in a transaction;
+- fail without partial writes when required data is invalid;
+- make duplicate handling deliberate: either reject duplicates or upsert by stable ids, but do not silently create conflicting rows;
+- log source name, imported file name, and timestamp once an import log table exists.
+
+For the first local MVP, a failed import can return a structured API error and leave the database unchanged. A full audit/revert UI can wait.
+
+## Proposed Implementation Path
+
+1. Add JSON import parser and validation functions for banzuke and results.
+2. Add repository/service functions that apply validated imports transactionally.
+3. Add local-only admin endpoints or scripts for importing JSON files.
+4. Add small sample import fixtures for tests.
+5. Add CSV support only if it makes manual operation easier after JSON works.
+6. Add optional source adapters later:
+   - JSA banzuke adapter using the currently working `indexAjax` endpoint;
+   - Sumo API adapter for banzuke and torikumi;
+   - no SumoDB scraper unless manual/API paths prove inadequate.
+
+## Follow-Up Tickets
+
+- GitHub issue #25: implement manual JSON import for banzuke and results.
+- GitHub issue #26: investigate optional live source adapters after manual import exists.

--- a/docs/MODERNISATION_PLAN.md
+++ b/docs/MODERNISATION_PLAN.md
@@ -122,17 +122,17 @@ The old app imported banzuke data from sumo.or.jp. Before relying on live source
 
 - Verify the endpoint still exists.
 - Check whether results data is available in a stable machine-readable format.
-- Consider a manual CSV/JSON import path as a fallback.
+- Keep a manual JSON path only as a fallback/debug fixture path.
 - Keep data import adapters isolated so the data source can change.
 
-Current recommendation: build manual JSON/CSV import first, then add optional JSA or Sumo API adapters once the local import path is tested.
+Current recommendation: build automated source-backed import first, using the JSA banzuke endpoint and Sumo API results endpoints as the initial likely sources. Add manual triggers, dry runs, and fallback source support so the game can be operated without hand-entering daily results.
 
 ## Recommended first engineering tickets
 
 1. Add a pure scoring module with tests.
 2. Add a minimal domain model for basho, rikishi, teams, picks, and results.
 3. Create a first team selection screen using seeded data.
-4. Add a result import or manual result entry path.
+4. Add an automated result import path.
 
 ## Avoid initially
 

--- a/docs/MODERNISATION_PLAN.md
+++ b/docs/MODERNISATION_PLAN.md
@@ -116,12 +116,16 @@ Before any deployment:
 
 ## Data-source investigation
 
-The app currently imports banzuke data from sumo.or.jp. Before relying on this:
+The accepted MVP data-source recommendation is documented in [Data Import Strategy](DATA_IMPORT_STRATEGY.md).
+
+The old app imported banzuke data from sumo.or.jp. Before relying on live sources:
 
 - Verify the endpoint still exists.
 - Check whether results data is available in a stable machine-readable format.
 - Consider a manual CSV/JSON import path as a fallback.
 - Keep data import adapters isolated so the data source can change.
+
+Current recommendation: build manual JSON/CSV import first, then add optional JSA or Sumo API adapters once the local import path is tested.
 
 ## Recommended first engineering tickets
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -39,7 +39,7 @@ Goal: make the core game loop work locally.
 - [x] Model fantasy teams and picks.
 - [x] Expose basho, rikishi, team, and leaderboard API routes.
 - [x] Add team selection flow.
-- [ ] Add result import or manual result entry.
+- [ ] Add manual JSON/CSV import for banzuke and results.
 - [x] Add leaderboard calculation.
 - [x] Add leaderboard UI.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -39,7 +39,7 @@ Goal: make the core game loop work locally.
 - [x] Model fantasy teams and picks.
 - [x] Expose basho, rikishi, team, and leaderboard API routes.
 - [x] Add team selection flow.
-- [ ] Add manual JSON/CSV import for banzuke and results.
+- [ ] Add automated source-backed import for banzuke and results.
 - [x] Add leaderboard calculation.
 - [x] Add leaderboard UI.
 


### PR DESCRIPTION
## Summary

- Adds docs/DATA_IMPORT_STRATEGY.md with the data-source investigation and MVP import recommendation.
- Recommends automated source-backed import first: JSA banzuke as the initial official banzuke adapter, Sumo API as the initial results adapter, and redundant fallback adapters later.
- Keeps manual JSON fixtures only for tests, dry runs, debugging, and emergency fallback; manual entry is not the product workflow.
- Documents internal banzuke and bout-result import command shapes, validation rules, failure handling, and implementation order.
- Links the strategy from README, AGENTS.md, architecture notes, modernisation plan, and roadmap.
- Updated follow-up issues #25 and #26 to match the automated import direction.

## Source checks

- Checked the old JSA banzuke URL from legacy notes; the lowercase index_ajax path redirects to /Mischief/.
- Confirmed the current JSA indexAjax banzuke endpoint returns machine-readable JSON.
- Reviewed official JSA results pages/Ajax-shaped URLs and did not find a clean documented results API contract.
- Reviewed Sumo API documentation and SumoDB as candidate third-party/reference sources.

## Trade-offs

- Automated import depends on less-than-perfect external sources, but that better matches the product goal than making admins hand-enter daily tournament data.
- Source adapters should be isolated so URL/payload changes are repairable without touching scoring or persistence rules.
- Manual JSON remains useful for deterministic tests and emergency debugging, not as the expected operating path.

## Validation

- make check

Closes #11.