### PR TITLE
Show basho status on leaderboard

### DIFF
--- a/apps/api/src/routes/basho.test.ts
+++ b/apps/api/src/routes/basho.test.ts
@@ -255,6 +255,16 @@ describe("basho routes", () => {
     });
 
     expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      basho: {
+        id: "2026-05",
+        name: "May 2026 Sample Basho",
+        status: "upcoming",
+        currentDay: 0,
+      },
+      bashoId: "2026-05",
+      totalDays: 15,
+    });
     expect(
       response
         .json()

--- a/apps/api/src/routes/basho.ts
+++ b/apps/api/src/routes/basho.ts
@@ -216,15 +216,33 @@ export function registerBashoRoutes(
       });
     }
 
+    const boutResults = await context.repositories.listBoutResultsForBasho(
+      basho.id,
+    );
+
     return {
+      basho,
       bashoId: basho.id,
+      totalDays: getBashoTotalDays(basho),
       leaderboard: calculateLeaderboard(
         await context.repositories.listFantasyTeamsForBasho(basho.id),
         await context.repositories.listFantasyPicksForBasho(basho.id),
-        await context.repositories.listBoutResultsForBasho(basho.id),
+        boutResults,
       ),
     };
   });
+}
+
+function getBashoTotalDays(basho: { startDate: string; endDate: string }) {
+  const startDate = Date.parse(`${basho.startDate}T00:00:00.000Z`);
+  const endDate = Date.parse(`${basho.endDate}T00:00:00.000Z`);
+
+  if (Number.isNaN(startDate) || Number.isNaN(endDate) || endDate < startDate) {
+    return undefined;
+  }
+
+  const millisecondsPerDay = 24 * 60 * 60 * 1000;
+  return Math.floor((endDate - startDate) / millisecondsPerDay) + 1;
 }
 
 async function findCurrentBasho(repositories: Repositories) {

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -135,7 +135,9 @@ describe("App", () => {
       screen.getByText("Leaderboard unavailable right now."),
     ).toBeInTheDocument();
     expect(
-      screen.getByText("No teams have joined this basho yet."),
+      screen.getByText(
+        "No teams have joined this basho yet. Picks are still open.",
+      ),
     ).toBeInTheDocument();
   });
 
@@ -156,10 +158,7 @@ describe("App", () => {
     ).not.toBeInTheDocument();
 
     leaderboardRequest.resolve(
-      createJsonResponse({
-        bashoId: currentBasho.id,
-        leaderboard,
-      }),
+      createJsonResponse(createLeaderboardResponse({ entries: leaderboard })),
     );
   });
 
@@ -182,10 +181,7 @@ describe("App", () => {
     expect(await screen.findByText("4 pts")).toBeInTheDocument();
 
     initialLeaderboardRequest.resolve(
-      createJsonResponse({
-        bashoId: currentBasho.id,
-        leaderboard,
-      }),
+      createJsonResponse(createLeaderboardResponse({ entries: leaderboard })),
     );
     await initialLeaderboardRequest.promise;
     await flushPromises();
@@ -316,8 +312,32 @@ describe("App", () => {
     fireEvent.click(screen.getByRole("button", { name: "Leaderboard" }));
 
     expect(
-      screen.getByText("No teams have joined this basho yet."),
+      screen.getByText(
+        "No teams have joined this basho yet. Picks are still open.",
+      ),
     ).toBeInTheDocument();
+  });
+
+  it("uses leaderboard metadata to show the simulated basho day", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) =>
+        mockSuccessfulFetch(input, {
+          ...currentBasho,
+          status: "active",
+          currentDay: 1,
+        }),
+      ),
+    );
+    render(<App />);
+
+    await screen.findByRole("button", { name: "Leaderboard" });
+    fireEvent.click(screen.getByRole("button", { name: "Leaderboard" }));
+
+    expect(
+      screen.getByText("May 2026 Sample Basho - Day 1 of 15"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Status: Scoring in progress")).toBeInTheDocument();
   });
 });
 
@@ -339,10 +359,12 @@ function mockSuccessfulFetch(
   }
 
   if (url === "/api/basho/2026-05/leaderboard") {
-    return jsonResponse({
-      bashoId: currentBasho.id,
-      leaderboard,
-    });
+    return jsonResponse(
+      createLeaderboardResponse({
+        basho,
+        entries: leaderboard,
+      }),
+    );
   }
 
   if (url === "/api/basho/2026-05/teams") {
@@ -370,10 +392,7 @@ function mockEmptyLeaderboardFetch(
     return mockSuccessfulFetch(input);
   }
 
-  return jsonResponse({
-    bashoId: currentBasho.id,
-    leaderboard: [],
-  });
+  return jsonResponse(createLeaderboardResponse({ entries: [] }));
 }
 
 function mockInitialLeaderboardErrorFetch(
@@ -425,29 +444,52 @@ function mockStaleInitialLeaderboardFetch(
       return initialLeaderboardRequest.promise;
     }
 
-    return jsonResponse({
-      bashoId: currentBasho.id,
-      leaderboard: [
-        {
-          rank: 1,
-          teamId: "team-east-stand",
-          displayName: "East Stand Heroes",
-          score: 4,
-          rikishiScores: [
-            {
-              rikishiId: "onosato",
-              wins: 2,
-              score: 2,
-            },
-            {
-              rikishiId: "kotozakura",
-              wins: 2,
-              score: 2,
-            },
-          ],
-        },
-      ],
-    });
+    return jsonResponse(
+      createLeaderboardResponse({
+        entries: [
+          {
+            rank: 1,
+            teamId: "team-east-stand",
+            displayName: "East Stand Heroes",
+            score: 4,
+            rikishiScores: [
+              {
+                rikishiId: "onosato",
+                wins: 2,
+                score: 2,
+              },
+              {
+                rikishiId: "kotozakura",
+                wins: 2,
+                score: 2,
+              },
+            ],
+          },
+        ],
+      }),
+    );
+  };
+}
+
+function createLeaderboardResponse({
+  basho = currentBasho,
+  entries = leaderboard,
+}: {
+  basho?: typeof currentBasho;
+  entries?: typeof leaderboard;
+} = {}) {
+  return {
+    basho: {
+      id: basho.id,
+      name: basho.name,
+      startDate: basho.startDate,
+      endDate: basho.endDate,
+      status: basho.status,
+      currentDay: basho.currentDay,
+    },
+    bashoId: basho.id,
+    totalDays: 15,
+    leaderboard: entries,
   };
 }
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -29,6 +29,9 @@ export function App() {
   const [basho, setBasho] = useState<Basho | null>(null);
   const [rikishi, setRikishi] = useState<RankedRikishi[]>([]);
   const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[]>([]);
+  const [leaderboardTotalDays, setLeaderboardTotalDays] = useState<
+    number | undefined
+  >(undefined);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [expandedTeamId, setExpandedTeamId] = useState<string | null>(null);
   const [activeView, setActiveView] = useState<ActiveView>("selection");
@@ -77,6 +80,10 @@ export function App() {
             return;
           }
 
+          setBasho((current) =>
+            mergeLeaderboardBasho(current, leaderboardResponse),
+          );
+          setLeaderboardTotalDays(leaderboardResponse.totalDays);
           setLeaderboard(leaderboardResponse.leaderboard);
           setExpandedTeamId(leaderboardResponse.leaderboard[0]?.teamId ?? null);
           setLeaderboardErrorMessage(null);
@@ -179,6 +186,10 @@ export function App() {
           return;
         }
 
+        setBasho((current) =>
+          mergeLeaderboardBasho(current, leaderboardResponse),
+        );
+        setLeaderboardTotalDays(leaderboardResponse.totalDays);
         setLeaderboard(leaderboardResponse.leaderboard);
         setExpandedTeamId(getExpandedTeamId(leaderboardResponse, response));
         setLeaderboardLoadState("ready");
@@ -253,6 +264,7 @@ export function App() {
 
           {activeView === "leaderboard" && (
             <LeaderboardPanel
+              basho={basho}
               createdTeam={createdTeam}
               errorMessage={leaderboardErrorMessage}
               expandedTeamId={expandedTeamId}
@@ -262,12 +274,23 @@ export function App() {
                 setExpandedTeamId(expandedTeamId === teamId ? null : teamId)
               }
               rikishi={rikishi}
+              totalDays={leaderboardTotalDays}
             />
           )}
         </>
       )}
     </main>
   );
+}
+
+function mergeLeaderboardBasho(
+  currentBasho: Basho | null,
+  leaderboardResponse: LeaderboardResponse,
+): Basho {
+  return {
+    ...leaderboardResponse.basho,
+    teamSize: currentBasho?.teamSize ?? 0,
+  };
 }
 
 function getExpandedTeamId(

--- a/apps/web/src/components/LeaderboardPanel.test.tsx
+++ b/apps/web/src/components/LeaderboardPanel.test.tsx
@@ -1,7 +1,17 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { LeaderboardPanel } from "./LeaderboardPanel";
-import type { LeaderboardEntry, RankedRikishi } from "../types";
+import type { Basho, LeaderboardEntry, RankedRikishi } from "../types";
+
+const basho: Basho = {
+  id: "2026-05",
+  name: "Demo May Basho",
+  startDate: "2026-05-10",
+  endDate: "2026-05-24",
+  status: "active",
+  currentDay: 4,
+  teamSize: 2,
+};
 
 const rikishi: RankedRikishi[] = [
   {
@@ -45,6 +55,7 @@ describe("LeaderboardPanel", () => {
   it("shows expanded rikishi score details for the selected team", () => {
     render(
       <LeaderboardPanel
+        basho={basho}
         createdTeam={null}
         errorMessage={null}
         expandedTeamId="team-east"
@@ -52,9 +63,14 @@ describe("LeaderboardPanel", () => {
         loadState="ready"
         onToggleTeam={vi.fn()}
         rikishi={rikishi}
+        totalDays={15}
       />,
     );
 
+    expect(
+      screen.getByText("Demo May Basho - Day 4 of 15"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Status: Scoring in progress")).toBeInTheDocument();
     expect(screen.getByText("East Side")).toBeInTheDocument();
     expect(screen.getByText("Onosato")).toBeInTheDocument();
     expect(screen.getByText("Kirishima")).toBeInTheDocument();
@@ -66,6 +82,7 @@ describe("LeaderboardPanel", () => {
 
     render(
       <LeaderboardPanel
+        basho={basho}
         createdTeam={null}
         errorMessage={null}
         expandedTeamId={null}
@@ -73,6 +90,7 @@ describe("LeaderboardPanel", () => {
         loadState="ready"
         onToggleTeam={onToggleTeam}
         rikishi={rikishi}
+        totalDays={15}
       />,
     );
 
@@ -84,6 +102,7 @@ describe("LeaderboardPanel", () => {
   it("shows a loading state before leaderboard data settles", () => {
     render(
       <LeaderboardPanel
+        basho={basho}
         createdTeam={null}
         errorMessage={null}
         expandedTeamId={null}
@@ -91,6 +110,7 @@ describe("LeaderboardPanel", () => {
         loadState="loading"
         onToggleTeam={vi.fn()}
         rikishi={rikishi}
+        totalDays={15}
       />,
     );
 
@@ -98,5 +118,53 @@ describe("LeaderboardPanel", () => {
     expect(
       screen.queryByText("No teams have joined this basho yet."),
     ).not.toBeInTheDocument();
+  });
+
+  it("shows locked pre-scoring context when teams exist but day one is unscored", () => {
+    render(
+      <LeaderboardPanel
+        basho={{ ...basho, status: "locked", currentDay: 0 }}
+        createdTeam={null}
+        errorMessage={null}
+        expandedTeamId={null}
+        leaderboard={[{ ...leaderboard[0]!, score: 0 }]}
+        loadState="ready"
+        onToggleTeam={vi.fn()}
+        rikishi={rikishi}
+        totalDays={15}
+      />,
+    );
+
+    expect(
+      screen.getByText("Demo May Basho - Picks locked, starts soon"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Status: Picks locked")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Picks are locked. Day 1 results have not been scored yet.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("East Side")).toBeInTheDocument();
+  });
+
+  it("shows final leaderboard wording for a complete basho", () => {
+    render(
+      <LeaderboardPanel
+        basho={{ ...basho, status: "complete", currentDay: 15 }}
+        createdTeam={null}
+        errorMessage={null}
+        expandedTeamId={null}
+        leaderboard={leaderboard}
+        loadState="ready"
+        onToggleTeam={vi.fn()}
+        rikishi={rikishi}
+        totalDays={15}
+      />,
+    );
+
+    expect(
+      screen.getByText("Demo May Basho - Complete, final leaderboard"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Status: Final scores")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/LeaderboardPanel.tsx
+++ b/apps/web/src/components/LeaderboardPanel.tsx
@@ -1,12 +1,15 @@
 import { useMemo } from "react";
 import type {
+  Basho,
   CreatedTeamResponse,
   LeaderboardEntry,
   LeaderboardLoadState,
   RankedRikishi,
 } from "../types";
+import { getBashoLifecycleLabel } from "../lifecycle";
 
 interface LeaderboardPanelProps {
+  basho: Basho;
   createdTeam: CreatedTeamResponse | null;
   errorMessage: string | null;
   expandedTeamId: string | null;
@@ -14,9 +17,11 @@ interface LeaderboardPanelProps {
   loadState: LeaderboardLoadState;
   onToggleTeam: (teamId: string) => void;
   rikishi: RankedRikishi[];
+  totalDays?: number;
 }
 
 export function LeaderboardPanel({
+  basho,
   createdTeam,
   errorMessage,
   expandedTeamId,
@@ -24,6 +29,7 @@ export function LeaderboardPanel({
   loadState,
   onToggleTeam,
   rikishi,
+  totalDays,
 }: LeaderboardPanelProps) {
   const rikishiById = useMemo(
     () => new Map(rikishi.map((entry) => [entry.id, entry])),
@@ -44,6 +50,10 @@ export function LeaderboardPanel({
       <div className="section-heading">
         <p className="eyebrow">Standings</p>
         <h2 id="standings-title">Leaderboard</h2>
+      </div>
+      <div className="leaderboard-context" aria-label="Basho status">
+        <strong>{formatBashoHeadline(basho, totalDays)}</strong>
+        <span>{getLeaderboardStatusCopy(basho)}</span>
       </div>
 
       {errorMessage !== null && (
@@ -67,67 +77,171 @@ export function LeaderboardPanel({
         </div>
       ) : leaderboard.length === 0 ? (
         <div className="state-panel leaderboard-empty">
-          No teams have joined this basho yet.
+          {getEmptyLeaderboardMessage(basho)}
         </div>
-      ) : (
-        <ol className="leaderboard-list">
-          {leaderboard.map((entry) => {
-            const isTied = (tiedScoreCounts.get(entry.score) ?? 0) > 1;
-            const isExpanded = expandedTeamId === entry.teamId;
-
-            return (
-              <li className="leaderboard-entry" key={entry.teamId}>
-                <button
-                  type="button"
-                  className="leaderboard-summary"
-                  onClick={() => onToggleTeam(entry.teamId)}
-                  aria-expanded={isExpanded}
-                >
-                  <span className="leaderboard-rank">#{entry.rank}</span>
-                  <span className="leaderboard-team">
-                    <strong>{entry.displayName}</strong>
-                    {isTied && <small>Tied on score</small>}
-                  </span>
-                  <span className="leaderboard-score">{entry.score} pts</span>
-                </button>
-
-                {isExpanded && (
-                  <div className="score-breakdown">
-                    {entry.rikishiScores.length === 0 ? (
-                      <p>No picks recorded for this team.</p>
-                    ) : (
-                      <ul>
-                        {entry.rikishiScores.map((score) => {
-                          const pickedRikishi = rikishiById.get(
-                            score.rikishiId,
-                          );
-
-                          return (
-                            <li key={score.rikishiId}>
-                              <span>
-                                <strong>
-                                  {pickedRikishi?.shikona ?? score.rikishiId}
-                                </strong>
-                                <small>
-                                  {pickedRikishi?.rank ?? "Unranked pick"}
-                                </small>
-                              </span>
-                              <span>
-                                {score.wins} win{score.wins === 1 ? "" : "s"}
-                              </span>
-                              <span>{score.score} pts</span>
-                            </li>
-                          );
-                        })}
-                      </ul>
-                    )}
-                  </div>
-                )}
-              </li>
-            );
+      ) : isPreScoringLeaderboard(basho, leaderboard) ? (
+        <>
+          <div className="state-panel leaderboard-empty">
+            {getEmptyScoringMessage(basho)}
+          </div>
+          {renderLeaderboardList({
+            expandedTeamId,
+            leaderboard,
+            onToggleTeam,
+            rikishiById,
+            tiedScoreCounts,
           })}
-        </ol>
+        </>
+      ) : (
+        renderLeaderboardList({
+          expandedTeamId,
+          leaderboard,
+          onToggleTeam,
+          rikishiById,
+          tiedScoreCounts,
+        })
       )}
     </section>
+  );
+}
+
+function renderLeaderboardList({
+  expandedTeamId,
+  leaderboard,
+  onToggleTeam,
+  rikishiById,
+  tiedScoreCounts,
+}: {
+  expandedTeamId: string | null;
+  leaderboard: LeaderboardEntry[];
+  onToggleTeam: (teamId: string) => void;
+  rikishiById: Map<string, RankedRikishi>;
+  tiedScoreCounts: Map<number, number>;
+}) {
+  return (
+    <ol className="leaderboard-list">
+      {leaderboard.map((entry) => {
+        const isTied = (tiedScoreCounts.get(entry.score) ?? 0) > 1;
+        const isExpanded = expandedTeamId === entry.teamId;
+
+        return (
+          <li className="leaderboard-entry" key={entry.teamId}>
+            <button
+              type="button"
+              className="leaderboard-summary"
+              onClick={() => onToggleTeam(entry.teamId)}
+              aria-expanded={isExpanded}
+            >
+              <span className="leaderboard-rank">#{entry.rank}</span>
+              <span className="leaderboard-team">
+                <strong>{entry.displayName}</strong>
+                {isTied && <small>Tied on score</small>}
+              </span>
+              <span className="leaderboard-score">{entry.score} pts</span>
+            </button>
+
+            {isExpanded && (
+              <div className="score-breakdown">
+                {entry.rikishiScores.length === 0 ? (
+                  <p>No picks recorded for this team.</p>
+                ) : (
+                  <ul>
+                    {entry.rikishiScores.map((score) => {
+                      const pickedRikishi = rikishiById.get(score.rikishiId);
+
+                      return (
+                        <li key={score.rikishiId}>
+                          <span>
+                            <strong>
+                              {pickedRikishi?.shikona ?? score.rikishiId}
+                            </strong>
+                            <small>
+                              {pickedRikishi?.rank ?? "Unranked pick"}
+                            </small>
+                          </span>
+                          <span>
+                            {score.wins} win{score.wins === 1 ? "" : "s"}
+                          </span>
+                          <span>{score.score} pts</span>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                )}
+              </div>
+            )}
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+function formatBashoHeadline(basho: Basho, totalDays?: number): string {
+  const dayCopy = formatDayCopy(basho.currentDay, totalDays);
+
+  if (basho.status === "locked") {
+    return `${basho.name} - Picks locked, starts soon`;
+  }
+
+  if (basho.status === "complete") {
+    return `${basho.name} - Complete, final leaderboard`;
+  }
+
+  return dayCopy === undefined ? basho.name : `${basho.name} - ${dayCopy}`;
+}
+
+function formatDayCopy(
+  currentDay?: number,
+  totalDays?: number,
+): string | undefined {
+  if (currentDay === undefined || currentDay <= 0) {
+    return undefined;
+  }
+
+  if (totalDays === undefined) {
+    return `Day ${currentDay}`;
+  }
+
+  return `Day ${currentDay} of ${totalDays}`;
+}
+
+function getLeaderboardStatusCopy(basho: Basho): string {
+  return `Status: ${getBashoLifecycleLabel(basho.status)}`;
+}
+
+function getEmptyLeaderboardMessage(basho: Basho): string {
+  if (basho.status === "upcoming") {
+    return "No teams have joined this basho yet. Picks are still open.";
+  }
+
+  if (basho.status === "locked") {
+    return "No teams joined before picks locked.";
+  }
+
+  return "No teams are available for this leaderboard.";
+}
+
+function getEmptyScoringMessage(basho: Basho): string {
+  if (basho.status === "locked") {
+    return "Picks are locked. Day 1 results have not been scored yet.";
+  }
+
+  if (basho.status === "active") {
+    return "This basho is active, but no results have been scored yet.";
+  }
+
+  return "Scores will appear once results are imported.";
+}
+
+function isPreScoringLeaderboard(
+  basho: Basho,
+  leaderboard: LeaderboardEntry[],
+): boolean {
+  return (
+    leaderboard.length > 0 &&
+    (basho.currentDay ?? 0) === 0 &&
+    leaderboard.every((entry) => entry.score === 0) &&
+    (basho.status === "locked" || basho.status === "active")
   );
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -362,6 +362,23 @@ input:focus,
   background: #fffaf2;
 }
 
+.leaderboard-context {
+  display: grid;
+  gap: 4px;
+  margin: -4px 0 18px;
+  padding: 12px;
+  border: 1px solid #d9d0c2;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #1f2b31;
+}
+
+.leaderboard-context span {
+  color: #60717a;
+  font-size: 0.9rem;
+  font-weight: 800;
+}
+
 .leaderboard-empty {
   border-style: dashed;
   background: transparent;

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -32,7 +32,9 @@ export interface CreatedTeamResponse {
 }
 
 export interface LeaderboardResponse {
+  basho: Omit<Basho, "teamSize">;
   bashoId: string;
+  totalDays?: number;
   leaderboard: LeaderboardEntry[];
 }
 


### PR DESCRIPTION
Closes #33.

## Summary
- add basho metadata and inclusive total day count to the leaderboard API response
- show basho name, status, day context, pre-scoring copy, and final-leaderboard wording in the leaderboard UI
- keep leaderboard metadata synced from the API so demo/current-day progression is reflected in the web app

## Checks
- PASS: make check
- E2E: skipped on this branch because origin/master currently has E2E strategy docs but no Playwright harness or make e2e target; I did not include the separate issue #23 harness commit in this PR.

## Docs
- No docs changed; this is a focused API/UI context-display update.