### PR TITLE
Add basho lifecycle states and pick-locking rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ The original app was an unfinished barebones prototype. Treat the removed legacy
 - Package manager: pnpm workspace.
 - Front end: Vite, React, TypeScript.
 - Back end: Fastify, TypeScript, Node.
-- Shared code: `packages/domain` for framework-free domain boundaries.
+- Shared code: `packages/domain` for framework-free domain boundaries, including basho lifecycle and pick-locking rules.
 - Data: SQLite via `packages/db`, with Drizzle schema, migration SQL, repositories, sample seed data, and deterministic demo seed data.
 - Existing behaviour: displays team selection and leaderboard views, and exposes local game API routes for health, basho, rikishi, team creation/retrieval, and leaderboard data.
 
@@ -40,6 +40,7 @@ Avoid overbuilding. A working single-user/local MVP is preferable to a half-fini
 - Replace hard-coded credentials before any real deployment work.
 - Prefer explicit domain names: `Basho`, `Rikishi`, `Banzuke`, `FantasyTeam`, `Pick`, `Bout`, `Result`, `Leaderboard`.
 - Keep scoring logic isolated and well-tested.
+- Keep basho lifecycle and pick-locking rules in the domain/API layer; UI state should mirror those rules, not replace API enforcement.
 - Keep data import logic separate from scoring logic.
 - Once an E2E harness exists, use it to validate completion for changes that affect the browser game loop.
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ make dev
 
 Local URLs:
 
-- Web: `http://localhost:5173`
+- Web: `http://localhost:7866`
 - API health: `http://localhost:3000/api/health`
 
 Useful API endpoints:

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ At present, the app has the first local playable foundations:
 
 - A Vite + React front end for creating a fantasy team from seeded basho data and viewing leaderboard standings.
 - A Fastify API with health, basho, rikishi, team, and leaderboard endpoints.
-- A shared TypeScript domain package with MVP types, validation, scoring, and leaderboard logic.
+- A shared TypeScript domain package with MVP types, lifecycle rules, validation, scoring, and leaderboard logic.
 - A local SQLite + Drizzle database package with schema, migration, repositories, sample seed data, and deterministic demo data.
 - Automated source-backed import commands and local admin endpoints for current banzuke and daily results.
 - Vitest, ESLint, and Prettier wired through pnpm scripts.
 
-It is close to a local playable loop, but still needs pick locking and a friendlier admin UI before it is useful during a real basho.
+It is close to a local playable loop, but still needs a friendlier admin UI before it is useful during a real basho.
 
 ## Tech Stack
 
@@ -99,6 +99,17 @@ Useful API endpoints:
 - `POST /api/admin/basho/:bashoId/import-results`
 
 The admin import endpoints are local development tools for now. Do not expose them publicly without authentication/protection.
+
+## Basho lifecycle
+
+Basho records use this lifecycle:
+
+- `upcoming` - picks are open and fantasy teams can be created.
+- `locked` - picks are closed before scoring starts.
+- `active` - results are being applied and leaderboard scoring is in progress.
+- `complete` - final scores are available.
+
+The API enforces pick locking. `POST /api/basho/:bashoId/teams` succeeds only while the basho is `upcoming`; locked, active, and complete basho return a `409 picks-locked` response.
 
 Useful checks:
 

--- a/apps/api/src/imports/adapters.test.ts
+++ b/apps/api/src/imports/adapters.test.ts
@@ -74,6 +74,33 @@ describe("source import adapters", () => {
     });
   });
 
+  it("locks imported basho once the start date has arrived before active scoring", () => {
+    const command = mapJsaBanzukePayload({
+      basho_name: "May Grand Sumo Tournament",
+      BashoInfo: {
+        start_date: "2026-05-10",
+        end_date: "2026-05-24",
+        today: "2026-05-10",
+        BattleNow: 0,
+        year_eng: "2026",
+      },
+      BanzukeTable: [
+        {
+          banzuke_id: 1,
+          banzuke_name: "Yokozuna",
+          rikishi_id: 3842,
+          shikona: "Hoshoryu",
+          heya_name: "Tatsunami",
+        },
+      ],
+    });
+
+    expect(command.basho).toMatchObject({
+      status: "locked",
+      currentDay: 1,
+    });
+  });
+
   it("maps Sumo API torikumi payloads into local result commands", () => {
     const command = mapSumoApiTorikumiPayload(
       {

--- a/apps/api/src/imports/adapters.test.ts
+++ b/apps/api/src/imports/adapters.test.ts
@@ -43,6 +43,7 @@ describe("source import adapters", () => {
         id: "2026-05",
         name: "2026 May Grand Sumo Tournament",
         status: "active",
+        currentDay: 3,
       },
       rikishi: [
         {

--- a/apps/api/src/imports/adapters.ts
+++ b/apps/api/src/imports/adapters.ts
@@ -195,11 +195,16 @@ function resolveBashoStatus(payload: JsaBanzukePayload) {
     return "active";
   }
 
+  const currentDay = resolveCurrentDay(payload);
   const today = payload.BashoInfo?.today;
   const endDate = payload.BashoInfo?.end_date;
 
   if (today !== undefined && endDate !== undefined && today > endDate) {
     return "complete";
+  }
+
+  if (currentDay !== undefined && currentDay > 0) {
+    return "locked";
   }
 
   return "upcoming";

--- a/apps/api/src/imports/adapters.ts
+++ b/apps/api/src/imports/adapters.ts
@@ -85,6 +85,7 @@ export function mapJsaBanzukePayload(
       startDate,
       endDate,
       status: resolveBashoStatus(payload),
+      currentDay: resolveCurrentDay(payload),
     },
     rikishi: rows.map((row) => ({
       id: toLocalRikishiId(String(row.shikona)),
@@ -202,6 +203,33 @@ function resolveBashoStatus(payload: JsaBanzukePayload) {
   }
 
   return "upcoming";
+}
+
+function resolveCurrentDay(payload: JsaBanzukePayload) {
+  const today = payload.BashoInfo?.today;
+  const startDate = payload.BashoInfo?.start_date;
+  const endDate = payload.BashoInfo?.end_date;
+
+  if (today === undefined || startDate === undefined || endDate === undefined) {
+    return undefined;
+  }
+
+  if (today < startDate) {
+    return 0;
+  }
+
+  const bashoLength = daysBetween(startDate, endDate) + 1;
+  const day = daysBetween(startDate, today) + 1;
+
+  return Math.min(Math.max(day, 0), bashoLength);
+}
+
+function daysBetween(startDate: string, endDate: string) {
+  return Math.floor(
+    (Date.parse(`${endDate}T00:00:00.000Z`) -
+      Date.parse(`${startDate}T00:00:00.000Z`)) /
+      86_400_000,
+  );
 }
 
 function requiredString(value: unknown, field: string): string {

--- a/apps/api/src/imports/service.test.ts
+++ b/apps/api/src/imports/service.test.ts
@@ -96,6 +96,33 @@ describe("import service", () => {
     });
   });
 
+  it("counts basho current-day changes in banzuke import summaries", () => {
+    const repositories = createRepositories(client.db);
+    importBanzuke(repositories, {
+      ...banzukeCommand,
+      basho: {
+        ...banzukeCommand.basho,
+        currentDay: 3,
+      },
+    });
+
+    const result = importBanzuke(
+      repositories,
+      {
+        ...banzukeCommand,
+        basho: {
+          ...banzukeCommand.basho,
+          currentDay: 4,
+        },
+      },
+      {
+        dryRun: true,
+      },
+    );
+
+    expect(result.summary.basho.updated).toBe(1);
+  });
+
   it("removes stale banzuke entries without deleting rikishi", () => {
     const repositories = createRepositories(client.db);
     importBanzuke(repositories, banzukeCommand);
@@ -115,7 +142,14 @@ describe("import service", () => {
 
   it("imports bout results after banzuke data exists", () => {
     const repositories = createRepositories(client.db);
-    importBanzuke(repositories, banzukeCommand);
+    importBanzuke(repositories, {
+      ...banzukeCommand,
+      basho: {
+        ...banzukeCommand.basho,
+        status: "upcoming",
+        currentDay: 0,
+      },
+    });
 
     const result = importBoutResults(repositories, {
       source: "test",
@@ -134,6 +168,48 @@ describe("import service", () => {
 
     expect(result.summary.results.created).toBe(1);
     expect(repositories.listBoutResultsForBasho("2026-05")).toHaveLength(1);
+    expect(repositories.getBasho("2026-05")).toMatchObject({
+      status: "active",
+      currentDay: 1,
+    });
+  });
+
+  it("reports basho lifecycle updates during result import dry runs", () => {
+    const repositories = createRepositories(client.db);
+    importBanzuke(repositories, {
+      ...banzukeCommand,
+      basho: {
+        ...banzukeCommand.basho,
+        status: "locked",
+        currentDay: 1,
+      },
+    });
+
+    const result = importBoutResults(
+      repositories,
+      {
+        source: "test",
+        bashoId: "2026-05",
+        results: [
+          {
+            id: "2026-05-day-2-match-1",
+            bashoId: "2026-05",
+            day: 2,
+            winnerRikishiId: "onosato",
+            loserRikishiId: "kotozakura",
+          },
+        ],
+      },
+      {
+        dryRun: true,
+      },
+    );
+
+    expect(result.summary.basho.updated).toBe(1);
+    expect(repositories.getBasho("2026-05")).toMatchObject({
+      status: "locked",
+      currentDay: 1,
+    });
   });
 
   it("replaces stale results for the imported day only", () => {

--- a/apps/api/src/imports/service.ts
+++ b/apps/api/src/imports/service.ts
@@ -81,6 +81,16 @@ export function importBoutResults(
   }
 
   const summary = createEmptySummary();
+  const existingBasho = repositories.getBasho(command.bashoId);
+  const nextBasho =
+    existingBasho === undefined
+      ? undefined
+      : advanceBashoForResults(existingBasho, command.results[0]?.day);
+
+  if (nextBasho !== undefined) {
+    summary.basho = summarizeOne(existingBasho, nextBasho, isEqualBasho);
+  }
+
   summary.results = summarizeMany(
     repositories
       .listBoutResultsForBasho(command.bashoId)
@@ -91,6 +101,10 @@ export function importBoutResults(
   );
 
   if (options.dryRun !== true) {
+    if (nextBasho !== undefined) {
+      repositories.upsertBasho(nextBasho);
+    }
+
     repositories.applyBoutResultsImport({
       bashoId: command.bashoId,
       day: command.results[0]!.day,
@@ -265,6 +279,21 @@ function createEmptyEntitySummary(): ImportEntitySummary {
   };
 }
 
+function advanceBashoForResults(
+  basho: Basho,
+  importedDay: BoutResult["day"] | undefined,
+): Basho {
+  if (importedDay === undefined) {
+    return basho;
+  }
+
+  return {
+    ...basho,
+    status: basho.status === "complete" ? "complete" : "active",
+    currentDay: Math.max(basho.currentDay ?? 0, importedDay),
+  };
+}
+
 function summarizeOne<T>(
   existing: T | undefined,
   next: T,
@@ -324,7 +353,8 @@ function isEqualBasho(left: Basho, right: Basho) {
     left.name === right.name &&
     left.startDate === right.startDate &&
     left.endDate === right.endDate &&
-    left.status === right.status
+    left.status === right.status &&
+    left.currentDay === right.currentDay
   );
 }
 

--- a/apps/api/src/routes/basho.test.ts
+++ b/apps/api/src/routes/basho.test.ts
@@ -52,6 +52,35 @@ describe("basho routes", () => {
     });
   });
 
+  it("prefers a locked current basho over a later upcoming basho", async () => {
+    const repositories = createRepositories(client.db);
+    repositories.upsertBasho({
+      ...sampleBasho,
+      status: "locked",
+      currentDay: 1,
+    });
+    repositories.insertBasho({
+      id: "2026-07",
+      name: "July 2026 Future Basho",
+      startDate: "2026-07-12",
+      endDate: "2026-07-26",
+      status: "upcoming",
+      currentDay: 0,
+    });
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/basho/current",
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      id: "2026-05",
+      status: "locked",
+      currentDay: 1,
+    });
+  });
+
   it("returns rikishi for a basho with banzuke ranks", async () => {
     const response = await app.inject({
       method: "GET",

--- a/apps/api/src/routes/basho.test.ts
+++ b/apps/api/src/routes/basho.test.ts
@@ -4,9 +4,11 @@ import { join } from "node:path";
 import type { FastifyInstance } from "fastify";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  createRepositories,
   createDatabaseClient,
   runMigrations,
   seedDatabase,
+  sampleBasho,
   type DatabaseClient,
 } from "@fantasy-sumo/db";
 import { buildApp } from "../app.js";
@@ -44,7 +46,8 @@ describe("basho routes", () => {
     expect(response.json()).toMatchObject({
       id: "2026-05",
       name: "May 2026 Sample Basho",
-      status: "active",
+      status: "upcoming",
+      currentDay: 0,
       teamSize: 2,
     });
   });
@@ -176,6 +179,45 @@ describe("basho routes", () => {
       ],
     });
   });
+
+  it.each([
+    {
+      status: "locked",
+      expectedMessage: "Picks are locked for this basho.",
+    },
+    {
+      status: "active",
+      expectedMessage: "This basho has started, so picks are locked.",
+    },
+    {
+      status: "complete",
+      expectedMessage: "This basho is complete, so picks are closed.",
+    },
+  ] as const)(
+    "rejects team creation when a basho is $status",
+    async ({ status, expectedMessage }) => {
+      createRepositories(client.db).upsertBasho({
+        ...sampleBasho,
+        status,
+      });
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/basho/2026-05/teams",
+        payload: {
+          displayName: "Late Team",
+          rikishiIds: ["onosato", "kotozakura"],
+        },
+      });
+
+      expect(response.statusCode).toBe(409);
+      expect(response.json()).toMatchObject({
+        error: "picks-locked",
+        message: expectedMessage,
+        bashoStatus: status,
+      });
+    },
+  );
 
   it("returns a leaderboard ordered by score", async () => {
     const response = await app.inject({

--- a/apps/api/src/routes/basho.ts
+++ b/apps/api/src/routes/basho.ts
@@ -4,6 +4,8 @@ import type { Repositories } from "@fantasy-sumo/db";
 import type { FantasyPick, FantasyTeam } from "@fantasy-sumo/domain";
 import {
   calculateLeaderboard,
+  canEditFantasyPicks,
+  getPickLockMessage,
   validateFantasyPicks,
 } from "@fantasy-sumo/domain";
 
@@ -87,6 +89,16 @@ export function registerBashoRoutes(
       return reply.code(404).send({
         error: "not-found",
         message: `Basho ${request.params.bashoId} was not found.`,
+      });
+    }
+
+    if (!canEditFantasyPicks(basho)) {
+      return reply.code(409).send({
+        error: "picks-locked",
+        message:
+          getPickLockMessage(basho) ??
+          "Fantasy team picks are locked for this basho.",
+        bashoStatus: basho.status,
       });
     }
 

--- a/apps/api/src/routes/basho.ts
+++ b/apps/api/src/routes/basho.ts
@@ -226,6 +226,11 @@ export function registerBashoRoutes(
 
 function findCurrentBasho(repositories: Repositories) {
   const bashos = repositories.listBashos();
+  const latestFirst = [...bashos].reverse();
 
-  return bashos.find((basho) => basho.status === "active") ?? bashos.at(-1);
+  return (
+    latestFirst.find((basho) => basho.status === "active") ??
+    latestFirst.find((basho) => basho.status === "locked") ??
+    latestFirst.at(0)
+  );
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,12 +4,11 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "pnpm --filter @fantasy-sumo/domain build && vite --host 0.0.0.0",
-    "build": "pnpm --filter @fantasy-sumo/domain build && tsc -p tsconfig.json && vite build",
-    "test": "pnpm --filter @fantasy-sumo/domain build && vitest run src"
+    "dev": "vite --host 0.0.0.0",
+    "build": "tsc -p tsconfig.json && vite build",
+    "test": "vitest run src"
   },
   "dependencies": {
-    "@fantasy-sumo/domain": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite --host 0.0.0.0",
-    "build": "tsc -p tsconfig.json && vite build",
+    "dev": "pnpm --filter @fantasy-sumo/domain build && vite --host 0.0.0.0",
+    "build": "pnpm --filter @fantasy-sumo/domain build && tsc -p tsconfig.json && vite build",
     "test": "pnpm --filter @fantasy-sumo/domain build && vitest run src"
   },
   "dependencies": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite --host 0.0.0.0",
     "build": "tsc -p tsconfig.json && vite build",
-    "test": "vitest run src"
+    "test": "pnpm --filter @fantasy-sumo/domain build && vitest run src"
   },
   "dependencies": {
     "@fantasy-sumo/domain": "workspace:*",

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -7,7 +7,8 @@ const currentBasho = {
   name: "May 2026 Sample Basho",
   startDate: "2026-05-10",
   endDate: "2026-05-24",
-  status: "active",
+  status: "upcoming",
+  currentDay: 0,
   teamSize: 2,
 };
 
@@ -210,6 +211,28 @@ describe("App", () => {
     expect(screen.getByRole("button", { name: /Hoshoryu/ })).not.toBeDisabled();
   });
 
+  it("shows locked basho messaging and prevents team selection", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) =>
+        mockSuccessfulFetch(input, {
+          ...currentBasho,
+          status: "active",
+          currentDay: 5,
+        }),
+      ),
+    );
+    render(<App />);
+
+    expect(
+      await screen.findByText("This basho has started, so picks are locked."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Scoring in progress")).toBeInTheDocument();
+    expect(screen.getByText(/Day 5/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Onosato/ })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Submit team" })).toBeDisabled();
+  });
+
   it("submits a selected team and shows confirmation", async () => {
     const fetchMock = vi.fn(mockSuccessfulFetch);
     vi.stubGlobal("fetch", fetchMock);
@@ -298,16 +321,19 @@ describe("App", () => {
   });
 });
 
-function mockSuccessfulFetch(input: RequestInfo | URL): Promise<Response> {
+function mockSuccessfulFetch(
+  input: RequestInfo | URL,
+  basho = currentBasho,
+): Promise<Response> {
   const url = String(input);
 
   if (url === "/api/basho/current") {
-    return jsonResponse(currentBasho);
+    return jsonResponse(basho);
   }
 
   if (url === "/api/basho/2026-05/rikishi") {
     return jsonResponse({
-      basho: currentBasho,
+      basho,
       rikishi: rankedRikishi,
     });
   }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,6 +1,5 @@
 import type { FormEvent, MutableRefObject } from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { canEditFantasyPicks, getPickLockMessage } from "@fantasy-sumo/domain";
 import {
   createFantasyTeam,
   fetchBashoRikishi,
@@ -23,6 +22,7 @@ import type {
   LoadState,
   RankedRikishi,
 } from "./types";
+import { canEditFantasyPicks, getPickLockMessage } from "./lifecycle";
 
 export function App() {
   const [loadState, setLoadState] = useState<LoadState>("loading");

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,6 @@
 import type { FormEvent, MutableRefObject } from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { canEditFantasyPicks, getPickLockMessage } from "@fantasy-sumo/domain";
 import {
   createFantasyTeam,
   fetchBashoRikishi,
@@ -118,13 +119,21 @@ export function App() {
     [rikishi, selectedIds],
   );
   const teamSize = basho?.teamSize ?? 0;
+  const canEditPicks = basho === null ? false : canEditFantasyPicks(basho);
+  const pickLockMessage =
+    basho === null ? undefined : getPickLockMessage(basho);
   const canSubmit =
     loadState === "ready" &&
+    canEditPicks &&
     submitState === "idle" &&
     displayName.trim().length > 0 &&
     selectedIds.length === teamSize;
 
   function toggleRikishi(rikishiId: string) {
+    if (!canEditPicks) {
+      return;
+    }
+
     setErrorMessage(null);
     setCreatedTeam(null);
     setSelectedIds((current) => {
@@ -226,6 +235,8 @@ export function App() {
               createdTeam={createdTeam}
               displayName={displayName}
               errorMessage={errorMessage}
+              isLocked={!canEditPicks}
+              lockMessage={pickLockMessage}
               onDisplayNameChange={(nextDisplayName) => {
                 setDisplayName(nextDisplayName);
                 setCreatedTeam(null);

--- a/apps/web/src/components/BashoPanel.test.tsx
+++ b/apps/web/src/components/BashoPanel.test.tsx
@@ -8,7 +8,8 @@ const basho: Basho = {
   name: "May 2026 Sample Basho",
   startDate: "2026-05-10",
   endDate: "2026-05-24",
-  status: "active",
+  status: "upcoming",
+  currentDay: 0,
   teamSize: 2,
 };
 
@@ -20,8 +21,25 @@ describe("BashoPanel", () => {
       screen.getByRole("heading", { name: "May 2026 Sample Basho" }),
     ).toBeInTheDocument();
     expect(screen.getByText("10 May to 24 May")).toBeInTheDocument();
+    expect(screen.getByText("Picks open")).toBeInTheDocument();
     expect(screen.getByText("1 of 2 selected")).toBeInTheDocument();
     expect(screen.getByText("1 pick left")).toBeInTheDocument();
+  });
+
+  it("shows day progress when the basho is active", () => {
+    render(
+      <BashoPanel
+        basho={{
+          ...basho,
+          status: "active",
+          currentDay: 5,
+        }}
+        selectedCount={2}
+      />,
+    );
+
+    expect(screen.getByText("Scoring in progress")).toBeInTheDocument();
+    expect(screen.getByText(/Day 5/)).toBeInTheDocument();
   });
 
   it("shows when the team is full", () => {

--- a/apps/web/src/components/BashoPanel.tsx
+++ b/apps/web/src/components/BashoPanel.tsx
@@ -1,5 +1,5 @@
 import type { Basho } from "../types";
-import { getBashoLifecycleLabel } from "@fantasy-sumo/domain";
+import { getBashoLifecycleLabel } from "../lifecycle";
 
 interface BashoPanelProps {
   basho: Basho;

--- a/apps/web/src/components/BashoPanel.tsx
+++ b/apps/web/src/components/BashoPanel.tsx
@@ -1,4 +1,5 @@
 import type { Basho } from "../types";
+import { getBashoLifecycleLabel } from "@fantasy-sumo/domain";
 
 interface BashoPanelProps {
   basho: Basho;
@@ -16,6 +17,12 @@ export function BashoPanel({ basho, selectedCount }: BashoPanelProps) {
       </div>
       <p className="basho-dates">
         {formatDate(basho.startDate)} to {formatDate(basho.endDate)}
+      </p>
+      <p className="lifecycle-state">
+        <strong>{getBashoLifecycleLabel(basho.status)}</strong>
+        {basho.currentDay === undefined || basho.currentDay === 0
+          ? null
+          : ` - Day ${basho.currentDay}`}
       </p>
       <div className="progress-wrap" aria-label="Pick progress">
         <span>

--- a/apps/web/src/components/TeamSelection.test.tsx
+++ b/apps/web/src/components/TeamSelection.test.tsx
@@ -102,6 +102,26 @@ describe("TeamSelection", () => {
       screen.getByText("2 rikishi selected for this basho."),
     ).toBeInTheDocument();
   });
+
+  it("disables team editing when picks are locked", () => {
+    const onToggleRikishi = vi.fn();
+
+    renderTeamSelection({
+      isLocked: true,
+      lockMessage: "This basho has started, so picks are locked.",
+      onToggleRikishi,
+    });
+
+    expect(
+      screen.getByText("This basho has started, so picks are locked."),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Team name")).toBeDisabled();
+    expect(screen.getByRole("button", { name: /Onosato/ })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Remove Kotozakura" }),
+    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Submit team" })).toBeDisabled();
+  });
 });
 
 function renderTeamSelection(
@@ -116,6 +136,8 @@ function renderTeamSelection(
       createdTeam={props.createdTeam ?? null}
       displayName={props.displayName ?? "East Stand Heroes"}
       errorMessage={props.errorMessage ?? null}
+      isLocked={props.isLocked ?? false}
+      lockMessage={props.lockMessage}
       onDisplayNameChange={props.onDisplayNameChange ?? vi.fn()}
       onSubmit={props.onSubmit ?? vi.fn()}
       onToggleRikishi={props.onToggleRikishi ?? vi.fn()}

--- a/apps/web/src/components/TeamSelection.tsx
+++ b/apps/web/src/components/TeamSelection.tsx
@@ -6,6 +6,8 @@ interface TeamSelectionProps {
   createdTeam: CreatedTeamResponse | null;
   displayName: string;
   errorMessage: string | null;
+  isLocked: boolean;
+  lockMessage?: string;
   onDisplayNameChange: (displayName: string) => void;
   onSubmit: (event: FormEvent<HTMLFormElement>) => void;
   onToggleRikishi: (rikishiId: string) => void;
@@ -21,6 +23,8 @@ export function TeamSelection({
   createdTeam,
   displayName,
   errorMessage,
+  isLocked,
+  lockMessage,
   onDisplayNameChange,
   onSubmit,
   onToggleRikishi,
@@ -39,10 +43,16 @@ export function TeamSelection({
           <p className="eyebrow">Banzuke</p>
           <h2 id="rikishi-title">Choose rikishi</h2>
         </div>
+        {isLocked && lockMessage !== undefined && (
+          <p className="form-message" role="status">
+            {lockMessage}
+          </p>
+        )}
         <div className="rikishi-list">
           {rikishi.map((entry) => {
             const isSelected = selectedIds.includes(entry.id);
-            const isDisabled = !isSelected && selectedIds.length >= teamSize;
+            const isDisabled =
+              isLocked || (!isSelected && selectedIds.length >= teamSize);
 
             return (
               <button
@@ -81,6 +91,7 @@ export function TeamSelection({
         <input
           id="displayName"
           name="displayName"
+          disabled={isLocked}
           value={displayName}
           onChange={(event) => onDisplayNameChange(event.target.value)}
           placeholder="East Stand Heroes"
@@ -92,6 +103,7 @@ export function TeamSelection({
               <span>{entry.shikona}</span>
               <button
                 type="button"
+                disabled={isLocked}
                 onClick={() => onToggleRikishi(entry.id)}
                 aria-label={`Remove ${entry.shikona}`}
               >
@@ -106,7 +118,11 @@ export function TeamSelection({
           ))}
         </ol>
 
-        <button className="submit-button" disabled={!canSubmit} type="submit">
+        <button
+          className="submit-button"
+          disabled={isLocked || !canSubmit}
+          type="submit"
+        >
           {submitState === "submitting" ? "Submitting..." : "Submit team"}
         </button>
 

--- a/apps/web/src/lifecycle.ts
+++ b/apps/web/src/lifecycle.ts
@@ -1,0 +1,34 @@
+import type { Basho } from "./types";
+
+export function canEditFantasyPicks(basho: Basho): boolean {
+  return basho.status === "upcoming";
+}
+
+export function getBashoLifecycleLabel(status: Basho["status"]): string {
+  switch (status) {
+    case "upcoming":
+      return "Picks open";
+    case "locked":
+      return "Picks locked";
+    case "active":
+      return "Scoring in progress";
+    case "complete":
+      return "Final scores";
+  }
+}
+
+export function getPickLockMessage(basho: Basho): string | undefined {
+  if (canEditFantasyPicks(basho)) {
+    return undefined;
+  }
+
+  if (basho.status === "locked") {
+    return "Picks are locked for this basho.";
+  }
+
+  if (basho.status === "active") {
+    return "This basho has started, so picks are locked.";
+  }
+
+  return "This basho is complete, so picks are closed.";
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -138,6 +138,12 @@ h2 {
   white-space: nowrap;
 }
 
+.lifecycle-state {
+  margin: 0;
+  color: #21332f;
+  white-space: nowrap;
+}
+
 .progress-wrap {
   min-width: 200px;
   padding: 12px 14px;

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -3,7 +3,8 @@ export interface Basho {
   name: string;
   startDate: string;
   endDate: string;
-  status: "upcoming" | "active" | "complete";
+  status: "upcoming" | "locked" | "active" | "complete";
+  currentDay?: number;
   teamSize: number;
 }
 

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -4,7 +4,8 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 5173,
+    port: 7866,
+    strictPort: true,
     proxy: {
       "/api": "http://localhost:3000",
     },

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -124,6 +124,7 @@ Current behaviour:
 - Provides transactional upsert helpers for banzuke and bout result imports.
 - Provides sample seed data for one basho, four rikishi, two fantasy teams, picks, and bout results.
 - Provides deterministic demo seed data for one active basho, eight rikishi, four fantasy teams, picks, and five days of bout results.
+- Stores basho lifecycle status and current day progress.
 
 Current scripts:
 
@@ -239,7 +240,8 @@ Basho
   name
   startDate
   endDate
-  status: upcoming | active | complete
+  status: upcoming | locked | active | complete
+  currentDay optional
 
 Rikishi
   id
@@ -292,6 +294,15 @@ POST   /api/admin/basho/:bashoId/import-results
 ```
 
 Admin endpoints can be protected later. For early local development, they can remain local-only but should be clearly marked as unsafe for production.
+
+`POST /api/basho/:bashoId/teams` is allowed only while the basho status is `upcoming`. The API rejects team creation for `locked`, `active`, and `complete` basho with `409 picks-locked`; the UI mirrors that state but is not the source of enforcement.
+
+Lifecycle meanings:
+
+- `upcoming`: picks are open.
+- `locked`: picks are closed before scoring starts.
+- `active`: results are being applied day by day.
+- `complete`: final scores are available.
 
 The first import implementation should follow [Data Import Strategy](DATA_IMPORT_STRATEGY.md): fetch through source-specific adapters, validate source-agnostic import commands, write them transactionally, and keep import adapters separate from scoring.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -58,7 +58,7 @@ Current routes:
 - `GET /api/health`
   - Returns a small JSON health payload.
 - `GET /api/basho/current`
-  - Returns the active basho and configured team size, falling back to the latest available basho when none is active.
+  - Returns the active basho and configured team size, falling back to the latest locked basho, then the latest available basho.
 - `GET /api/basho/:bashoId/rikishi`
   - Returns a basho and its rikishi with banzuke rank data.
 - `POST /api/basho/:bashoId/teams`
@@ -123,7 +123,7 @@ Current behaviour:
 - Provides repository functions for reading and writing basho, rikishi, banzuke entries, fantasy teams, fantasy picks, and bout results.
 - Provides transactional upsert helpers for banzuke and bout result imports.
 - Provides sample seed data for one basho, four rikishi, two fantasy teams, picks, and bout results.
-- Provides deterministic demo seed data for one active basho, eight rikishi, four fantasy teams, picks, and five days of bout results.
+- Provides deterministic demo seed data for one pickable basho, eight rikishi, four fantasy teams, picks, and five days of bout results.
 - Stores basho lifecycle status and current day progress.
 
 Current scripts:

--- a/docs/PROJECT_BRIEF.md
+++ b/docs/PROJECT_BRIEF.md
@@ -79,3 +79,14 @@ Start with something simple and transparent:
 - Tied teams are allowed and are ordered deterministically by display name, then team id.
 
 Keep this in an isolated scoring module so future bonuses can be added safely.
+
+## Basho lifecycle
+
+The MVP lifecycle is:
+
+- `upcoming`: picks are open.
+- `locked`: picks are closed before results are scored.
+- `active`: results are being applied day by day.
+- `complete`: final scores are available.
+
+Fantasy teams and picks can be created only while the basho is `upcoming`.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -39,6 +39,7 @@ Goal: make the core game loop work locally.
 - [x] Model fantasy teams and picks.
 - [x] Expose basho, rikishi, team, and leaderboard API routes.
 - [x] Add team selection flow.
+- [x] Add basho lifecycle states and pick-locking rules.
 - [x] Add automated source-backed import for banzuke and results.
 - [x] Add leaderboard calculation.
 - [x] Add leaderboard UI.
@@ -50,7 +51,6 @@ Goal: make it usable by a small group of friends.
 
 - [ ] Add simple user identity or display-name-based teams.
 - [ ] Add private league concept if needed.
-- [ ] Add pick-locking before basho starts.
 - [ ] Add basic admin flow for importing data.
 - [ ] Improve responsive UI.
 - [x] Add error/loading/empty states.

--- a/packages/db/drizzle/0001_basho_lifecycle.sql
+++ b/packages/db/drizzle/0001_basho_lifecycle.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `basho` ADD `current_day` integer;

--- a/packages/db/drizzle/meta/0001_snapshot.json
+++ b/packages/db/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,385 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "9d146db8-8f2f-42ea-8d2e-962c5e5de1e1",
+  "prevId": "5300bdb7-c134-4e58-a5a8-4de8c5b7c58c",
+  "tables": {
+    "banzuke_entries": {
+      "name": "banzuke_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "basho_id": {
+          "name": "basho_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rikishi_id": {
+          "name": "rikishi_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rank_order": {
+          "name": "rank_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "banzuke_entries_basho_rikishi_idx": {
+          "name": "banzuke_entries_basho_rikishi_idx",
+          "columns": ["basho_id", "rikishi_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "banzuke_entries_basho_id_basho_id_fk": {
+          "name": "banzuke_entries_basho_id_basho_id_fk",
+          "tableFrom": "banzuke_entries",
+          "tableTo": "basho",
+          "columnsFrom": ["basho_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "banzuke_entries_rikishi_id_rikishi_id_fk": {
+          "name": "banzuke_entries_rikishi_id_rikishi_id_fk",
+          "tableFrom": "banzuke_entries",
+          "tableTo": "rikishi",
+          "columnsFrom": ["rikishi_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "basho": {
+      "name": "basho",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_day": {
+          "name": "current_day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "bout_results": {
+      "name": "bout_results",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "basho_id": {
+          "name": "basho_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "day": {
+          "name": "day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "winner_rikishi_id": {
+          "name": "winner_rikishi_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "loser_rikishi_id": {
+          "name": "loser_rikishi_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kimarite": {
+          "name": "kimarite",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "winner_absent": {
+          "name": "winner_absent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "loser_absent": {
+          "name": "loser_absent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bout_results_basho_id_basho_id_fk": {
+          "name": "bout_results_basho_id_basho_id_fk",
+          "tableFrom": "bout_results",
+          "tableTo": "basho",
+          "columnsFrom": ["basho_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bout_results_winner_rikishi_id_rikishi_id_fk": {
+          "name": "bout_results_winner_rikishi_id_rikishi_id_fk",
+          "tableFrom": "bout_results",
+          "tableTo": "rikishi",
+          "columnsFrom": ["winner_rikishi_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bout_results_loser_rikishi_id_rikishi_id_fk": {
+          "name": "bout_results_loser_rikishi_id_rikishi_id_fk",
+          "tableFrom": "bout_results",
+          "tableTo": "rikishi",
+          "columnsFrom": ["loser_rikishi_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "fantasy_picks": {
+      "name": "fantasy_picks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rikishi_id": {
+          "name": "rikishi_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "fantasy_picks_team_rikishi_idx": {
+          "name": "fantasy_picks_team_rikishi_idx",
+          "columns": ["team_id", "rikishi_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "fantasy_picks_team_id_fantasy_teams_id_fk": {
+          "name": "fantasy_picks_team_id_fantasy_teams_id_fk",
+          "tableFrom": "fantasy_picks",
+          "tableTo": "fantasy_teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fantasy_picks_rikishi_id_rikishi_id_fk": {
+          "name": "fantasy_picks_rikishi_id_rikishi_id_fk",
+          "tableFrom": "fantasy_picks",
+          "tableTo": "rikishi",
+          "columnsFrom": ["rikishi_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "fantasy_teams": {
+      "name": "fantasy_teams",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "basho_id": {
+          "name": "basho_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_name": {
+          "name": "owner_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fantasy_teams_basho_id_basho_id_fk": {
+          "name": "fantasy_teams_basho_id_basho_id_fk",
+          "tableFrom": "fantasy_teams",
+          "tableTo": "basho",
+          "columnsFrom": ["basho_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rikishi": {
+      "name": "rikishi",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shikona": {
+          "name": "shikona",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "heya": {
+          "name": "heya",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1779051420132,
       "tag": "0000_workable_human_cannonball",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1780675200000,
+      "tag": "0001_basho_lifecycle",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/demo-seed-data.ts
+++ b/packages/db/src/demo-seed-data.ts
@@ -12,8 +12,8 @@ export const demoBasho: Basho = {
   name: "Demo May Basho",
   startDate: "2026-05-10",
   endDate: "2026-05-24",
-  status: "active",
-  currentDay: 5,
+  status: "upcoming",
+  currentDay: 0,
 };
 
 export const demoRikishi: Rikishi[] = [

--- a/packages/db/src/demo-seed-data.ts
+++ b/packages/db/src/demo-seed-data.ts
@@ -13,6 +13,7 @@ export const demoBasho: Basho = {
   startDate: "2026-05-10",
   endDate: "2026-05-24",
   status: "active",
+  currentDay: 5,
 };
 
 export const demoRikishi: Rikishi[] = [

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -19,19 +19,21 @@ import {
 
 export function createRepositories(db: SqliteDatabase) {
   const repositories = {
-    insertBasho: (entry: Basho) => db.insert(basho).values(entry).run(),
+    insertBasho: (entry: Basho) =>
+      db.insert(basho).values(toBashoRow(entry)).run(),
     upsertBasho: (entry: Basho) =>
       db
         .insert(basho)
-        .values(entry)
+        .values(toBashoRow(entry))
         .onConflictDoUpdate({
           target: basho.id,
-          set: entry,
+          set: toBashoRow(entry),
         })
         .run(),
-    listBashos: () => db.select().from(basho).orderBy(basho.startDate).all(),
+    listBashos: () =>
+      db.select().from(basho).orderBy(basho.startDate).all().map(toBasho),
     getBasho: (id: Basho["id"]) =>
-      db.select().from(basho).where(eq(basho.id, id)).get(),
+      toOptionalBasho(db.select().from(basho).where(eq(basho.id, id)).get()),
 
     insertRikishi: (entry: Rikishi) =>
       db.insert(rikishi).values(toRikishiRow(entry)).run(),
@@ -139,10 +141,10 @@ export function createRepositories(db: SqliteDatabase) {
       db.transaction((transaction) => {
         transaction
           .insert(basho)
-          .values(importData.basho)
+          .values(toBashoRow(importData.basho))
           .onConflictDoUpdate({
             target: basho.id,
-            set: importData.basho,
+            set: toBashoRow(importData.basho),
           })
           .run();
 
@@ -222,6 +224,30 @@ export function createRepositories(db: SqliteDatabase) {
 }
 
 export type Repositories = ReturnType<typeof createRepositories>;
+
+function toBashoRow(entry: Basho) {
+  return {
+    ...entry,
+    currentDay: entry.currentDay ?? null,
+  };
+}
+
+function toBasho(row: typeof basho.$inferSelect): Basho {
+  return {
+    id: row.id,
+    name: row.name,
+    startDate: row.startDate,
+    endDate: row.endDate,
+    status: row.status,
+    ...(row.currentDay === null ? {} : { currentDay: row.currentDay }),
+  };
+}
+
+function toOptionalBasho(
+  row: typeof basho.$inferSelect | undefined,
+): Basho | undefined {
+  return row === undefined ? undefined : toBasho(row);
+}
 
 function toRikishiRow(entry: Rikishi) {
   return {

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -11,8 +11,9 @@ export const basho = sqliteTable("basho", {
   startDate: text("start_date").notNull(),
   endDate: text("end_date").notNull(),
   status: text("status", {
-    enum: ["upcoming", "active", "complete"],
+    enum: ["upcoming", "locked", "active", "complete"],
   }).notNull(),
+  currentDay: integer("current_day"),
 });
 
 export const rikishi = sqliteTable("rikishi", {

--- a/packages/db/src/seed-data.ts
+++ b/packages/db/src/seed-data.ts
@@ -12,7 +12,8 @@ export const sampleBasho: Basho = {
   name: "May 2026 Sample Basho",
   startDate: "2026-05-10",
   endDate: "2026-05-24",
-  status: "active",
+  status: "upcoming",
+  currentDay: 0,
 };
 
 export const sampleRikishi: Rikishi[] = [

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -62,7 +62,12 @@ function replaceSeedData(db: SqliteDatabase, seedData: SeedData): void {
   db.delete(rikishi).run();
   db.delete(basho).run();
 
-  db.insert(basho).values(seedData.basho).run();
+  db.insert(basho)
+    .values({
+      ...seedData.basho,
+      currentDay: seedData.basho.currentDay ?? null,
+    })
+    .run();
   db.insert(rikishi)
     .values([...seedData.rikishi])
     .run();

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -15,6 +15,11 @@ export type {
   TeamScore,
 } from "./types.js";
 export {
+  canEditFantasyPicks,
+  getBashoLifecycleLabel,
+  getPickLockMessage,
+} from "./lifecycle.js";
+export {
   calculateLeaderboard,
   compareLeaderboardEntries,
 } from "./leaderboard.js";

--- a/packages/domain/src/lifecycle.test.ts
+++ b/packages/domain/src/lifecycle.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import type { Basho } from "./types.js";
+import {
+  canEditFantasyPicks,
+  getBashoLifecycleLabel,
+  getPickLockMessage,
+} from "./lifecycle.js";
+
+const baseBasho: Basho = {
+  id: "2026-05",
+  name: "May 2026 Basho",
+  startDate: "2026-05-10",
+  endDate: "2026-05-24",
+  status: "upcoming",
+};
+
+describe("basho lifecycle", () => {
+  it("allows fantasy picks only while the basho is upcoming", () => {
+    expect(canEditFantasyPicks({ ...baseBasho, status: "upcoming" })).toBe(
+      true,
+    );
+    expect(canEditFantasyPicks({ ...baseBasho, status: "locked" })).toBe(false);
+    expect(canEditFantasyPicks({ ...baseBasho, status: "active" })).toBe(false);
+    expect(canEditFantasyPicks({ ...baseBasho, status: "complete" })).toBe(
+      false,
+    );
+  });
+
+  it("labels each lifecycle status for user-facing state", () => {
+    expect(getBashoLifecycleLabel("upcoming")).toBe("Picks open");
+    expect(getBashoLifecycleLabel("locked")).toBe("Picks locked");
+    expect(getBashoLifecycleLabel("active")).toBe("Scoring in progress");
+    expect(getBashoLifecycleLabel("complete")).toBe("Final scores");
+  });
+
+  it("explains why picks cannot be edited after lock", () => {
+    expect(getPickLockMessage({ ...baseBasho, status: "upcoming" })).toBe(
+      undefined,
+    );
+    expect(getPickLockMessage({ ...baseBasho, status: "locked" })).toBe(
+      "Picks are locked for this basho.",
+    );
+    expect(getPickLockMessage({ ...baseBasho, status: "active" })).toBe(
+      "This basho has started, so picks are locked.",
+    );
+    expect(getPickLockMessage({ ...baseBasho, status: "complete" })).toBe(
+      "This basho is complete, so picks are closed.",
+    );
+  });
+});

--- a/packages/domain/src/lifecycle.ts
+++ b/packages/domain/src/lifecycle.ts
@@ -1,0 +1,34 @@
+import type { Basho, BashoStatus } from "./types.js";
+
+export function canEditFantasyPicks(basho: Basho): boolean {
+  return basho.status === "upcoming";
+}
+
+export function getBashoLifecycleLabel(status: BashoStatus): string {
+  switch (status) {
+    case "upcoming":
+      return "Picks open";
+    case "locked":
+      return "Picks locked";
+    case "active":
+      return "Scoring in progress";
+    case "complete":
+      return "Final scores";
+  }
+}
+
+export function getPickLockMessage(basho: Basho): string | undefined {
+  if (canEditFantasyPicks(basho)) {
+    return undefined;
+  }
+
+  if (basho.status === "locked") {
+    return "Picks are locked for this basho.";
+  }
+
+  if (basho.status === "active") {
+    return "This basho has started, so picks are locked.";
+  }
+
+  return "This basho is complete, so picks are closed.";
+}

--- a/packages/domain/src/types.ts
+++ b/packages/domain/src/types.ts
@@ -1,4 +1,4 @@
-export type BashoStatus = "upcoming" | "active" | "complete";
+export type BashoStatus = "upcoming" | "locked" | "active" | "complete";
 
 export interface Basho {
   id: string;
@@ -6,6 +6,7 @@ export interface Basho {
   startDate: string;
   endDate: string;
   status: BashoStatus;
+  currentDay?: number;
 }
 
 export interface Rikishi {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,9 +63,6 @@ importers:
 
   apps/web:
     dependencies:
-      '@fantasy-sumo/domain':
-        specifier: workspace:*
-        version: link:../../packages/domain
       react:
         specifier: ^19.2.0
         version: 19.2.6


### PR DESCRIPTION
Summary
- Add basho lifecycle support for upcoming, locked, active and complete statuses, plus current day progress.
- Add domain lifecycle helpers and enforce pick locking in the API with 409 picks-locked responses outside upcoming basho.
- Add SQLite migration and Drizzle metadata for basho current_day, and update seed/import mapping.
- Update the React UI to show lifecycle state and disable team selection when picks are locked.
- Update docs and agent guidance for lifecycle and pick-locking rules.

Validation
- make check
- Browser smoke with DATABASE_URL=file:/private/tmp/fantasy-sumo-issue31-demo.sqlite make demo: verified demo active state shows Scoring in progress, Day 5, lock message, and disabled selection controls.
- Playwright E2E was not run because this repo still documents the strategy only and has no e2e target yet.

Closes #31