### PR TITLE
Add Playwright E2E harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ data/
 
 # Test coverage reports
 coverage/
+playwright-report/
+test-results/
 
 # OS files
 .DS_Store

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,6 @@
 node_modules
 dist
 coverage
+playwright-report
+test-results
 pnpm-lock.yaml

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ ifneq ($(PNPM_DIR),)
 export PATH := $(PNPM_DIR):$(PATH)
 endif
 
-.PHONY: help install dev demo dev-client dev-server build test lint format format-check check db-migrate db-seed db-seed-demo demo-reset demo-start demo-advance-day demo-complete import-banzuke import-results clean
+.PHONY: help install dev demo dev-client dev-server build test lint format format-check check e2e e2e-ui e2e-install db-migrate db-seed db-seed-demo demo-reset demo-start demo-advance-day demo-complete import-banzuke import-results clean
 
 help: ## Show available make targets.
 	@awk 'BEGIN {FS = ":.*## "; printf "Fantasy Sumo development commands:\n\n"} /^[a-zA-Z0-9_-]+:.*## / {printf "  %-14s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -49,6 +49,15 @@ check: ## Run the main pre-PR validation suite.
 	$(PNPM) format:check
 	$(PNPM) test
 	$(PNPM) build
+
+e2e: ## Run Playwright E2E tests against deterministic demo data.
+	$(PNPM) e2e
+
+e2e-ui: ## Open the Playwright UI runner.
+	$(PNPM) e2e:ui
+
+e2e-install: ## Install the Chromium browser used by Playwright.
+	$(PNPM) e2e:install
 
 db-migrate: ## Apply local database migrations.
 	$(PNPM) db:migrate

--- a/README.md
+++ b/README.md
@@ -97,6 +97,15 @@ Run both the API and web dev servers:
 make dev
 ```
 
+Run the browser E2E suite:
+
+```bash
+make e2e-install  # one-time Chromium install
+make e2e
+```
+
+The Playwright suite starts the Fastify API and Vite web app, resets deterministic demo data, and uses a dedicated SQLite database at `packages/db/data/e2e/fantasy-sumo-e2e.sqlite` by default. Override the test database with `E2E_DATABASE_URL=file:./data/e2e/another.sqlite`. Do not point E2E at the default developer database or production data.
+
 Local URLs:
 
 - Web: `http://localhost:7866`
@@ -203,6 +212,9 @@ Common targets:
 - `make lint` - run ESLint.
 - `make build` - build all packages/apps.
 - `make check` - run lint, format check, tests, and build before a PR.
+- `make e2e` - run Playwright against deterministic local demo data.
+- `make e2e-ui` - open the Playwright UI runner.
+- `make e2e-install` - install the Chromium browser used by the E2E suite.
 - `make import-banzuke` - import current banzuke data from source.
 - `make import-results` - import one day of results from source.
 

--- a/docs/E2E_TESTING.md
+++ b/docs/E2E_TESTING.md
@@ -122,7 +122,8 @@ When implemented, add scripts at the root so agents can run E2E consistently:
 {
   "scripts": {
     "e2e": "playwright test",
-    "e2e:ui": "playwright test --ui"
+    "e2e:ui": "playwright test --ui",
+    "e2e:install": "playwright install chromium"
   }
 }
 ```
@@ -135,9 +136,37 @@ e2e:
 
 e2e-ui:
 	$(PNPM) e2e:ui
+
+e2e-install:
+	$(PNPM) e2e:install
 ```
 
 Do not add E2E to `make check` until the suite is reliable and fast enough for routine PR validation. Before that, document it as an explicit pre-merge or feature-flow check.
+
+## Current Playwright Harness
+
+The initial harness for issue #23 lives in `e2e/` and is configured by `playwright.config.ts`.
+
+Run it with:
+
+```bash
+make e2e-install
+make e2e
+```
+
+The suite uses Chromium only for now, starts the local Fastify API and Vite web app, and runs with one worker because the tests reset shared deterministic demo data. By default it writes to a test-only SQLite file:
+
+```bash
+file:./data/e2e/fantasy-sumo-e2e.sqlite
+```
+
+That relative URL resolves inside `packages/db`, so it does not mutate the default developer database at `packages/db/data/fantasy-sumo.sqlite`. To use a different E2E database, set `E2E_DATABASE_URL`:
+
+```bash
+E2E_DATABASE_URL=file:./data/e2e/local-run.sqlite make e2e
+```
+
+Playwright uses ports `3000` for the API and `7866` for Vite. Stop any existing processes on those ports if the harness cannot start them. The protected demo admin controls are enabled with an E2E-only `DEMO_ADMIN_TOKEN` from the Playwright config; no live sumo data sources or production services are used.
 
 ## Agent Completion Loop
 

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,17 @@
+import { execFileSync } from "node:child_process";
+
+const databaseUrl =
+  process.env.E2E_DATABASE_URL ?? "file:./data/e2e/fantasy-sumo-e2e.sqlite";
+
+export default async function globalSetup() {
+  execFileSync("pnpm", ["--filter", "@fantasy-sumo/domain", "build"], {
+    stdio: "inherit",
+  });
+  execFileSync("pnpm", ["db:seed:demo"], {
+    env: {
+      ...process.env,
+      DATABASE_URL: databaseUrl,
+    },
+    stdio: "inherit",
+  });
+}

--- a/e2e/mvp-game-loop.spec.ts
+++ b/e2e/mvp-game-loop.spec.ts
@@ -1,0 +1,99 @@
+import { expect, test, type APIRequestContext } from "@playwright/test";
+
+const demoAdminToken =
+  process.env.DEMO_ADMIN_TOKEN ?? "playwright-demo-admin-token";
+const demoAdminHeaders = {
+  "x-demo-admin-token": demoAdminToken,
+};
+
+test.beforeEach(async ({ request }) => {
+  await resetDemo(request);
+});
+
+test("loads API-backed current basho content", async ({ page, request }) => {
+  const health = await request.get("/api/health");
+  await expect(health).toBeOK();
+
+  await page.goto("/");
+
+  await expect(
+    page.getByRole("heading", { name: "Demo May Basho" }),
+  ).toBeVisible();
+  await expect(page.getByText("0 of 2 selected")).toBeVisible();
+  await expect(page.getByRole("button", { name: /Onosato/ })).toBeVisible();
+});
+
+test("creates a fantasy team and shows it on the leaderboard", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  await page.getByLabel("Team name").fill("Codex Stable");
+  await page.getByRole("button", { name: /Onosato/ }).click();
+  await page.getByRole("button", { name: /Hoshoryu/ }).click();
+  await expect(page.getByText("Team full")).toBeVisible();
+
+  await page.getByRole("button", { name: "Submit team" }).click();
+
+  await expect(page.getByText("Codex Stable submitted.")).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: /Codex Stable.*0 pts/ }),
+  ).toBeVisible();
+});
+
+test("shows completed demo leaderboard entries in score order", async ({
+  page,
+  request,
+}) => {
+  const completeResponse = await request.post("/api/admin/demo/complete", {
+    headers: demoAdminHeaders,
+  });
+  await expect(completeResponse).toBeOK();
+
+  await page.goto("/");
+  await page.getByRole("button", { name: "Leaderboard" }).click();
+
+  const leaderboardRows = page.getByRole("button").filter({ hasText: /pts/ });
+  await expect(leaderboardRows).toHaveCount(4);
+
+  const rowTexts = await leaderboardRows.allTextContents();
+  const scores = rowTexts.map((text) => {
+    const match = /(\d+) pts/.exec(text);
+
+    expect(match).not.toBeNull();
+
+    return Number(match?.[1]);
+  });
+
+  expect(scores).toEqual([...scores].sort((left, right) => right - left));
+  await expect(page.getByText(/wins/).first()).toBeVisible();
+});
+
+test("prevents incomplete and overfull team submissions", async ({ page }) => {
+  await page.goto("/");
+
+  const submitButton = page.getByRole("button", { name: "Submit team" });
+  await expect(submitButton).toBeDisabled();
+
+  await page.getByLabel("Team name").fill("Validation Stable");
+  await page.getByRole("button", { name: /Onosato/ }).click();
+  await expect(page.getByText("1 pick left")).toBeVisible();
+  await expect(submitButton).toBeDisabled();
+
+  await page.getByRole("button", { name: /Hoshoryu/ }).click();
+  await expect(page.getByText("Team full")).toBeVisible();
+  await expect(submitButton).toBeEnabled();
+  await expect(page.getByRole("button", { name: /Kotozakura/ })).toBeDisabled();
+
+  await page.getByRole("button", { name: "Remove Hoshoryu" }).click();
+  await expect(page.getByRole("button", { name: /Kotozakura/ })).toBeEnabled();
+  await expect(submitButton).toBeDisabled();
+});
+
+async function resetDemo(request: APIRequestContext) {
+  const response = await request.post("/api/admin/demo/reset", {
+    headers: demoAdminHeaders,
+  });
+
+  await expect(response).toBeOK();
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "demo:complete": "pnpm --filter @fantasy-sumo/db demo:complete",
     "import:banzuke": "pnpm --filter @fantasy-sumo/api import:banzuke",
     "import:results": "pnpm --filter @fantasy-sumo/api import:results",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui",
+    "e2e:install": "playwright install chromium",
     "test": "pnpm --filter @fantasy-sumo/domain build && pnpm -r --if-present test",
     "lint": "eslint .",
     "format": "prettier --write .",
@@ -34,6 +37,7 @@
   "homepage": "https://github.com/Phugsy/fantasySumo#readme",
   "devDependencies": {
     "@eslint/js": "^9.39.1",
+    "@playwright/test": "^1.61.1",
     "concurrently": "^9.2.1",
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,54 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const e2eDatabaseUrl =
+  process.env.E2E_DATABASE_URL ?? "file:./data/e2e/fantasy-sumo-e2e.sqlite";
+const demoAdminToken =
+  process.env.DEMO_ADMIN_TOKEN ?? "playwright-demo-admin-token";
+
+process.env.E2E_DATABASE_URL = e2eDatabaseUrl;
+process.env.DEMO_ADMIN_TOKEN = demoAdminToken;
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: false,
+  workers: 1,
+  timeout: 30_000,
+  expect: {
+    timeout: 5_000,
+  },
+  globalSetup: "./e2e/global-setup.ts",
+  reporter: process.env.CI ? [["list"], ["html", { open: "never" }]] : "list",
+  use: {
+    baseURL: "http://127.0.0.1:7866",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: [
+    {
+      command:
+        "pnpm --filter @fantasy-sumo/domain build && pnpm --filter @fantasy-sumo/api dev",
+      env: {
+        ...process.env,
+        DATABASE_URL: e2eDatabaseUrl,
+        DEMO_ADMIN_TOKEN: demoAdminToken,
+      },
+      url: "http://127.0.0.1:3000/api/health",
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+    },
+    {
+      command: "pnpm --filter @fantasy-sumo/web dev",
+      env: {
+        ...process.env,
+      },
+      url: "http://127.0.0.1:7866",
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+    },
+  ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@eslint/js':
         specifier: ^9.39.1
         version: 9.39.4
+      '@playwright/test':
+        specifier: ^1.61.1
+        version: 1.61.1
       concurrently:
         specifier: ^9.2.1
         version: 9.2.1
@@ -831,6 +834,11 @@ packages:
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
 
@@ -1613,6 +1621,11 @@ packages:
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1889,6 +1902,16 @@ packages:
 
   pino@10.3.1:
     resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+    hasBin: true
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
     hasBin: true
 
   postcss@8.5.14:
@@ -2882,6 +2905,10 @@ snapshots:
 
   '@pinojs/redact@0.4.0': {}
 
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
+
   '@rolldown/pluginutils@1.0.0-rc.3': {}
 
   '@rollup/rollup-android-arm-eabi@4.60.3':
@@ -3658,6 +3685,9 @@ snapshots:
 
   fs-constants@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -3917,6 +3947,14 @@ snapshots:
       safe-stable-stringify: 2.5.0
       sonic-boom: 4.2.1
       thread-stream: 4.0.0
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.14:
     dependencies:


### PR DESCRIPTION
## Summary
- Add Playwright config and Chromium-only MVP game-loop tests for smoke/API content, team creation, leaderboard ordering, and validation controls.
- Reset deterministic demo data against an E2E-only SQLite database and start the Fastify API plus Vite web app from Playwright.
- Add pnpm and Makefile wrappers plus README/E2E docs for installing Chromium and running the suite.

Closes #23.

## Checks
- PASS: make e2e
- PASS: make check

## E2E Evidence
- PASS: make e2e (4 Chromium tests)
- One-time local browser setup was run with make e2e-install after the first run reported a missing Playwright Chromium cache.

## Docs
- Updated README.md and docs/E2E_TESTING.md with the E2E commands, dedicated SQLite database path, ports, and browser install notes.

## Notes
- The E2E database defaults to packages/db/data/e2e/fantasy-sumo-e2e.sqlite via E2E_DATABASE_URL=file:./data/e2e/fantasy-sumo-e2e.sqlite.
- E2E is intentionally not added to make check yet, matching the existing strategy doc.