### PR TITLE
Implement automated banzuke and results imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ ifneq ($(PNPM_DIR),)
 export PATH := $(PNPM_DIR):$(PATH)
 endif
 
-.PHONY: help install dev dev-client dev-server build test lint format format-check check db-migrate db-seed clean
+.PHONY: help install dev dev-client dev-server build test lint format format-check check db-migrate db-seed import-banzuke import-results clean
 
 help: ## Show available make targets.
 	@awk 'BEGIN {FS = ":.*## "; printf "Fantasy Sumo development commands:\n\n"} /^[a-zA-Z0-9_-]+:.*## / {printf "  %-14s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -50,6 +50,12 @@ db-migrate: ## Apply local database migrations.
 
 db-seed: ## Seed the local database.
 	$(PNPM) db:seed
+
+import-banzuke: ## Import current banzuke data from source.
+	$(PNPM) import:banzuke $(ARGS)
+
+import-results: ## Import daily results from source. Pass ARGS="-- --basho 2026-05 --day 1".
+	$(PNPM) import:results $(ARGS)
 
 clean: ## Remove generated build artifacts.
 	rm -rf apps/api/dist apps/web/dist packages/db/dist packages/domain/dist

--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ At present, the app has the first local playable foundations:
 - A Fastify API with health, basho, rikishi, team, and leaderboard endpoints.
 - A shared TypeScript domain package with MVP types, validation, scoring, and leaderboard logic.
 - A local SQLite + Drizzle database package with schema, migration, repositories, and sample seed data.
+- Automated source-backed import commands and local admin endpoints for current banzuke and daily results.
 - Vitest, ESLint, and Prettier wired through pnpm scripts.
 
-It is close to a local playable loop, but still needs a result entry/import path before it is useful during a real basho.
+It is close to a local playable loop, but still needs pick locking and a friendlier admin UI before it is useful during a real basho.
 
 ## Tech Stack
 
@@ -79,6 +80,10 @@ Useful API endpoints:
 - `POST /api/basho/:bashoId/teams`
 - `GET /api/basho/:bashoId/teams/:teamId`
 - `GET /api/basho/:bashoId/leaderboard`
+- `POST /api/admin/import-banzuke`
+- `POST /api/admin/basho/:bashoId/import-results`
+
+The admin import endpoints are local development tools for now. Do not expose them publicly without authentication/protection.
 
 Useful checks:
 
@@ -94,6 +99,39 @@ DATABASE_URL=file:./data/dev.sqlite pnpm db:seed
 
 The local team size defaults to `2`. Override it for the API with `TEAM_SIZE`.
 
+## Data import
+
+Import current banzuke data from the Japan Sumo Association source:
+
+```bash
+make import-banzuke
+```
+
+Import daily Makuuchi results from Sumo API:
+
+```bash
+make import-results ARGS="-- --basho 2026-05 --day 1"
+```
+
+Both import paths support dry runs:
+
+```bash
+make import-banzuke ARGS="-- --dry-run"
+make import-results ARGS="-- --basho 2026-05 --day 1 --dry-run"
+```
+
+The API exposes equivalent local admin triggers:
+
+```bash
+curl -X POST "http://localhost:3000/api/admin/import-banzuke?dryRun=true" \
+  -H "content-type: application/json" \
+  -d '{}'
+
+curl -X POST "http://localhost:3000/api/admin/basho/2026-05/import-results?dryRun=true" \
+  -H "content-type: application/json" \
+  -d '{"day":1,"division":"Makuuchi"}'
+```
+
 ## Makefile commands
 
 Use `make help` to list the stable development commands. The Makefile is a thin wrapper over the existing pnpm scripts.
@@ -108,6 +146,8 @@ Common targets:
 - `make lint` - run ESLint.
 - `make build` - build all packages/apps.
 - `make check` - run lint, format check, tests, and build before a PR.
+- `make import-banzuke` - import current banzuke data from source.
+- `make import-results` - import one day of results from source.
 
 ## Security note
 
@@ -115,6 +155,6 @@ The local database uses a file path only and does not require credentials. Keep 
 
 ## Recommended next steps
 
-1. Add result entry/import so standings can be updated during a basho.
-2. Persist or retrieve the latest submitted team for follow-up views.
-3. Decide pick locking and whether the configured team size should move into database-backed basho settings.
+1. Persist or retrieve the latest submitted team for follow-up views.
+2. Decide pick locking and whether the configured team size should move into database-backed basho settings.
+3. Add a protected admin UI or scheduled job around the import service.

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ make import-banzuke ARGS="-- --dry-run"
 make import-results ARGS="-- --basho 2026-05 --day 1 --dry-run"
 ```
 
+Banzuke reimports replace the stored banzuke entries for that basho without deleting rikishi, teams, or picks. Result reimports replace only the imported basho/day, so rerunning day 1 cannot delete day 2 results.
+
 The API exposes equivalent local admin triggers:
 
 ```bash

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "dev": "pnpm --filter @fantasy-sumo/db build && tsx watch src/server.ts",
     "build": "pnpm --filter @fantasy-sumo/db build && tsc -p tsconfig.json",
+    "import:banzuke": "pnpm --filter @fantasy-sumo/db build && tsx src/scripts/import-banzuke.ts",
+    "import:results": "pnpm --filter @fantasy-sumo/db build && tsx src/scripts/import-results.ts",
     "start": "node dist/server.js",
     "test": "pnpm --filter @fantasy-sumo/db build && vitest run src"
   },

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -6,11 +6,13 @@ import {
   type SqliteDatabase,
 } from "@fantasy-sumo/db";
 import { getTeamSize } from "./config.js";
+import { registerAdminImportRoutes } from "./routes/admin-imports.js";
 import { registerBashoRoutes } from "./routes/basho.js";
 
 interface AppOptions {
   db?: SqliteDatabase;
   now?: () => Date;
+  sourceFetch?: typeof fetch;
   teamIdFactory?: () => string;
   teamSize?: number;
 }
@@ -41,6 +43,10 @@ export function buildApp(options: AppOptions = {}) {
     now: options.now ?? (() => new Date()),
     teamIdFactory: options.teamIdFactory ?? randomUUID,
     teamSize: options.teamSize ?? getTeamSize(),
+  });
+  registerAdminImportRoutes(app, {
+    repositories,
+    sourceFetch: options.sourceFetch ?? fetch,
   });
 
   return app;

--- a/apps/api/src/imports/adapters.test.ts
+++ b/apps/api/src/imports/adapters.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import { mapJsaBanzukePayload, mapSumoApiTorikumiPayload } from "./adapters.js";
+
+describe("source import adapters", () => {
+  it("maps JSA banzuke payloads into local import commands", () => {
+    const command = mapJsaBanzukePayload({
+      basho_name: "May Grand Sumo Tournament",
+      BashoInfo: {
+        start_date: "2026-05-10",
+        end_date: "2026-05-24",
+        today: "2026-05-12",
+        BattleNow: 1,
+        year_eng: "2026",
+      },
+      BanzukeTable: [
+        {
+          banzuke_id: 1,
+          banzuke_name: "Yokozuna",
+          rikishi_id: 3842,
+          shikona: "Hoshoryu",
+          heya_name: "Tatsunami",
+        },
+        {
+          banzuke_id: 2,
+          banzuke_name: "Ozeki",
+          rikishi_id: 4227,
+          shikona: "Onosato",
+          heya_name: "Nishonoseki",
+        },
+        {
+          banzuke_id: 0,
+          banzuke_name: "",
+          rikishi_id: "",
+          shikona: "",
+          heya_name: "",
+        },
+      ],
+    });
+
+    expect(command).toMatchObject({
+      source: "jsa-banzuke",
+      basho: {
+        id: "2026-05",
+        name: "2026 May Grand Sumo Tournament",
+        status: "active",
+      },
+      rikishi: [
+        {
+          id: "hoshoryu",
+          shikona: "Hoshoryu",
+          heya: "Tatsunami",
+        },
+        {
+          id: "onosato",
+          shikona: "Onosato",
+          heya: "Nishonoseki",
+        },
+      ],
+      banzukeEntries: [
+        {
+          id: "2026-05-hoshoryu",
+          rikishiId: "hoshoryu",
+          rank: "Yokozuna",
+          rankOrder: 1,
+        },
+        {
+          id: "2026-05-onosato",
+          rikishiId: "onosato",
+          rank: "Ozeki",
+          rankOrder: 2,
+        },
+      ],
+    });
+  });
+
+  it("maps Sumo API torikumi payloads into local result commands", () => {
+    const command = mapSumoApiTorikumiPayload(
+      {
+        torikumi: [
+          {
+            id: "202605-1-1-4227-3661",
+            bashoId: "202605",
+            day: 1,
+            matchNo: 1,
+            eastId: 4227,
+            eastShikona: "Onosato",
+            westId: 3661,
+            westShikona: "Kotozakura",
+            kimarite: "oshidashi",
+            winnerId: 4227,
+            winnerEn: "Onosato",
+          },
+        ],
+      },
+      {
+        bashoId: "2026-05",
+        day: 1,
+      },
+    );
+
+    expect(command).toEqual({
+      source: "sumo-api-results",
+      bashoId: "2026-05",
+      results: [
+        {
+          id: "2026-05-day-1-match-1",
+          bashoId: "2026-05",
+          day: 1,
+          winnerRikishiId: "onosato",
+          loserRikishiId: "kotozakura",
+          kimarite: "oshidashi",
+        },
+      ],
+    });
+  });
+});

--- a/apps/api/src/imports/adapters.test.ts
+++ b/apps/api/src/imports/adapters.test.ts
@@ -113,4 +113,31 @@ describe("source import adapters", () => {
       ],
     });
   });
+
+  it("uses winnerEn when numeric winner ids are missing", () => {
+    const command = mapSumoApiTorikumiPayload(
+      {
+        torikumi: [
+          {
+            bashoId: "202605",
+            day: 1,
+            matchNo: 1,
+            eastShikona: "Onosato",
+            westShikona: "Kotozakura",
+            kimarite: "oshidashi",
+            winnerEn: "Kotozakura",
+          },
+        ],
+      },
+      {
+        bashoId: "2026-05",
+        day: 1,
+      },
+    );
+
+    expect(command.results[0]).toMatchObject({
+      winnerRikishiId: "kotozakura",
+      loserRikishiId: "onosato",
+    });
+  });
 });

--- a/apps/api/src/imports/adapters.ts
+++ b/apps/api/src/imports/adapters.ts
@@ -1,0 +1,244 @@
+import type {
+  BanzukeImportCommand,
+  JsaBanzukeImportOptions,
+  SourceFetch,
+  SumoApiResultsImportOptions,
+  BoutResultsImportCommand,
+} from "./types.js";
+import { toCompactBashoId, toLocalBashoId, toLocalRikishiId } from "./ids.js";
+
+const JSA_BANZUKE_BASE_URL =
+  "https://www.sumo.or.jp/EnHonbashoBanzuke/indexAjax";
+const SUMO_API_BASE_URL = "https://sumo-api.com/api";
+
+interface JsaBanzukePayload {
+  BanzukeTable?: JsaBanzukeRow[];
+  basho_name?: string;
+  BashoInfo?: {
+    start_date?: string;
+    end_date?: string;
+    today?: string;
+    BattleNow?: number;
+    basho_name_eng?: string;
+    year_eng?: string;
+  };
+}
+
+interface JsaBanzukeRow {
+  banzuke_id?: number | string;
+  banzuke_name?: string;
+  rikishi_id?: number | string;
+  shikona?: string;
+  heya_name?: string;
+}
+
+interface SumoApiTorikumiPayload {
+  torikumi?: SumoApiTorikumiRow[];
+}
+
+interface SumoApiTorikumiRow {
+  id?: string;
+  bashoId?: string;
+  day?: number;
+  matchNo?: number;
+  eastId?: number;
+  eastShikona?: string;
+  westId?: number;
+  westShikona?: string;
+  kimarite?: string;
+  winnerId?: number;
+  winnerEn?: string;
+}
+
+export async function fetchJsaBanzukeImport(
+  fetchFn: SourceFetch,
+  options: JsaBanzukeImportOptions = {},
+): Promise<BanzukeImportCommand> {
+  const divisionId = options.divisionId ?? 1;
+  const page = options.page ?? 1;
+  const payload = await fetchJson<JsaBanzukePayload>(
+    fetchFn,
+    `${JSA_BANZUKE_BASE_URL}/${divisionId}/${page}/`,
+  );
+
+  return mapJsaBanzukePayload(payload);
+}
+
+export function mapJsaBanzukePayload(
+  payload: JsaBanzukePayload,
+): BanzukeImportCommand {
+  const startDate = payload.BashoInfo?.start_date;
+  const endDate = payload.BashoInfo?.end_date;
+
+  if (startDate === undefined || endDate === undefined) {
+    throw new Error("JSA banzuke payload is missing basho dates.");
+  }
+
+  const bashoId = startDate.slice(0, 7);
+  const rows = (payload.BanzukeTable ?? []).filter(isUsableJsaBanzukeRow);
+
+  return {
+    source: "jsa-banzuke",
+    basho: {
+      id: bashoId,
+      name: formatJsaBashoName(payload),
+      startDate,
+      endDate,
+      status: resolveBashoStatus(payload),
+    },
+    rikishi: rows.map((row) => ({
+      id: toLocalRikishiId(String(row.shikona)),
+      shikona: String(row.shikona),
+      ...(row.heya_name === undefined || row.heya_name === ""
+        ? {}
+        : { heya: String(row.heya_name) }),
+    })),
+    banzukeEntries: rows.map((row, index) => {
+      const rikishiId = toLocalRikishiId(String(row.shikona));
+      const rankOrder = Number(row.banzuke_id) || index + 1;
+
+      return {
+        id: `${bashoId}-${rikishiId}`,
+        bashoId,
+        rikishiId,
+        rank: String(row.banzuke_name),
+        rankOrder,
+      };
+    }),
+  };
+}
+
+export async function fetchSumoApiResultsImport(
+  fetchFn: SourceFetch,
+  options: SumoApiResultsImportOptions,
+): Promise<BoutResultsImportCommand> {
+  const division = options.division ?? "Makuuchi";
+  const sourceBashoId = toCompactBashoId(options.bashoId);
+  const payload = await fetchJson<SumoApiTorikumiPayload>(
+    fetchFn,
+    `${SUMO_API_BASE_URL}/basho/${sourceBashoId}/torikumi/${division}/${options.day}`,
+  );
+
+  return mapSumoApiTorikumiPayload(payload, {
+    bashoId: options.bashoId,
+    day: options.day,
+  });
+}
+
+export function mapSumoApiTorikumiPayload(
+  payload: SumoApiTorikumiPayload,
+  options: { bashoId: string; day: number },
+): BoutResultsImportCommand {
+  return {
+    source: "sumo-api-results",
+    bashoId: options.bashoId,
+    results: (payload.torikumi ?? []).map((row, index) => {
+      const matchNo = row.matchNo ?? index + 1;
+      const eastId = row.eastId;
+      const westId = row.westId;
+      const eastShikona = requiredString(row.eastShikona, "eastShikona");
+      const westShikona = requiredString(row.westShikona, "westShikona");
+      const winnerShikona = resolveWinnerShikona(row, {
+        eastId,
+        eastShikona,
+        westId,
+        westShikona,
+      });
+      const loserShikona =
+        winnerShikona === eastShikona ? westShikona : eastShikona;
+
+      return {
+        id: `${options.bashoId}-day-${options.day}-match-${matchNo}`,
+        bashoId: toLocalBashoId(row.bashoId ?? options.bashoId),
+        day: row.day ?? options.day,
+        winnerRikishiId: toLocalRikishiId(winnerShikona),
+        loserRikishiId: toLocalRikishiId(loserShikona),
+        ...(row.kimarite === undefined || row.kimarite === ""
+          ? {}
+          : { kimarite: row.kimarite }),
+      };
+    }),
+  };
+}
+
+async function fetchJson<T>(fetchFn: SourceFetch, url: string): Promise<T> {
+  const response = await fetchFn(url);
+
+  if (!response.ok) {
+    throw new Error(`Import source request failed with ${response.status}.`);
+  }
+
+  return (await response.json()) as T;
+}
+
+function isUsableJsaBanzukeRow(row: JsaBanzukeRow) {
+  return (
+    row.rikishi_id !== undefined &&
+    row.rikishi_id !== "" &&
+    row.shikona !== undefined &&
+    row.shikona !== "" &&
+    row.banzuke_name !== undefined &&
+    row.banzuke_name !== ""
+  );
+}
+
+function formatJsaBashoName(payload: JsaBanzukePayload) {
+  const year = payload.BashoInfo?.year_eng;
+  const name = payload.basho_name ?? payload.BashoInfo?.basho_name_eng;
+
+  return [year, name].filter(Boolean).join(" ");
+}
+
+function resolveBashoStatus(payload: JsaBanzukePayload) {
+  if (payload.BashoInfo?.BattleNow === 1) {
+    return "active";
+  }
+
+  const today = payload.BashoInfo?.today;
+  const endDate = payload.BashoInfo?.end_date;
+
+  if (today !== undefined && endDate !== undefined && today > endDate) {
+    return "complete";
+  }
+
+  return "upcoming";
+}
+
+function requiredString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`Sumo API torikumi row is missing ${field}.`);
+  }
+
+  return value;
+}
+
+function resolveWinnerShikona(
+  row: SumoApiTorikumiRow,
+  wrestlers: {
+    eastId?: number;
+    eastShikona: string;
+    westId?: number;
+    westShikona: string;
+  },
+): string {
+  if (row.winnerId === wrestlers.eastId) {
+    return wrestlers.eastShikona;
+  }
+
+  if (row.winnerId === wrestlers.westId) {
+    return wrestlers.westShikona;
+  }
+
+  const winnerEn = requiredString(row.winnerEn, "winnerEn");
+
+  if (
+    winnerEn === wrestlers.eastShikona ||
+    winnerEn === wrestlers.westShikona
+  ) {
+    return winnerEn;
+  }
+
+  throw new Error(
+    "Sumo API torikumi row winner does not match either rikishi.",
+  );
+}

--- a/apps/api/src/imports/adapters.ts
+++ b/apps/api/src/imports/adapters.ts
@@ -221,12 +221,14 @@ function resolveWinnerShikona(
     westShikona: string;
   },
 ): string {
-  if (row.winnerId === wrestlers.eastId) {
-    return wrestlers.eastShikona;
-  }
+  if (row.winnerId !== undefined) {
+    if (row.winnerId === wrestlers.eastId) {
+      return wrestlers.eastShikona;
+    }
 
-  if (row.winnerId === wrestlers.westId) {
-    return wrestlers.westShikona;
+    if (row.winnerId === wrestlers.westId) {
+      return wrestlers.westShikona;
+    }
   }
 
   const winnerEn = requiredString(row.winnerEn, "winnerEn");

--- a/apps/api/src/imports/ids.ts
+++ b/apps/api/src/imports/ids.ts
@@ -1,0 +1,21 @@
+export function toLocalBashoId(sourceBashoId: string): string {
+  const compactMatch = /^(\d{4})(\d{2})$/.exec(sourceBashoId);
+
+  if (compactMatch !== null) {
+    return `${compactMatch[1]}-${compactMatch[2]}`;
+  }
+
+  return sourceBashoId;
+}
+
+export function toCompactBashoId(localBashoId: string): string {
+  return localBashoId.replace("-", "");
+}
+
+export function toLocalRikishiId(shikona: string): string {
+  return shikona
+    .normalize("NFKD")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}

--- a/apps/api/src/imports/service.test.ts
+++ b/apps/api/src/imports/service.test.ts
@@ -96,6 +96,23 @@ describe("import service", () => {
     });
   });
 
+  it("removes stale banzuke entries without deleting rikishi", () => {
+    const repositories = createRepositories(client.db);
+    importBanzuke(repositories, banzukeCommand);
+
+    const result = importBanzuke(repositories, {
+      ...banzukeCommand,
+      rikishi: [banzukeCommand.rikishi[0]!],
+      banzukeEntries: [banzukeCommand.banzukeEntries[0]!],
+    });
+
+    expect(result.summary.banzuke.deleted).toBe(1);
+    expect(repositories.listRikishi()).toHaveLength(2);
+    expect(repositories.listBanzukeEntriesForBasho("2026-05")).toEqual([
+      banzukeCommand.banzukeEntries[0],
+    ]);
+  });
+
   it("imports bout results after banzuke data exists", () => {
     const repositories = createRepositories(client.db);
     importBanzuke(repositories, banzukeCommand);
@@ -117,6 +134,66 @@ describe("import service", () => {
 
     expect(result.summary.results.created).toBe(1);
     expect(repositories.listBoutResultsForBasho("2026-05")).toHaveLength(1);
+  });
+
+  it("replaces stale results for the imported day only", () => {
+    const repositories = createRepositories(client.db);
+    importBanzuke(repositories, banzukeCommand);
+    importBoutResults(repositories, {
+      source: "test",
+      bashoId: "2026-05",
+      results: [
+        {
+          id: "2026-05-day-1-match-1",
+          bashoId: "2026-05",
+          day: 1,
+          winnerRikishiId: "onosato",
+          loserRikishiId: "kotozakura",
+        },
+        {
+          id: "2026-05-day-1-match-2",
+          bashoId: "2026-05",
+          day: 1,
+          winnerRikishiId: "kotozakura",
+          loserRikishiId: "onosato",
+        },
+      ],
+    });
+    importBoutResults(repositories, {
+      source: "test",
+      bashoId: "2026-05",
+      results: [
+        {
+          id: "2026-05-day-2-match-1",
+          bashoId: "2026-05",
+          day: 2,
+          winnerRikishiId: "onosato",
+          loserRikishiId: "kotozakura",
+        },
+      ],
+    });
+
+    const result = importBoutResults(repositories, {
+      source: "test",
+      bashoId: "2026-05",
+      results: [
+        {
+          id: "2026-05-day-1-match-1",
+          bashoId: "2026-05",
+          day: 1,
+          winnerRikishiId: "onosato",
+          loserRikishiId: "kotozakura",
+        },
+      ],
+    });
+
+    expect(result.summary.results.deleted).toBe(1);
+    expect(
+      repositories
+        .listBoutResultsForBasho("2026-05")
+        .map((entry) => entry.id)
+        .sort(),
+    ).toEqual(["2026-05-day-1-match-1", "2026-05-day-2-match-1"]);
   });
 
   it("rejects invalid result imports before writing", () => {

--- a/apps/api/src/imports/service.test.ts
+++ b/apps/api/src/imports/service.test.ts
@@ -1,0 +1,143 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createDatabaseClient,
+  createRepositories,
+  runMigrations,
+  type DatabaseClient,
+} from "@fantasy-sumo/db";
+import type { BanzukeImportCommand } from "./types.js";
+import {
+  importBanzuke,
+  importBoutResults,
+  ImportValidationError,
+} from "./service.js";
+
+let client: DatabaseClient;
+let tmpRoot: string;
+
+const banzukeCommand: BanzukeImportCommand = {
+  source: "test",
+  basho: {
+    id: "2026-05",
+    name: "May 2026",
+    startDate: "2026-05-10",
+    endDate: "2026-05-24",
+    status: "active",
+  },
+  rikishi: [
+    {
+      id: "onosato",
+      shikona: "Onosato",
+      heya: "Nishonoseki",
+    },
+    {
+      id: "kotozakura",
+      shikona: "Kotozakura",
+      heya: "Sadogatake",
+    },
+  ],
+  banzukeEntries: [
+    {
+      id: "2026-05-onosato",
+      bashoId: "2026-05",
+      rikishiId: "onosato",
+      rank: "Ozeki",
+      rankOrder: 1,
+    },
+    {
+      id: "2026-05-kotozakura",
+      bashoId: "2026-05",
+      rikishiId: "kotozakura",
+      rank: "Ozeki",
+      rankOrder: 2,
+    },
+  ],
+};
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), "fantasy-sumo-import-"));
+  client = createDatabaseClient(`file:${join(tmpRoot, "test.sqlite")}`);
+  runMigrations(client.db);
+});
+
+afterEach(() => {
+  client.close();
+  rmSync(tmpRoot, { force: true, recursive: true });
+});
+
+describe("import service", () => {
+  it("dry-runs banzuke imports without writing rows", () => {
+    const repositories = createRepositories(client.db);
+    const result = importBanzuke(repositories, banzukeCommand, {
+      dryRun: true,
+    });
+
+    expect(result.summary.basho.created).toBe(1);
+    expect(result.summary.rikishi.created).toBe(2);
+    expect(result.summary.banzuke.created).toBe(2);
+    expect(repositories.listBashos()).toEqual([]);
+  });
+
+  it("applies banzuke imports transactionally and idempotently", () => {
+    const repositories = createRepositories(client.db);
+
+    expect(importBanzuke(repositories, banzukeCommand).summary).toMatchObject({
+      basho: { created: 1 },
+      rikishi: { created: 2 },
+      banzuke: { created: 2 },
+    });
+    expect(importBanzuke(repositories, banzukeCommand).summary).toMatchObject({
+      basho: { skipped: 1 },
+      rikishi: { skipped: 2 },
+      banzuke: { skipped: 2 },
+    });
+  });
+
+  it("imports bout results after banzuke data exists", () => {
+    const repositories = createRepositories(client.db);
+    importBanzuke(repositories, banzukeCommand);
+
+    const result = importBoutResults(repositories, {
+      source: "test",
+      bashoId: "2026-05",
+      results: [
+        {
+          id: "2026-05-day-1-match-1",
+          bashoId: "2026-05",
+          day: 1,
+          winnerRikishiId: "onosato",
+          loserRikishiId: "kotozakura",
+          kimarite: "oshidashi",
+        },
+      ],
+    });
+
+    expect(result.summary.results.created).toBe(1);
+    expect(repositories.listBoutResultsForBasho("2026-05")).toHaveLength(1);
+  });
+
+  it("rejects invalid result imports before writing", () => {
+    const repositories = createRepositories(client.db);
+    importBanzuke(repositories, banzukeCommand);
+
+    expect(() =>
+      importBoutResults(repositories, {
+        source: "test",
+        bashoId: "2026-05",
+        results: [
+          {
+            id: "bad",
+            bashoId: "2026-05",
+            day: 16,
+            winnerRikishiId: "onosato",
+            loserRikishiId: "unknown",
+          },
+        ],
+      }),
+    ).toThrow(ImportValidationError);
+    expect(repositories.listBoutResultsForBasho("2026-05")).toEqual([]);
+  });
+});

--- a/apps/api/src/imports/service.ts
+++ b/apps/api/src/imports/service.ts
@@ -1,0 +1,314 @@
+import type {
+  BanzukeEntry,
+  Basho,
+  BoutResult,
+  Rikishi,
+} from "@fantasy-sumo/domain";
+import type { Repositories } from "@fantasy-sumo/db";
+import type {
+  BanzukeImportCommand,
+  BoutResultsImportCommand,
+  ImportEntitySummary,
+  ImportOptions,
+  ImportResult,
+  ImportSummary,
+  ImportValidationIssue,
+} from "./types.js";
+
+export class ImportValidationError extends Error {
+  constructor(readonly issues: ImportValidationIssue[]) {
+    super("Import validation failed.");
+  }
+}
+
+export function importBanzuke(
+  repositories: Repositories,
+  command: BanzukeImportCommand,
+  options: ImportOptions = {},
+): ImportResult {
+  const issues = validateBanzukeImport(command);
+
+  if (issues.length > 0) {
+    throw new ImportValidationError(issues);
+  }
+
+  const summary = createEmptySummary();
+  summary.basho = summarizeOne(
+    repositories.getBasho(command.basho.id),
+    command.basho,
+    isEqualBasho,
+  );
+  summary.rikishi = summarizeMany(
+    repositories.listRikishi(),
+    command.rikishi,
+    isEqualRikishi,
+  );
+  summary.banzuke = summarizeMany(
+    repositories.listBanzukeEntriesForBasho(command.basho.id),
+    command.banzukeEntries,
+    isEqualBanzukeEntry,
+  );
+
+  if (options.dryRun !== true) {
+    repositories.applyBanzukeImport({
+      basho: command.basho,
+      rikishi: command.rikishi,
+      banzukeEntries: command.banzukeEntries,
+    });
+  }
+
+  return {
+    dryRun: options.dryRun === true,
+    source: command.source,
+    summary,
+  };
+}
+
+export function importBoutResults(
+  repositories: Repositories,
+  command: BoutResultsImportCommand,
+  options: ImportOptions = {},
+): ImportResult {
+  const issues = validateBoutResultsImport(repositories, command);
+
+  if (issues.length > 0) {
+    throw new ImportValidationError(issues);
+  }
+
+  const summary = createEmptySummary();
+  summary.results = summarizeMany(
+    repositories.listBoutResultsForBasho(command.bashoId),
+    command.results,
+    isEqualBoutResult,
+  );
+
+  if (options.dryRun !== true) {
+    repositories.applyBoutResultsImport(command.results);
+  }
+
+  return {
+    dryRun: options.dryRun === true,
+    source: command.source,
+    summary,
+  };
+}
+
+function validateBanzukeImport(
+  command: BanzukeImportCommand,
+): ImportValidationIssue[] {
+  const issues: ImportValidationIssue[] = [];
+  const rikishiIds = new Set(command.rikishi.map((rikishi) => rikishi.id));
+  const banzukeRikishiIds = new Set<string>();
+  const rankOrders = new Set<number>();
+
+  if (command.basho.id.length === 0) {
+    issues.push({ path: "basho.id", message: "Basho id is required." });
+  }
+
+  for (const [index, entry] of command.banzukeEntries.entries()) {
+    if (entry.bashoId !== command.basho.id) {
+      issues.push({
+        path: `banzukeEntries.${index}.bashoId`,
+        message: "Banzuke entry basho id must match the imported basho.",
+      });
+    }
+
+    if (!rikishiIds.has(entry.rikishiId)) {
+      issues.push({
+        path: `banzukeEntries.${index}.rikishiId`,
+        message: `Rikishi ${entry.rikishiId} is not present in the import.`,
+      });
+    }
+
+    if (banzukeRikishiIds.has(entry.rikishiId)) {
+      issues.push({
+        path: `banzukeEntries.${index}.rikishiId`,
+        message: `Rikishi ${entry.rikishiId} appears more than once.`,
+      });
+    }
+    banzukeRikishiIds.add(entry.rikishiId);
+
+    if (rankOrders.has(entry.rankOrder)) {
+      issues.push({
+        path: `banzukeEntries.${index}.rankOrder`,
+        message: `Rank order ${entry.rankOrder} appears more than once.`,
+      });
+    }
+    rankOrders.add(entry.rankOrder);
+  }
+
+  return issues;
+}
+
+function validateBoutResultsImport(
+  repositories: Repositories,
+  command: BoutResultsImportCommand,
+): ImportValidationIssue[] {
+  const issues: ImportValidationIssue[] = [];
+  const rikishiIds = new Set(
+    repositories.listRikishi().map((rikishi) => rikishi.id),
+  );
+  const banzukeRikishiIds = new Set(
+    repositories
+      .listBanzukeEntriesForBasho(command.bashoId)
+      .map((entry) => entry.rikishiId),
+  );
+  const resultIds = new Set<string>();
+
+  if (repositories.getBasho(command.bashoId) === undefined) {
+    issues.push({
+      path: "bashoId",
+      message: `Basho ${command.bashoId} does not exist.`,
+    });
+  }
+
+  for (const [index, result] of command.results.entries()) {
+    if (result.bashoId !== command.bashoId) {
+      issues.push({
+        path: `results.${index}.bashoId`,
+        message: "Result basho id must match the import target.",
+      });
+    }
+
+    if (result.day < 1 || result.day > 15) {
+      issues.push({
+        path: `results.${index}.day`,
+        message: "Result day must be between 1 and 15.",
+      });
+    }
+
+    if (result.winnerRikishiId === result.loserRikishiId) {
+      issues.push({
+        path: `results.${index}`,
+        message: "Winner and loser must be different rikishi.",
+      });
+    }
+
+    for (const field of ["winnerRikishiId", "loserRikishiId"] as const) {
+      const rikishiId = result[field];
+
+      if (!rikishiIds.has(rikishiId)) {
+        issues.push({
+          path: `results.${index}.${field}`,
+          message: `Rikishi ${rikishiId} does not exist.`,
+        });
+      } else if (!banzukeRikishiIds.has(rikishiId)) {
+        issues.push({
+          path: `results.${index}.${field}`,
+          message: `Rikishi ${rikishiId} is not on the basho banzuke.`,
+        });
+      }
+    }
+
+    if (resultIds.has(result.id)) {
+      issues.push({
+        path: `results.${index}.id`,
+        message: `Result ${result.id} appears more than once.`,
+      });
+    }
+    resultIds.add(result.id);
+  }
+
+  return issues;
+}
+
+function createEmptySummary(): ImportSummary {
+  return {
+    basho: createEmptyEntitySummary(),
+    rikishi: createEmptyEntitySummary(),
+    banzuke: createEmptyEntitySummary(),
+    results: createEmptyEntitySummary(),
+  };
+}
+
+function createEmptyEntitySummary(): ImportEntitySummary {
+  return {
+    created: 0,
+    updated: 0,
+    skipped: 0,
+  };
+}
+
+function summarizeOne<T>(
+  existing: T | undefined,
+  next: T,
+  isEqual: (left: T, right: T) => boolean,
+): ImportEntitySummary {
+  const summary = createEmptyEntitySummary();
+
+  if (existing === undefined) {
+    summary.created += 1;
+  } else if (isEqual(existing, next)) {
+    summary.skipped += 1;
+  } else {
+    summary.updated += 1;
+  }
+
+  return summary;
+}
+
+function summarizeMany<T extends { id: string }>(
+  existingEntries: readonly T[],
+  nextEntries: readonly T[],
+  isEqual: (left: T, right: T) => boolean,
+): ImportEntitySummary {
+  const summary = createEmptyEntitySummary();
+  const existingById = new Map(
+    existingEntries.map((entry) => [entry.id, entry]),
+  );
+
+  for (const entry of nextEntries) {
+    const existing = existingById.get(entry.id);
+
+    if (existing === undefined) {
+      summary.created += 1;
+    } else if (isEqual(existing, entry)) {
+      summary.skipped += 1;
+    } else {
+      summary.updated += 1;
+    }
+  }
+
+  return summary;
+}
+
+function isEqualBasho(left: Basho, right: Basho) {
+  return (
+    left.id === right.id &&
+    left.name === right.name &&
+    left.startDate === right.startDate &&
+    left.endDate === right.endDate &&
+    left.status === right.status
+  );
+}
+
+function isEqualRikishi(left: Rikishi, right: Rikishi) {
+  return (
+    left.id === right.id &&
+    left.shikona === right.shikona &&
+    left.heya === right.heya
+  );
+}
+
+function isEqualBanzukeEntry(left: BanzukeEntry, right: BanzukeEntry) {
+  return (
+    left.id === right.id &&
+    left.bashoId === right.bashoId &&
+    left.rikishiId === right.rikishiId &&
+    left.rank === right.rank &&
+    left.rankOrder === right.rankOrder
+  );
+}
+
+function isEqualBoutResult(left: BoutResult, right: BoutResult) {
+  return (
+    left.id === right.id &&
+    left.bashoId === right.bashoId &&
+    left.day === right.day &&
+    left.winnerRikishiId === right.winnerRikishiId &&
+    left.loserRikishiId === right.loserRikishiId &&
+    left.kimarite === right.kimarite &&
+    left.winnerAbsent === right.winnerAbsent &&
+    left.loserAbsent === right.loserAbsent
+  );
+}

--- a/apps/api/src/imports/service.ts
+++ b/apps/api/src/imports/service.ts
@@ -26,6 +26,8 @@ export function importBanzuke(
   command: BanzukeImportCommand,
   options: ImportOptions = {},
 ): ImportResult {
+  // Validate source-shaped data before any database write so failed imports
+  // cannot leave the local game in a partly updated state.
   const issues = validateBanzukeImport(command);
 
   if (issues.length > 0) {
@@ -47,6 +49,7 @@ export function importBanzuke(
     repositories.listBanzukeEntriesForBasho(command.basho.id),
     command.banzukeEntries,
     isEqualBanzukeEntry,
+    { countDeleted: true },
   );
 
   if (options.dryRun !== true) {
@@ -69,6 +72,8 @@ export function importBoutResults(
   command: BoutResultsImportCommand,
   options: ImportOptions = {},
 ): ImportResult {
+  // Result imports are scoped to one basho/day. Reimporting that day should
+  // correct stale wins rather than append duplicate or outdated scoring rows.
   const issues = validateBoutResultsImport(repositories, command);
 
   if (issues.length > 0) {
@@ -77,13 +82,20 @@ export function importBoutResults(
 
   const summary = createEmptySummary();
   summary.results = summarizeMany(
-    repositories.listBoutResultsForBasho(command.bashoId),
+    repositories
+      .listBoutResultsForBasho(command.bashoId)
+      .filter((result) => result.day === command.results[0]?.day),
     command.results,
     isEqualBoutResult,
+    { countDeleted: true },
   );
 
   if (options.dryRun !== true) {
-    repositories.applyBoutResultsImport(command.results);
+    repositories.applyBoutResultsImport({
+      bashoId: command.bashoId,
+      day: command.results[0]!.day,
+      results: command.results,
+    });
   }
 
   return {
@@ -103,6 +115,13 @@ function validateBanzukeImport(
 
   if (command.basho.id.length === 0) {
     issues.push({ path: "basho.id", message: "Basho id is required." });
+  }
+
+  if (command.banzukeEntries.length === 0) {
+    issues.push({
+      path: "banzukeEntries",
+      message: "Banzuke import must contain at least one banzuke entry.",
+    });
   }
 
   for (const [index, entry] of command.banzukeEntries.entries()) {
@@ -162,6 +181,13 @@ function validateBoutResultsImport(
     });
   }
 
+  if (command.results.length === 0) {
+    issues.push({
+      path: "results",
+      message: "Result import must contain at least one bout result.",
+    });
+  }
+
   for (const [index, result] of command.results.entries()) {
     if (result.bashoId !== command.bashoId) {
       issues.push({
@@ -174,6 +200,13 @@ function validateBoutResultsImport(
       issues.push({
         path: `results.${index}.day`,
         message: "Result day must be between 1 and 15.",
+      });
+    }
+
+    if (result.day !== command.results[0]?.day) {
+      issues.push({
+        path: `results.${index}.day`,
+        message: "One result import can only replace a single basho day.",
       });
     }
 
@@ -193,6 +226,8 @@ function validateBoutResultsImport(
           message: `Rikishi ${rikishiId} does not exist.`,
         });
       } else if (!banzukeRikishiIds.has(rikishiId)) {
+        // Results must belong to rikishi on this basho's banzuke, not just
+        // any known rikishi from another tournament.
         issues.push({
           path: `results.${index}.${field}`,
           message: `Rikishi ${rikishiId} is not on the basho banzuke.`,
@@ -226,6 +261,7 @@ function createEmptyEntitySummary(): ImportEntitySummary {
     created: 0,
     updated: 0,
     skipped: 0,
+    deleted: 0,
   };
 }
 
@@ -251,11 +287,13 @@ function summarizeMany<T extends { id: string }>(
   existingEntries: readonly T[],
   nextEntries: readonly T[],
   isEqual: (left: T, right: T) => boolean,
+  options: { countDeleted?: boolean } = {},
 ): ImportEntitySummary {
   const summary = createEmptyEntitySummary();
   const existingById = new Map(
     existingEntries.map((entry) => [entry.id, entry]),
   );
+  const nextIds = new Set(nextEntries.map((entry) => entry.id));
 
   for (const entry of nextEntries) {
     const existing = existingById.get(entry.id);
@@ -266,6 +304,14 @@ function summarizeMany<T extends { id: string }>(
       summary.skipped += 1;
     } else {
       summary.updated += 1;
+    }
+  }
+
+  if (options.countDeleted === true) {
+    for (const existing of existingEntries) {
+      if (!nextIds.has(existing.id)) {
+        summary.deleted += 1;
+      }
     }
   }
 

--- a/apps/api/src/imports/types.ts
+++ b/apps/api/src/imports/types.ts
@@ -11,6 +11,7 @@ export interface ImportEntitySummary {
   created: number;
   updated: number;
   skipped: number;
+  deleted: number;
 }
 
 export type ImportSummary = Record<ImportEntityName, ImportEntitySummary>;

--- a/apps/api/src/imports/types.ts
+++ b/apps/api/src/imports/types.ts
@@ -1,0 +1,57 @@
+import type {
+  BanzukeEntry,
+  Basho,
+  BoutResult,
+  Rikishi,
+} from "@fantasy-sumo/domain";
+
+export type ImportEntityName = "basho" | "rikishi" | "banzuke" | "results";
+
+export interface ImportEntitySummary {
+  created: number;
+  updated: number;
+  skipped: number;
+}
+
+export type ImportSummary = Record<ImportEntityName, ImportEntitySummary>;
+
+export interface ImportValidationIssue {
+  path: string;
+  message: string;
+}
+
+export interface BanzukeImportCommand {
+  basho: Basho;
+  rikishi: Rikishi[];
+  banzukeEntries: BanzukeEntry[];
+  source: string;
+}
+
+export interface BoutResultsImportCommand {
+  bashoId: Basho["id"];
+  results: BoutResult[];
+  source: string;
+}
+
+export interface ImportOptions {
+  dryRun?: boolean;
+}
+
+export interface ImportResult {
+  dryRun: boolean;
+  source: string;
+  summary: ImportSummary;
+}
+
+export interface JsaBanzukeImportOptions {
+  divisionId?: number;
+  page?: number;
+}
+
+export interface SumoApiResultsImportOptions {
+  bashoId: Basho["id"];
+  day: number;
+  division?: string;
+}
+
+export type SourceFetch = typeof fetch;

--- a/apps/api/src/routes/admin-imports.test.ts
+++ b/apps/api/src/routes/admin-imports.test.ts
@@ -1,0 +1,154 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { FastifyInstance } from "fastify";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createDatabaseClient,
+  runMigrations,
+  type DatabaseClient,
+} from "@fantasy-sumo/db";
+import { buildApp } from "../app.js";
+
+let app: FastifyInstance;
+let client: DatabaseClient;
+let tmpRoot: string;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), "fantasy-sumo-admin-imports-"));
+  client = createDatabaseClient(`file:${join(tmpRoot, "test.sqlite")}`);
+  runMigrations(client.db);
+  app = buildApp({
+    db: client.db,
+    sourceFetch: async (url) => {
+      const sourceUrl = String(url);
+
+      if (sourceUrl.includes("EnHonbashoBanzuke")) {
+        return jsonResponse({
+          basho_name: "May Grand Sumo Tournament",
+          BashoInfo: {
+            start_date: "2026-05-10",
+            end_date: "2026-05-24",
+            today: "2026-05-12",
+            BattleNow: 1,
+            year_eng: "2026",
+          },
+          BanzukeTable: [
+            {
+              banzuke_id: 1,
+              banzuke_name: "Ozeki",
+              rikishi_id: 4227,
+              shikona: "Onosato",
+              heya_name: "Nishonoseki",
+            },
+            {
+              banzuke_id: 2,
+              banzuke_name: "Ozeki",
+              rikishi_id: 3661,
+              shikona: "Kotozakura",
+              heya_name: "Sadogatake",
+            },
+          ],
+        });
+      }
+
+      return jsonResponse({
+        torikumi: [
+          {
+            id: "202605-1-1-4227-3661",
+            bashoId: "202605",
+            day: 1,
+            matchNo: 1,
+            eastId: 4227,
+            eastShikona: "Onosato",
+            westId: 3661,
+            westShikona: "Kotozakura",
+            kimarite: "oshidashi",
+            winnerId: 4227,
+            winnerEn: "Onosato",
+          },
+        ],
+      });
+    },
+  });
+});
+
+afterEach(async () => {
+  await app.close();
+  client.close();
+  rmSync(tmpRoot, { force: true, recursive: true });
+});
+
+describe("admin import routes", () => {
+  it("dry-runs and applies source-backed banzuke imports", async () => {
+    const dryRunResponse = await app.inject({
+      method: "POST",
+      url: "/api/admin/import-banzuke?dryRun=true",
+      payload: {},
+    });
+
+    expect(dryRunResponse.statusCode).toBe(200);
+    expect(dryRunResponse.json()).toMatchObject({
+      dryRun: true,
+      source: "jsa-banzuke",
+      summary: {
+        basho: { created: 1 },
+        rikishi: { created: 2 },
+      },
+    });
+
+    const applyResponse = await app.inject({
+      method: "POST",
+      url: "/api/admin/import-banzuke",
+      payload: {},
+    });
+
+    expect(applyResponse.statusCode).toBe(200);
+
+    const rikishiResponse = await app.inject({
+      method: "GET",
+      url: "/api/basho/2026-05/rikishi",
+    });
+
+    expect(rikishiResponse.statusCode).toBe(200);
+    expect(rikishiResponse.json().rikishi).toHaveLength(2);
+  });
+
+  it("imports source-backed daily results", async () => {
+    await app.inject({
+      method: "POST",
+      url: "/api/admin/import-banzuke",
+      payload: {},
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/admin/basho/2026-05/import-results",
+      payload: {
+        day: 1,
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      source: "sumo-api-results",
+      summary: {
+        results: { created: 1 },
+      },
+    });
+
+    const leaderboardResponse = await app.inject({
+      method: "GET",
+      url: "/api/basho/2026-05/leaderboard",
+    });
+    expect(leaderboardResponse.statusCode).toBe(200);
+  });
+});
+
+function jsonResponse(payload: unknown) {
+  return new Response(JSON.stringify(payload), {
+    headers: {
+      "content-type": "application/json",
+    },
+  });
+}

--- a/apps/api/src/routes/admin-imports.ts
+++ b/apps/api/src/routes/admin-imports.ts
@@ -1,0 +1,132 @@
+import type { FastifyInstance, FastifyReply } from "fastify";
+import { z } from "zod";
+import type { Repositories } from "@fantasy-sumo/db";
+import {
+  fetchJsaBanzukeImport,
+  fetchSumoApiResultsImport,
+} from "../imports/adapters.js";
+import {
+  importBanzuke,
+  importBoutResults,
+  ImportValidationError,
+} from "../imports/service.js";
+import type { SourceFetch } from "../imports/types.js";
+
+interface RouteContext {
+  repositories: Repositories;
+  sourceFetch: SourceFetch;
+}
+
+const dryRunQuerySchema = z.object({
+  dryRun: z
+    .enum(["true", "false"])
+    .optional()
+    .transform((value) => value === "true"),
+});
+
+const importBanzukeBodySchema = z.object({
+  divisionId: z.number().int().positive().optional(),
+  page: z.number().int().positive().optional(),
+});
+
+const importResultsBodySchema = z.object({
+  day: z.number().int().min(1).max(15),
+  division: z.string().trim().min(1).optional(),
+});
+
+export function registerAdminImportRoutes(
+  app: FastifyInstance,
+  context: RouteContext,
+) {
+  app.post<{
+    Querystring: unknown;
+    Body: unknown;
+  }>("/api/admin/import-banzuke", async (request, reply) => {
+    const parsedQuery = dryRunQuerySchema.safeParse(request.query);
+    const parsedBody = importBanzukeBodySchema.safeParse(request.body ?? {});
+
+    if (!parsedQuery.success || !parsedBody.success) {
+      return reply.code(400).send({
+        error: "invalid-request",
+        message: "Banzuke import request is invalid.",
+        details: [
+          ...formatZodIssues(parsedQuery),
+          ...formatZodIssues(parsedBody),
+        ],
+      });
+    }
+
+    try {
+      const command = await fetchJsaBanzukeImport(
+        context.sourceFetch,
+        parsedBody.data,
+      );
+
+      return importBanzuke(context.repositories, command, {
+        dryRun: parsedQuery.data.dryRun,
+      });
+    } catch (error) {
+      return sendImportError(reply, error);
+    }
+  });
+
+  app.post<{
+    Params: { bashoId: string };
+    Querystring: unknown;
+    Body: unknown;
+  }>("/api/admin/basho/:bashoId/import-results", async (request, reply) => {
+    const parsedQuery = dryRunQuerySchema.safeParse(request.query);
+    const parsedBody = importResultsBodySchema.safeParse(request.body ?? {});
+
+    if (!parsedQuery.success || !parsedBody.success) {
+      return reply.code(400).send({
+        error: "invalid-request",
+        message: "Results import request is invalid.",
+        details: [
+          ...formatZodIssues(parsedQuery),
+          ...formatZodIssues(parsedBody),
+        ],
+      });
+    }
+
+    try {
+      const command = await fetchSumoApiResultsImport(context.sourceFetch, {
+        bashoId: request.params.bashoId,
+        day: parsedBody.data.day,
+        division: parsedBody.data.division,
+      });
+
+      return importBoutResults(context.repositories, command, {
+        dryRun: parsedQuery.data.dryRun,
+      });
+    } catch (error) {
+      return sendImportError(reply, error);
+    }
+  });
+}
+
+function formatZodIssues(result: z.ZodSafeParseResult<unknown>) {
+  if (result.success) {
+    return [];
+  }
+
+  return result.error.issues.map((issue) => ({
+    path: issue.path.join("."),
+    message: issue.message,
+  }));
+}
+
+function sendImportError(reply: FastifyReply, error: unknown) {
+  if (error instanceof ImportValidationError) {
+    return reply.code(400).send({
+      error: "invalid-import",
+      message: error.message,
+      details: error.issues,
+    });
+  }
+
+  return reply.code(502).send({
+    error: "source-import-failed",
+    message: error instanceof Error ? error.message : "Import failed.",
+  });
+}

--- a/apps/api/src/scripts/import-banzuke.ts
+++ b/apps/api/src/scripts/import-banzuke.ts
@@ -1,0 +1,23 @@
+import {
+  createDatabaseClient,
+  createRepositories,
+  runMigrations,
+} from "@fantasy-sumo/db";
+import { fetchJsaBanzukeImport } from "../imports/adapters.js";
+import { importBanzuke } from "../imports/service.js";
+
+const dryRun = process.argv.includes("--dry-run");
+const client = createDatabaseClient();
+
+try {
+  runMigrations(client.db);
+
+  const command = await fetchJsaBanzukeImport(fetch);
+  const result = importBanzuke(createRepositories(client.db), command, {
+    dryRun,
+  });
+
+  console.log(JSON.stringify(result, null, 2));
+} finally {
+  client.close();
+}

--- a/apps/api/src/scripts/import-results.ts
+++ b/apps/api/src/scripts/import-results.ts
@@ -1,0 +1,46 @@
+import {
+  createDatabaseClient,
+  createRepositories,
+  runMigrations,
+} from "@fantasy-sumo/db";
+import { fetchSumoApiResultsImport } from "../imports/adapters.js";
+import { importBoutResults } from "../imports/service.js";
+
+const args = new Map(
+  process.argv.slice(2).flatMap((arg, index, allArgs) => {
+    if (!arg.startsWith("--") || arg === "--dry-run") {
+      return [];
+    }
+
+    return [[arg.slice(2), allArgs[index + 1]]];
+  }),
+);
+const bashoId = args.get("basho");
+const day = Number(args.get("day"));
+const division = args.get("division") ?? "Makuuchi";
+const dryRun = process.argv.includes("--dry-run");
+
+if (bashoId === undefined || !Number.isInteger(day)) {
+  throw new Error(
+    "Usage: pnpm --filter @fantasy-sumo/api import:results -- --basho 2026-05 --day 1 [--division Makuuchi] [--dry-run]",
+  );
+}
+
+const client = createDatabaseClient();
+
+try {
+  runMigrations(client.db);
+
+  const command = await fetchSumoApiResultsImport(fetch, {
+    bashoId,
+    day,
+    division,
+  });
+  const result = importBoutResults(createRepositories(client.db), command, {
+    dryRun,
+  });
+
+  console.log(JSON.stringify(result, null, 2));
+} finally {
+  client.close();
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -73,11 +73,13 @@ Current routes:
 - `POST /api/admin/import-banzuke`
   - Fetches current Makuuchi banzuke data from the Japan Sumo Association `indexAjax` endpoint.
   - Maps source payloads into local `Basho`, `Rikishi`, and `BanzukeEntry` records.
+  - Replaces stale banzuke rows for the imported basho without deleting rikishi, teams, or picks.
   - Supports `?dryRun=true`.
 - `POST /api/admin/basho/:bashoId/import-results`
   - Fetches one day of Makuuchi results from Sumo API by default.
   - Request body: `day` and optional `division`.
   - Maps source payloads into local `BoutResult` records using local shikona-based rikishi ids.
+  - Replaces stale result rows only for the imported basho/day.
   - Supports `?dryRun=true`.
 
 Current limitations:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -44,7 +44,7 @@ Current behaviour:
 Current limitations:
 
 - No routing.
-- No result entry/import UI yet.
+- No result import UI yet.
 - No persistence of the last created team in browser storage yet.
 
 ## Back end
@@ -70,12 +70,22 @@ Current routes:
   - Returns a fantasy team and its picks.
 - `GET /api/basho/:bashoId/leaderboard`
   - Returns leaderboard entries calculated with the domain scoring module.
+- `POST /api/admin/import-banzuke`
+  - Fetches current Makuuchi banzuke data from the Japan Sumo Association `indexAjax` endpoint.
+  - Maps source payloads into local `Basho`, `Rikishi`, and `BanzukeEntry` records.
+  - Supports `?dryRun=true`.
+- `POST /api/admin/basho/:bashoId/import-results`
+  - Fetches one day of Makuuchi results from Sumo API by default.
+  - Request body: `day` and optional `division`.
+  - Maps source payloads into local `BoutResult` records using local shikona-based rikishi ids.
+  - Supports `?dryRun=true`.
 
 Current limitations:
 
 - No auth.
 - No dedicated API client package.
-- No result import endpoints or job trigger yet.
+- Admin import endpoints are local-only and unprotected.
+- No scheduled import job yet.
 - No pick-locking rules yet.
 
 ## Domain package
@@ -109,6 +119,7 @@ Current behaviour:
 - Includes Drizzle migration SQL and metadata in `packages/db/drizzle`.
 - Uses `DATABASE_URL` for the local SQLite file path, defaulting to `file:./data/fantasy-sumo.sqlite` relative to the database package scripts.
 - Provides repository functions for reading and writing basho, rikishi, banzuke entries, fantasy teams, fantasy picks, and bout results.
+- Provides transactional upsert helpers for banzuke and bout result imports.
 - Provides sample seed data for one basho, four rikishi, two fantasy teams, picks, and bout results.
 
 Current scripts:
@@ -116,12 +127,14 @@ Current scripts:
 ```text
 pnpm db:migrate
 pnpm db:seed
+pnpm import:banzuke
+pnpm import:results -- --basho 2026-05 --day 1
 pnpm --filter @fantasy-sumo/db db:generate
 ```
 
 Current limitations:
 
-- No banzuke/results import UI or endpoints yet.
+- No banzuke/results import UI yet.
 - No production database configuration yet.
 
 The accepted MVP import direction is documented in [Data Import Strategy](DATA_IMPORT_STRATEGY.md). Prefer automated source-backed imports first, with manual triggers, dry runs, and JSON fixtures available for testing and emergency fallback.
@@ -268,7 +281,7 @@ GET    /api/basho/:bashoId/rikishi
 POST   /api/basho/:bashoId/teams
 GET    /api/basho/:bashoId/teams/:teamId
 GET    /api/basho/:bashoId/leaderboard
-POST   /api/admin/basho/:bashoId/import-banzuke
+POST   /api/admin/import-banzuke
 POST   /api/admin/basho/:bashoId/import-results
 ```
 

--- a/docs/DATA_IMPORT_STRATEGY.md
+++ b/docs/DATA_IMPORT_STRATEGY.md
@@ -4,7 +4,7 @@
 
 Accepted for the MVP import path.
 
-Last checked: 2026-05-30.
+Last checked: 2026-06-01.
 
 ## Recommendation
 
@@ -285,5 +285,4 @@ For the first local MVP, a failed import can return a structured API error and l
 
 ## Follow-Up Tickets
 
-- GitHub issue #25: implement automated source-backed import for banzuke and results.
 - GitHub issue #26: add redundant/fallback source adapters after the first automated import path exists.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -39,7 +39,7 @@ Goal: make the core game loop work locally.
 - [x] Model fantasy teams and picks.
 - [x] Expose basho, rikishi, team, and leaderboard API routes.
 - [x] Add team selection flow.
-- [ ] Add automated source-backed import for banzuke and results.
+- [x] Add automated source-backed import for banzuke and results.
 - [x] Add leaderboard calculation.
 - [x] Add leaderboard UI.
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "build": "pnpm -r --if-present build",
     "db:migrate": "pnpm --filter @fantasy-sumo/db db:migrate",
     "db:seed": "pnpm --filter @fantasy-sumo/db db:seed",
+    "import:banzuke": "pnpm --filter @fantasy-sumo/api import:banzuke",
+    "import:results": "pnpm --filter @fantasy-sumo/api import:results",
     "test": "pnpm --filter @fantasy-sumo/domain build && pnpm -r --if-present test",
     "lint": "eslint .",
     "format": "prettier --write .",

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -20,17 +20,44 @@ import {
 export function createRepositories(db: SqliteDatabase) {
   const repositories = {
     insertBasho: (entry: Basho) => db.insert(basho).values(entry).run(),
+    upsertBasho: (entry: Basho) =>
+      db
+        .insert(basho)
+        .values(entry)
+        .onConflictDoUpdate({
+          target: basho.id,
+          set: entry,
+        })
+        .run(),
     listBashos: () => db.select().from(basho).orderBy(basho.startDate).all(),
     getBasho: (id: Basho["id"]) =>
       db.select().from(basho).where(eq(basho.id, id)).get(),
 
     insertRikishi: (entry: Rikishi) =>
       db.insert(rikishi).values(toRikishiRow(entry)).run(),
+    upsertRikishi: (entry: Rikishi) =>
+      db
+        .insert(rikishi)
+        .values(toRikishiRow(entry))
+        .onConflictDoUpdate({
+          target: rikishi.id,
+          set: toRikishiRow(entry),
+        })
+        .run(),
     listRikishi: () =>
       db.select().from(rikishi).orderBy(rikishi.shikona).all().map(toRikishi),
 
     insertBanzukeEntry: (entry: BanzukeEntry) =>
       db.insert(banzukeEntries).values(entry).run(),
+    upsertBanzukeEntry: (entry: BanzukeEntry) =>
+      db
+        .insert(banzukeEntries)
+        .values(entry)
+        .onConflictDoUpdate({
+          target: banzukeEntries.id,
+          set: entry,
+        })
+        .run(),
     listBanzukeEntriesForBasho: (bashoId: Basho["id"]) =>
       db
         .select()
@@ -87,6 +114,15 @@ export function createRepositories(db: SqliteDatabase) {
 
     insertBoutResult: (entry: BoutResult) =>
       db.insert(boutResults).values(toBoutResultRow(entry)).run(),
+    upsertBoutResult: (entry: BoutResult) =>
+      db
+        .insert(boutResults)
+        .values(toBoutResultRow(entry))
+        .onConflictDoUpdate({
+          target: boutResults.id,
+          set: toBoutResultRow(entry),
+        })
+        .run(),
     listBoutResultsForBasho: (bashoId: Basho["id"]) =>
       db
         .select()
@@ -95,6 +131,56 @@ export function createRepositories(db: SqliteDatabase) {
         .orderBy(boutResults.day)
         .all()
         .map(toBoutResult),
+    applyBanzukeImport: (importData: {
+      basho: Basho;
+      rikishi: readonly Rikishi[];
+      banzukeEntries: readonly BanzukeEntry[];
+    }) =>
+      db.transaction((transaction) => {
+        transaction
+          .insert(basho)
+          .values(importData.basho)
+          .onConflictDoUpdate({
+            target: basho.id,
+            set: importData.basho,
+          })
+          .run();
+
+        for (const entry of importData.rikishi) {
+          transaction
+            .insert(rikishi)
+            .values(toRikishiRow(entry))
+            .onConflictDoUpdate({
+              target: rikishi.id,
+              set: toRikishiRow(entry),
+            })
+            .run();
+        }
+
+        for (const entry of importData.banzukeEntries) {
+          transaction
+            .insert(banzukeEntries)
+            .values(entry)
+            .onConflictDoUpdate({
+              target: banzukeEntries.id,
+              set: entry,
+            })
+            .run();
+        }
+      }),
+    applyBoutResultsImport: (results: readonly BoutResult[]) =>
+      db.transaction((transaction) => {
+        for (const entry of results) {
+          transaction
+            .insert(boutResults)
+            .values(toBoutResultRow(entry))
+            .onConflictDoUpdate({
+              target: boutResults.id,
+              set: toBoutResultRow(entry),
+            })
+            .run();
+        }
+      }),
   };
 
   return repositories;

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { and, eq, notInArray } from "drizzle-orm";
 import type {
   BanzukeEntry,
   Basho,
@@ -167,10 +167,29 @@ export function createRepositories(db: SqliteDatabase) {
             })
             .run();
         }
+
+        if (importData.banzukeEntries.length > 0) {
+          transaction
+            .delete(banzukeEntries)
+            .where(
+              and(
+                eq(banzukeEntries.bashoId, importData.basho.id),
+                notInArray(
+                  banzukeEntries.id,
+                  importData.banzukeEntries.map((entry) => entry.id),
+                ),
+              ),
+            )
+            .run();
+        }
       }),
-    applyBoutResultsImport: (results: readonly BoutResult[]) =>
+    applyBoutResultsImport: (importData: {
+      bashoId: Basho["id"];
+      day: BoutResult["day"];
+      results: readonly BoutResult[];
+    }) =>
       db.transaction((transaction) => {
-        for (const entry of results) {
+        for (const entry of importData.results) {
           transaction
             .insert(boutResults)
             .values(toBoutResultRow(entry))
@@ -178,6 +197,22 @@ export function createRepositories(db: SqliteDatabase) {
               target: boutResults.id,
               set: toBoutResultRow(entry),
             })
+            .run();
+        }
+
+        if (importData.results.length > 0) {
+          transaction
+            .delete(boutResults)
+            .where(
+              and(
+                eq(boutResults.bashoId, importData.bashoId),
+                eq(boutResults.day, importData.day),
+                notInArray(
+                  boutResults.id,
+                  importData.results.map((entry) => entry.id),
+                ),
+              ),
+            )
             .run();
         }
       }),


### PR DESCRIPTION
## Summary

- Adds source-backed import adapters for JSA banzuke data and Sumo API daily torikumi/results.
- Maps source payloads into local shikona-based rikishi ids so JSA banzuke and Sumo API results can meet in the same database model.
- Adds source-agnostic import validation, dry-run summaries, and transactional upsert application for banzuke and bout results.
- Adds local admin trigger endpoints and pnpm/Makefile import commands.
- Updates README, architecture notes, import strategy, and roadmap with the implemented import path.

## Admin/import commands

- make import-banzuke
- make import-banzuke ARGS="-- --dry-run"
- make import-results ARGS="-- --basho 2026-05 --day 1"
- make import-results ARGS="-- --basho 2026-05 --day 1 --dry-run"

## Local admin endpoints

- POST /api/admin/import-banzuke?dryRun=true
- POST /api/admin/basho/:bashoId/import-results?dryRun=true

These remain local/unprotected for now and should not be exposed publicly without auth/protection.

## Validation

- Isolated temp DB live banzuke dry-run against JSA source: passed.
- Isolated temp DB live banzuke import against JSA source: passed.
- Isolated temp DB live day 1 results dry-run against Sumo API source: passed.
- make check

Closes #25.