### PR TITLE
Handle cross-division result imports

### DIFF
--- a/apps/api/src/imports/adapters.test.ts
+++ b/apps/api/src/imports/adapters.test.ts
@@ -129,6 +129,16 @@ describe("source import adapters", () => {
     expect(command).toEqual({
       source: "sumo-api-results",
       bashoId: "2026-05",
+      rikishi: [
+        {
+          id: "onosato",
+          shikona: "Onosato",
+        },
+        {
+          id: "kotozakura",
+          shikona: "Kotozakura",
+        },
+      ],
       results: [
         {
           id: "2026-05-day-1-match-1",

--- a/apps/api/src/imports/adapters.ts
+++ b/apps/api/src/imports/adapters.ts
@@ -130,10 +130,18 @@ export function mapSumoApiTorikumiPayload(
   payload: SumoApiTorikumiPayload,
   options: { bashoId: string; day: number },
 ): BoutResultsImportCommand {
+  const rows = payload.torikumi ?? [];
+
   return {
     source: "sumo-api-results",
     bashoId: options.bashoId,
-    results: (payload.torikumi ?? []).map((row, index) => {
+    rikishi: uniqueRikishi(
+      rows.flatMap((row) => [
+        toSourceRikishi(requiredString(row.eastShikona, "eastShikona")),
+        toSourceRikishi(requiredString(row.westShikona, "westShikona")),
+      ]),
+    ),
+    results: rows.map((row, index) => {
       const matchNo = row.matchNo ?? index + 1;
       const eastId = row.eastId;
       const westId = row.westId;
@@ -160,6 +168,23 @@ export function mapSumoApiTorikumiPayload(
       };
     }),
   };
+}
+
+function toSourceRikishi(shikona: string) {
+  return {
+    id: toLocalRikishiId(shikona),
+    shikona,
+  };
+}
+
+function uniqueRikishi(rikishi: ReturnType<typeof toSourceRikishi>[]) {
+  const byId = new Map<string, ReturnType<typeof toSourceRikishi>>();
+
+  for (const entry of rikishi) {
+    byId.set(entry.id, entry);
+  }
+
+  return [...byId.values()];
 }
 
 async function fetchJson<T>(fetchFn: SourceFetch, url: string): Promise<T> {

--- a/apps/api/src/imports/service.test.ts
+++ b/apps/api/src/imports/service.test.ts
@@ -180,6 +180,76 @@ describe("import service", () => {
     });
   });
 
+  it("imports source-provided cross-division opponents without adding them to the banzuke", async () => {
+    const repositories = createRepositories(client);
+    await importBanzuke(repositories, banzukeCommand);
+
+    const result = await importBoutResults(repositories, {
+      source: "test",
+      bashoId: "2026-05",
+      rikishi: [
+        {
+          id: "onosato",
+          shikona: "Onosato",
+          heya: "Nishonoseki",
+        },
+        {
+          id: "juryo-visitor",
+          shikona: "Juryo Visitor",
+        },
+      ],
+      results: [
+        {
+          id: "2026-05-day-1-match-1",
+          bashoId: "2026-05",
+          day: 1,
+          winnerRikishiId: "onosato",
+          loserRikishiId: "juryo-visitor",
+        },
+      ],
+    });
+
+    expect(result.summary.rikishi.created).toBe(1);
+    expect(await repositories.listBoutResultsForBasho("2026-05")).toHaveLength(
+      1,
+    );
+    expect(
+      await repositories.listBanzukeEntriesForBasho("2026-05"),
+    ).toHaveLength(2);
+  });
+
+  it("rejects source-provided results with no target banzuke rikishi", async () => {
+    const repositories = createRepositories(client);
+    await importBanzuke(repositories, banzukeCommand);
+
+    await expect(
+      importBoutResults(repositories, {
+        source: "test",
+        bashoId: "2026-05",
+        rikishi: [
+          {
+            id: "juryo-winner",
+            shikona: "Juryo Winner",
+          },
+          {
+            id: "juryo-loser",
+            shikona: "Juryo Loser",
+          },
+        ],
+        results: [
+          {
+            id: "2026-05-day-1-match-1",
+            bashoId: "2026-05",
+            day: 1,
+            winnerRikishiId: "juryo-winner",
+            loserRikishiId: "juryo-loser",
+          },
+        ],
+      }),
+    ).rejects.toThrow(ImportValidationError);
+    expect(await repositories.listBoutResultsForBasho("2026-05")).toEqual([]);
+  });
+
   it("reports basho lifecycle updates during result import dry runs", async () => {
     const repositories = createRepositories(client);
     await importBanzuke(repositories, {

--- a/apps/api/src/imports/service.test.ts
+++ b/apps/api/src/imports/service.test.ts
@@ -191,7 +191,6 @@ describe("import service", () => {
         {
           id: "onosato",
           shikona: "Onosato",
-          heya: "Nishonoseki",
         },
         {
           id: "juryo-visitor",
@@ -216,6 +215,15 @@ describe("import service", () => {
     expect(
       await repositories.listBanzukeEntriesForBasho("2026-05"),
     ).toHaveLength(2);
+    expect(
+      (await repositories.listRikishi()).find(
+        (rikishi) => rikishi.id === "onosato",
+      ),
+    ).toMatchObject({
+      id: "onosato",
+      shikona: "Onosato",
+      heya: "Nishonoseki",
+    });
   });
 
   it("rejects source-provided results with no target banzuke rikishi", async () => {

--- a/apps/api/src/imports/service.ts
+++ b/apps/api/src/imports/service.ts
@@ -82,6 +82,13 @@ export async function importBoutResults(
 
   const summary = createEmptySummary();
   const existingBasho = await repositories.getBasho(command.bashoId);
+  const existingRikishi = await repositories.listRikishi();
+  const existingRikishiIds = new Set(
+    existingRikishi.map((rikishi) => rikishi.id),
+  );
+  const missingSourceRikishi = (command.rikishi ?? []).filter(
+    (rikishi) => !existingRikishiIds.has(rikishi.id),
+  );
   const nextBasho =
     existingBasho === undefined
       ? undefined
@@ -100,8 +107,8 @@ export async function importBoutResults(
     { countDeleted: true },
   );
   summary.rikishi = summarizeMany(
-    await repositories.listRikishi(),
-    command.rikishi ?? [],
+    existingRikishi,
+    missingSourceRikishi,
     isEqualRikishi,
   );
 
@@ -113,7 +120,7 @@ export async function importBoutResults(
     await repositories.applyBoutResultsImport({
       bashoId: command.bashoId,
       day: command.results[0]!.day,
-      rikishi: command.rikishi,
+      rikishi: missingSourceRikishi,
       results: command.results,
     });
   }

--- a/apps/api/src/imports/service.ts
+++ b/apps/api/src/imports/service.ts
@@ -99,6 +99,11 @@ export async function importBoutResults(
     isEqualBoutResult,
     { countDeleted: true },
   );
+  summary.rikishi = summarizeMany(
+    await repositories.listRikishi(),
+    command.rikishi ?? [],
+    isEqualRikishi,
+  );
 
   if (options.dryRun !== true) {
     if (nextBasho !== undefined) {
@@ -108,6 +113,7 @@ export async function importBoutResults(
     await repositories.applyBoutResultsImport({
       bashoId: command.bashoId,
       day: command.results[0]!.day,
+      rikishi: command.rikishi,
       results: command.results,
     });
   }
@@ -181,6 +187,12 @@ async function validateBoutResultsImport(
   const rikishiIds = new Set(
     (await repositories.listRikishi()).map((rikishi) => rikishi.id),
   );
+  const importedRikishiIds = new Set(
+    (command.rikishi ?? []).map((rikishi) => rikishi.id),
+  );
+  for (const rikishiId of importedRikishiIds) {
+    rikishiIds.add(rikishiId);
+  }
   const banzukeRikishiIds = new Set(
     (await repositories.listBanzukeEntriesForBasho(command.bashoId)).map(
       (entry) => entry.rikishiId,
@@ -231,6 +243,10 @@ async function validateBoutResultsImport(
       });
     }
 
+    const hasBanzukeRikishi =
+      banzukeRikishiIds.has(result.winnerRikishiId) ||
+      banzukeRikishiIds.has(result.loserRikishiId);
+
     for (const field of ["winnerRikishiId", "loserRikishiId"] as const) {
       const rikishiId = result[field];
 
@@ -239,14 +255,25 @@ async function validateBoutResultsImport(
           path: `results.${index}.${field}`,
           message: `Rikishi ${rikishiId} does not exist.`,
         });
-      } else if (!banzukeRikishiIds.has(rikishiId)) {
+      } else if (
+        !banzukeRikishiIds.has(rikishiId) &&
+        !importedRikishiIds.has(rikishiId)
+      ) {
         // Results must belong to rikishi on this basho's banzuke, not just
-        // any known rikishi from another tournament.
+        // any known rikishi from another tournament. Source-provided rikishi
+        // are allowed for cross-division bouts against the target banzuke.
         issues.push({
           path: `results.${index}.${field}`,
           message: `Rikishi ${rikishiId} is not on the basho banzuke.`,
         });
       }
+    }
+
+    if (!hasBanzukeRikishi) {
+      issues.push({
+        path: `results.${index}`,
+        message: "At least one rikishi must be on the basho banzuke.",
+      });
     }
 
     if (resultIds.has(result.id)) {

--- a/apps/api/src/imports/types.ts
+++ b/apps/api/src/imports/types.ts
@@ -30,6 +30,7 @@ export interface BanzukeImportCommand {
 
 export interface BoutResultsImportCommand {
   bashoId: Basho["id"];
+  rikishi?: Rikishi[];
   results: BoutResult[];
   source: string;
 }

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -306,10 +306,7 @@ function createSqliteRepositories(db: SqliteDatabase): Repositories {
           transaction
             .insert(sqlite.rikishi)
             .values(toRikishiRow(entry))
-            .onConflictDoUpdate({
-              target: sqlite.rikishi.id,
-              set: toRikishiRow(entry),
-            })
+            .onConflictDoNothing({ target: sqlite.rikishi.id })
             .run();
         }
 
@@ -556,10 +553,7 @@ function createPostgresRepositories(db: PostgresDatabase): Repositories {
           await transaction
             .insert(pg.rikishi)
             .values(toRikishiRow(entry))
-            .onConflictDoUpdate({
-              target: pg.rikishi.id,
-              set: toRikishiRow(entry),
-            });
+            .onConflictDoNothing({ target: pg.rikishi.id });
         }
 
         for (const entry of importData.results) {

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -24,6 +24,7 @@ export interface BanzukeImportData {
 export interface BoutResultsImportData {
   bashoId: Basho["id"];
   day: BoutResult["day"];
+  rikishi?: readonly Rikishi[];
   results: readonly BoutResult[];
 }
 
@@ -301,6 +302,17 @@ function createSqliteRepositories(db: SqliteDatabase): Repositories {
     },
     applyBoutResultsImport: async (importData) => {
       db.transaction((transaction) => {
+        for (const entry of importData.rikishi ?? []) {
+          transaction
+            .insert(sqlite.rikishi)
+            .values(toRikishiRow(entry))
+            .onConflictDoUpdate({
+              target: sqlite.rikishi.id,
+              set: toRikishiRow(entry),
+            })
+            .run();
+        }
+
         for (const entry of importData.results) {
           transaction
             .insert(sqlite.boutResults)
@@ -540,6 +552,16 @@ function createPostgresRepositories(db: PostgresDatabase): Repositories {
     },
     applyBoutResultsImport: async (importData) => {
       await db.transaction(async (transaction) => {
+        for (const entry of importData.rikishi ?? []) {
+          await transaction
+            .insert(pg.rikishi)
+            .values(toRikishiRow(entry))
+            .onConflictDoUpdate({
+              target: pg.rikishi.id,
+              set: toRikishiRow(entry),
+            });
+        }
+
         for (const entry of importData.results) {
           await transaction
             .insert(pg.boutResults)


### PR DESCRIPTION
## Summary

Fixes daily result imports for top-division bouts where one side is a non-Makuuchi crossover opponent.

The Sumo API result adapter now includes source-provided bout participants in the import command. The import service upserts those rikishi before writing bout results, so foreign keys remain valid, but it does not add crossover opponents to the basho banzuke. That keeps pick eligibility tied to the imported Makuuchi banzuke while allowing Makuuchi-vs-Juryo results to score normally.

Validation still rejects result rows where neither wrestler belongs to the target basho banzuke, so a bad fully off-division row cannot be imported silently.

## Validation

- `pnpm --filter @fantasy-sumo/api test -- imports`
- `make check`