### PR TITLE
Schedule daily result imports for active bashos

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ DATABASE_URL=file:./data/fantasy-sumo.sqlite
 TEAM_SIZE=2
 DEMO_ADMIN_TOKEN=
 ADMIN_IMPORT_TOKEN=
+CRON_SECRET=

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Useful API endpoints:
 - `POST /api/admin/demo/complete`
 - `POST /api/admin/import-banzuke`
 - `POST /api/admin/basho/:bashoId/import-results`
+- `GET /api/cron/import-results`
 
 The demo admin endpoints require `DEMO_ADMIN_TOKEN` and an `x-demo-admin-token` header. They reset and mutate demo data, so do not expose them without that protection.
 
@@ -156,6 +157,7 @@ Use a `postgres:` or `postgresql:` `DATABASE_URL` for managed production persist
 
 The local team size defaults to `2`. Override it for the API with `TEAM_SIZE`.
 Set `DEMO_ADMIN_TOKEN` to enable protected demo admin API controls.
+Set `CRON_SECRET` in production to authenticate Vercel's scheduled results import.
 
 ## Data import
 
@@ -191,6 +193,12 @@ curl -X POST "http://localhost:3000/api/admin/basho/2026-05/import-results?dryRu
   -H "content-type: application/json" \
   -d '{"day":1,"division":"Makuuchi"}'
 ```
+
+Production deployments also expose a Vercel Cron-only
+`GET /api/cron/import-results` path. It selects the single active live basho,
+derives the current basho day in Japan time, and reuses the same transactional
+result import service as the manual trigger. See `docs/DEPLOYMENT.md` for the
+schedule and authentication details.
 
 ## Makefile commands
 
@@ -228,4 +236,4 @@ For Vercel deployment prep and the managed Postgres production path, see `docs/D
 
 1. Persist or retrieve the latest submitted team for follow-up views.
 2. Decide pick locking and whether the configured team size should move into database-backed basho settings.
-3. Add a protected admin UI or scheduled job around the import service.
+3. Add a protected admin UI around the import service.

--- a/README.md
+++ b/README.md
@@ -195,10 +195,10 @@ curl -X POST "http://localhost:3000/api/admin/basho/2026-05/import-results?dryRu
 ```
 
 Production deployments also expose a Vercel Cron-only
-`GET /api/cron/import-results` path. It selects the single active live basho,
-derives the current basho day in Japan time, and reuses the same transactional
-result import service as the manual trigger. See `docs/DEPLOYMENT.md` for the
-schedule and authentication details.
+`GET /api/cron/import-results` path. It selects the single eligible live basho,
+including a locked basho on day 1, derives the current basho day in Japan time,
+and reuses the same transactional result import service as the manual trigger.
+See `docs/DEPLOYMENT.md` for the schedule and authentication details.
 
 ## Makefile commands
 

--- a/README.md
+++ b/README.md
@@ -196,9 +196,10 @@ curl -X POST "http://localhost:3000/api/admin/basho/2026-05/import-results?dryRu
 
 Production deployments also expose a Vercel Cron-only
 `GET /api/cron/import-results` path. It selects the single eligible live basho,
-including a locked basho on day 1, derives the current basho day in Japan time,
-and reuses the same transactional result import service as the manual trigger.
-See `docs/DEPLOYMENT.md` for the schedule and authentication details.
+including an upcoming or locked basho on day 1, derives the current basho day
+in Japan time, and reuses the same transactional result import service as the
+manual trigger. See `docs/DEPLOYMENT.md` for the schedule and authentication
+details.
 
 ## Makefile commands
 

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -8,12 +8,14 @@ import {
 import {
   allowsUnprotectedAdminImports,
   getAdminImportToken,
+  getCronSecret,
   getDemoAdminToken,
   getTeamSize,
 } from "./config.js";
 import { registerAdminDemoRoutes } from "./routes/admin-demo.js";
 import { registerAdminImportRoutes } from "./routes/admin-imports.js";
 import { registerBashoRoutes } from "./routes/basho.js";
+import { registerScheduledImportRoutes } from "./routes/scheduled-imports.js";
 
 interface AppOptions {
   db?: AppDatabase;
@@ -23,6 +25,7 @@ interface AppOptions {
   teamSize?: number;
   demoAdminToken?: string;
   adminImportToken?: string;
+  cronSecret?: string;
   allowUnprotectedAdminImports?: boolean;
   allowUnprotectedDemoAdmin?: boolean;
 }
@@ -66,6 +69,12 @@ export function buildApp(options: AppOptions = {}) {
     demoAdminToken: options.demoAdminToken ?? getDemoAdminToken(),
     repositories,
     now: options.now ?? (() => new Date()),
+  });
+  registerScheduledImportRoutes(app, {
+    cronSecret: options.cronSecret ?? getCronSecret(),
+    now: options.now ?? (() => new Date()),
+    repositories,
+    sourceFetch: options.sourceFetch ?? fetch,
   });
 
   return app;

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -23,6 +23,12 @@ export function getAdminImportToken(): string | undefined {
   return token === undefined || token.length === 0 ? undefined : token;
 }
 
+export function getCronSecret(): string | undefined {
+  const secret = process.env.CRON_SECRET?.trim();
+
+  return secret === undefined || secret.length === 0 ? undefined : secret;
+}
+
 export function allowsUnprotectedAdminImports(): boolean {
   const nodeEnv = process.env.NODE_ENV?.trim();
 

--- a/apps/api/src/imports/scheduled-results.ts
+++ b/apps/api/src/imports/scheduled-results.ts
@@ -1,0 +1,125 @@
+import type { Basho } from "@fantasy-sumo/domain";
+import { DEMO_BASHO_ID, type Repositories } from "@fantasy-sumo/db";
+import { fetchSumoApiResultsImport } from "./adapters.js";
+import { importBoutResults } from "./service.js";
+import type { ImportResult, SourceFetch } from "./types.js";
+
+const JAPAN_TIME_ZONE = "Asia/Tokyo";
+const MILLISECONDS_PER_DAY = 86_400_000;
+
+export type ScheduledResultsImportResult =
+  | {
+      status: "skipped";
+      reason: "no-active-basho" | "outside-basho-window";
+      bashoId?: string;
+      japanDate: string;
+    }
+  | {
+      status: "imported";
+      bashoId: string;
+      day: number;
+      japanDate: string;
+      import: ImportResult;
+    };
+
+interface ScheduledResultsImportOptions {
+  now?: () => Date;
+}
+
+export async function runScheduledResultsImport(
+  repositories: Repositories,
+  sourceFetch: SourceFetch,
+  options: ScheduledResultsImportOptions = {},
+): Promise<ScheduledResultsImportResult> {
+  const japanDate = formatDateInTimeZone(
+    (options.now ?? (() => new Date()))(),
+    JAPAN_TIME_ZONE,
+  );
+  const activeBashos = (await repositories.listBashos()).filter(
+    (basho) => basho.status === "active" && basho.id !== DEMO_BASHO_ID,
+  );
+
+  if (activeBashos.length === 0) {
+    return {
+      status: "skipped",
+      reason: "no-active-basho",
+      japanDate,
+    };
+  }
+
+  if (activeBashos.length > 1) {
+    throw new Error(
+      `Scheduled results import found multiple active live bashos: ${activeBashos
+        .map((basho) => basho.id)
+        .join(", ")}.`,
+    );
+  }
+
+  const basho = activeBashos[0]!;
+  const day = resolveBashoDay(basho, japanDate);
+
+  if (day === undefined) {
+    return {
+      status: "skipped",
+      reason: "outside-basho-window",
+      bashoId: basho.id,
+      japanDate,
+    };
+  }
+
+  const command = await fetchSumoApiResultsImport(sourceFetch, {
+    bashoId: basho.id,
+    day,
+  });
+  const importResult = await importBoutResults(repositories, command);
+
+  return {
+    status: "imported",
+    bashoId: basho.id,
+    day,
+    japanDate,
+    import: importResult,
+  };
+}
+
+function resolveBashoDay(basho: Basho, japanDate: string) {
+  const currentDate = parseDateOnly(japanDate);
+  const startDate = parseDateOnly(basho.startDate);
+  const endDate = parseDateOnly(basho.endDate);
+
+  if (
+    currentDate === undefined ||
+    startDate === undefined ||
+    endDate === undefined ||
+    currentDate < startDate ||
+    currentDate > endDate
+  ) {
+    return undefined;
+  }
+
+  return Math.floor((currentDate - startDate) / MILLISECONDS_PER_DAY) + 1;
+}
+
+function parseDateOnly(value: string) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return undefined;
+  }
+
+  const parsed = Date.parse(`${value}T00:00:00.000Z`);
+
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+function formatDateInTimeZone(date: Date, timeZone: string) {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    day: "2-digit",
+    month: "2-digit",
+    timeZone,
+    year: "numeric",
+  }).formatToParts(date);
+  const values = Object.fromEntries(
+    parts.map((part) => [part.type, part.value]),
+  );
+
+  return `${values.year}-${values.month}-${values.day}`;
+}

--- a/apps/api/src/imports/scheduled-results.ts
+++ b/apps/api/src/imports/scheduled-results.ts
@@ -35,15 +35,17 @@ export async function runScheduledResultsImport(
     (options.now ?? (() => new Date()))(),
     JAPAN_TIME_ZONE,
   );
-  const liveBashos = (await repositories.listBashos()).filter(
+  const scheduledBashos = (await repositories.listBashos()).filter(
     (basho) =>
-      (basho.status === "locked" || basho.status === "active") &&
+      (basho.status === "upcoming" ||
+        basho.status === "locked" ||
+        basho.status === "active") &&
       basho.id !== DEMO_BASHO_ID,
   );
-  const eligibleBashos = liveBashos.flatMap((basho) => {
+  const eligibleBashos = scheduledBashos.flatMap((basho) => {
     const day = resolveBashoDay(basho, japanDate);
 
-    if (day === undefined || (basho.status === "locked" && day !== 1)) {
+    if (day === undefined || (basho.status !== "active" && day !== 1)) {
       return [];
     }
 
@@ -51,11 +53,11 @@ export async function runScheduledResultsImport(
   });
 
   if (eligibleBashos.length === 0) {
-    if (liveBashos.length === 1) {
+    if (scheduledBashos.length === 1) {
       return {
         status: "skipped",
         reason: "outside-basho-window",
-        bashoId: liveBashos[0]!.id,
+        bashoId: scheduledBashos[0]!.id,
         japanDate,
       };
     }

--- a/apps/api/src/imports/scheduled-results.ts
+++ b/apps/api/src/imports/scheduled-results.ts
@@ -35,11 +35,31 @@ export async function runScheduledResultsImport(
     (options.now ?? (() => new Date()))(),
     JAPAN_TIME_ZONE,
   );
-  const activeBashos = (await repositories.listBashos()).filter(
-    (basho) => basho.status === "active" && basho.id !== DEMO_BASHO_ID,
+  const liveBashos = (await repositories.listBashos()).filter(
+    (basho) =>
+      (basho.status === "locked" || basho.status === "active") &&
+      basho.id !== DEMO_BASHO_ID,
   );
+  const eligibleBashos = liveBashos.flatMap((basho) => {
+    const day = resolveBashoDay(basho, japanDate);
 
-  if (activeBashos.length === 0) {
+    if (day === undefined || (basho.status === "locked" && day !== 1)) {
+      return [];
+    }
+
+    return [{ basho, day }];
+  });
+
+  if (eligibleBashos.length === 0) {
+    if (liveBashos.length === 1) {
+      return {
+        status: "skipped",
+        reason: "outside-basho-window",
+        bashoId: liveBashos[0]!.id,
+        japanDate,
+      };
+    }
+
     return {
       status: "skipped",
       reason: "no-active-basho",
@@ -47,25 +67,15 @@ export async function runScheduledResultsImport(
     };
   }
 
-  if (activeBashos.length > 1) {
+  if (eligibleBashos.length > 1) {
     throw new Error(
-      `Scheduled results import found multiple active live bashos: ${activeBashos
-        .map((basho) => basho.id)
+      `Scheduled results import found multiple eligible live bashos: ${eligibleBashos
+        .map(({ basho }) => basho.id)
         .join(", ")}.`,
     );
   }
 
-  const basho = activeBashos[0]!;
-  const day = resolveBashoDay(basho, japanDate);
-
-  if (day === undefined) {
-    return {
-      status: "skipped",
-      reason: "outside-basho-window",
-      bashoId: basho.id,
-      japanDate,
-    };
-  }
+  const { basho, day } = eligibleBashos[0]!;
 
   const command = await fetchSumoApiResultsImport(sourceFetch, {
     bashoId: basho.id,

--- a/apps/api/src/imports/service.ts
+++ b/apps/api/src/imports/service.ts
@@ -320,7 +320,8 @@ function advanceBashoForResults(
 
   return {
     ...basho,
-    status: basho.status === "complete" ? "complete" : "active",
+    status:
+      basho.status === "complete" || importedDay === 15 ? "complete" : "active",
     currentDay: Math.max(basho.currentDay ?? 0, importedDay),
   };
 }

--- a/apps/api/src/imports/service.ts
+++ b/apps/api/src/imports/service.ts
@@ -113,11 +113,8 @@ export async function importBoutResults(
   );
 
   if (options.dryRun !== true) {
-    if (nextBasho !== undefined) {
-      await repositories.upsertBasho(nextBasho);
-    }
-
     await repositories.applyBoutResultsImport({
+      ...(nextBasho === undefined ? {} : { basho: nextBasho }),
       bashoId: command.bashoId,
       day: command.results[0]!.day,
       rikishi: missingSourceRikishi,

--- a/apps/api/src/routes/admin-imports.test.ts
+++ b/apps/api/src/routes/admin-imports.test.ts
@@ -97,6 +97,14 @@ describe("admin import routes", () => {
 
     expect(unauthorizedResponse.statusCode).toBe(401);
 
+    const unauthorizedResultsResponse = await app.inject({
+      method: "POST",
+      url: "/api/admin/basho/2026-05/import-results",
+      payload: { day: 1 },
+    });
+
+    expect(unauthorizedResultsResponse.statusCode).toBe(401);
+
     const authorizedResponse = await app.inject({
       headers: {
         "x-admin-import-token": "test-import-token",

--- a/apps/api/src/routes/admin-imports.ts
+++ b/apps/api/src/routes/admin-imports.ts
@@ -49,7 +49,10 @@ export function registerAdminImportRoutes(
   });
 
   app.addHook("preHandler", async (request, reply) => {
-    if (!request.url.includes("/import-results")) {
+    if (
+      !request.url.startsWith("/api/admin/basho/") ||
+      !request.url.includes("/import-results")
+    ) {
       return;
     }
 

--- a/apps/api/src/routes/scheduled-imports.test.ts
+++ b/apps/api/src/routes/scheduled-imports.test.ts
@@ -116,6 +116,27 @@ describe("scheduled result import route", () => {
     });
   });
 
+  it("imports day one for an upcoming basho created by an early banzuke import", async () => {
+    await seedLiveBasho("2026-05", { status: "upcoming", currentDay: 0 });
+    app = createApp(
+      async () => resultsResponse(1),
+      new Date("2026-05-10T02:00:00.000Z"),
+    );
+
+    const response = await injectCron(app);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      status: "imported",
+      bashoId: "2026-05",
+      day: 1,
+    });
+    expect(await createRepositories(client).getBasho("2026-05")).toMatchObject({
+      status: "active",
+      currentDay: 1,
+    });
+  });
+
   it("completes the basho atomically with its day 15 results", async () => {
     await seedLiveBasho("2026-05", { currentDay: 14 });
     app = createApp(
@@ -232,7 +253,10 @@ function injectCron(instance: FastifyInstance) {
 
 async function seedLiveBasho(
   bashoId: string,
-  options: { status?: "active" | "locked"; currentDay?: number } = {},
+  options: {
+    status?: "active" | "locked" | "upcoming";
+    currentDay?: number;
+  } = {},
 ) {
   const repositories = createRepositories(client);
 

--- a/apps/api/src/routes/scheduled-imports.test.ts
+++ b/apps/api/src/routes/scheduled-imports.test.ts
@@ -1,0 +1,242 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { FastifyInstance } from "fastify";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createDatabaseClient,
+  createRepositories,
+  DEMO_BASHO_ID,
+  runMigrations,
+  type DatabaseClient,
+} from "@fantasy-sumo/db";
+import { buildApp } from "../app.js";
+
+const CRON_SECRET = "test-cron-secret";
+const NOW = new Date("2026-05-11T15:30:00.000Z");
+
+let app: FastifyInstance | undefined;
+let client: DatabaseClient;
+let tmpRoot: string;
+
+beforeEach(async () => {
+  tmpRoot = mkdtempSync(join(tmpdir(), "fantasy-sumo-scheduled-imports-"));
+  client = createDatabaseClient(`file:${join(tmpRoot, "test.sqlite")}`);
+  await runMigrations(client);
+});
+
+afterEach(async () => {
+  await app?.close();
+  await client.close();
+  rmSync(tmpRoot, { force: true, recursive: true });
+});
+
+describe("scheduled result import route", () => {
+  it("requires the configured Vercel cron bearer token", async () => {
+    app = createApp();
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/cron/import-results",
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(response.json()).toMatchObject({
+      error: "scheduled-import-unauthorized",
+    });
+  });
+
+  it("imports the Japan-calendar basho day and safely reruns that same day", async () => {
+    await seedActiveBasho("2026-05");
+    let requestedUrl = "";
+    app = createApp(async (url) => {
+      requestedUrl = String(url);
+      return resultsResponse();
+    });
+
+    const firstResponse = await injectCron(app);
+
+    expect(firstResponse.statusCode).toBe(200);
+    expect(firstResponse.json()).toMatchObject({
+      status: "imported",
+      bashoId: "2026-05",
+      day: 3,
+      japanDate: "2026-05-12",
+      import: {
+        source: "sumo-api-results",
+        summary: {
+          results: { created: 1 },
+        },
+      },
+    });
+    expect(requestedUrl).toContain("/basho/202605/torikumi/Makuuchi/3");
+
+    const secondResponse = await injectCron(app);
+
+    expect(secondResponse.statusCode).toBe(200);
+    expect(secondResponse.json()).toMatchObject({
+      status: "imported",
+      bashoId: "2026-05",
+      day: 3,
+      import: {
+        summary: {
+          results: { created: 0, skipped: 1 },
+        },
+      },
+    });
+
+    const repositories = createRepositories(client);
+    expect(await repositories.listBoutResultsForBasho("2026-05")).toHaveLength(
+      1,
+    );
+    expect(await repositories.getBasho("2026-05")).toMatchObject({
+      status: "active",
+      currentDay: 3,
+    });
+  });
+
+  it("skips cleanly when there is no active live basho", async () => {
+    let fetchCalls = 0;
+    app = createApp(async () => {
+      fetchCalls += 1;
+      return resultsResponse();
+    });
+
+    const response = await injectCron(app);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      status: "skipped",
+      reason: "no-active-basho",
+      japanDate: "2026-05-12",
+    });
+    expect(fetchCalls).toBe(0);
+  });
+
+  it("does not treat the deterministic demo basho as a live import target", async () => {
+    await seedActiveBasho(DEMO_BASHO_ID);
+    app = createApp();
+
+    const response = await injectCron(app);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      status: "skipped",
+      reason: "no-active-basho",
+    });
+  });
+
+  it("reports source failures as unsuccessful cron responses", async () => {
+    await seedActiveBasho("2026-05");
+    app = createApp(async () => new Response(null, { status: 503 }));
+
+    const response = await injectCron(app);
+
+    expect(response.statusCode).toBe(500);
+    expect(response.json()).toMatchObject({
+      status: "failed",
+      error: "scheduled-results-import-failed",
+      message: "Import source request failed with 503.",
+    });
+    expect(
+      await createRepositories(client).listBoutResultsForBasho("2026-05"),
+    ).toEqual([]);
+  });
+
+  it("fails safely when more than one live basho is marked active", async () => {
+    await seedActiveBasho("2026-05");
+    await seedActiveBasho("2026-05-conflict");
+    app = createApp();
+
+    const response = await injectCron(app);
+
+    expect(response.statusCode).toBe(500);
+    expect(response.json()).toMatchObject({
+      status: "failed",
+      error: "scheduled-results-import-failed",
+    });
+  });
+});
+
+function createApp(sourceFetch: typeof fetch = async () => resultsResponse()) {
+  return buildApp({
+    cronSecret: CRON_SECRET,
+    db: client,
+    now: () => NOW,
+    sourceFetch,
+  });
+}
+
+function injectCron(instance: FastifyInstance) {
+  return instance.inject({
+    headers: {
+      authorization: `Bearer ${CRON_SECRET}`,
+    },
+    method: "GET",
+    url: "/api/cron/import-results",
+  });
+}
+
+async function seedActiveBasho(bashoId: string) {
+  const repositories = createRepositories(client);
+
+  await repositories.insertBasho({
+    id: bashoId,
+    name: "May 2026",
+    startDate: "2026-05-10",
+    endDate: "2026-05-24",
+    status: "active",
+    currentDay: 2,
+  });
+  await repositories.upsertRikishi({
+    id: "onosato",
+    shikona: "Onosato",
+    heya: "Nishonoseki",
+  });
+  await repositories.upsertRikishi({
+    id: "kotozakura",
+    shikona: "Kotozakura",
+    heya: "Sadogatake",
+  });
+  await repositories.upsertBanzukeEntry({
+    id: `${bashoId}-onosato`,
+    bashoId,
+    rikishiId: "onosato",
+    rank: "Yokozuna",
+    rankOrder: 1,
+  });
+  await repositories.upsertBanzukeEntry({
+    id: `${bashoId}-kotozakura`,
+    bashoId,
+    rikishiId: "kotozakura",
+    rank: "Ozeki",
+    rankOrder: 2,
+  });
+}
+
+function resultsResponse() {
+  return new Response(
+    JSON.stringify({
+      torikumi: [
+        {
+          id: "202605-3-1-4227-3661",
+          bashoId: "202605",
+          day: 3,
+          matchNo: 1,
+          eastId: 4227,
+          eastShikona: "Onosato",
+          westId: 3661,
+          westShikona: "Kotozakura",
+          kimarite: "oshidashi",
+          winnerId: 4227,
+          winnerEn: "Onosato",
+        },
+      ],
+    }),
+    {
+      headers: {
+        "content-type": "application/json",
+      },
+    },
+  );
+}

--- a/apps/api/src/routes/scheduled-imports.test.ts
+++ b/apps/api/src/routes/scheduled-imports.test.ts
@@ -47,7 +47,7 @@ describe("scheduled result import route", () => {
   });
 
   it("imports the Japan-calendar basho day and safely reruns that same day", async () => {
-    await seedActiveBasho("2026-05");
+    await seedLiveBasho("2026-05");
     let requestedUrl = "";
     app = createApp(async (url) => {
       requestedUrl = String(url);
@@ -95,7 +95,55 @@ describe("scheduled result import route", () => {
     });
   });
 
-  it("skips cleanly when there is no active live basho", async () => {
+  it("imports day one for a locked basho and advances it to active", async () => {
+    await seedLiveBasho("2026-05", { status: "locked", currentDay: 0 });
+    app = createApp(
+      async () => resultsResponse(1),
+      new Date("2026-05-10T02:00:00.000Z"),
+    );
+
+    const response = await injectCron(app);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      status: "imported",
+      bashoId: "2026-05",
+      day: 1,
+    });
+    expect(await createRepositories(client).getBasho("2026-05")).toMatchObject({
+      status: "active",
+      currentDay: 1,
+    });
+  });
+
+  it("completes the basho atomically with its day 15 results", async () => {
+    await seedLiveBasho("2026-05", { currentDay: 14 });
+    app = createApp(
+      async () => resultsResponse(15),
+      new Date("2026-05-24T02:00:00.000Z"),
+    );
+
+    const response = await injectCron(app);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      status: "imported",
+      bashoId: "2026-05",
+      day: 15,
+      import: {
+        summary: {
+          basho: { updated: 1 },
+          results: { created: 1 },
+        },
+      },
+    });
+    expect(await createRepositories(client).getBasho("2026-05")).toMatchObject({
+      status: "complete",
+      currentDay: 15,
+    });
+  });
+
+  it("skips cleanly when there is no eligible live basho", async () => {
     let fetchCalls = 0;
     app = createApp(async () => {
       fetchCalls += 1;
@@ -114,7 +162,7 @@ describe("scheduled result import route", () => {
   });
 
   it("does not treat the deterministic demo basho as a live import target", async () => {
-    await seedActiveBasho(DEMO_BASHO_ID);
+    await seedLiveBasho(DEMO_BASHO_ID);
     app = createApp();
 
     const response = await injectCron(app);
@@ -127,7 +175,7 @@ describe("scheduled result import route", () => {
   });
 
   it("reports source failures as unsuccessful cron responses", async () => {
-    await seedActiveBasho("2026-05");
+    await seedLiveBasho("2026-05");
     app = createApp(async () => new Response(null, { status: 503 }));
 
     const response = await injectCron(app);
@@ -144,8 +192,8 @@ describe("scheduled result import route", () => {
   });
 
   it("fails safely when more than one live basho is marked active", async () => {
-    await seedActiveBasho("2026-05");
-    await seedActiveBasho("2026-05-conflict");
+    await seedLiveBasho("2026-05");
+    await seedLiveBasho("2026-05-conflict");
     app = createApp();
 
     const response = await injectCron(app);
@@ -158,11 +206,16 @@ describe("scheduled result import route", () => {
   });
 });
 
-function createApp(sourceFetch: typeof fetch = async () => resultsResponse()) {
+function createApp(
+  sourceFetch: typeof fetch = async () => resultsResponse(),
+  now = NOW,
+) {
   return buildApp({
+    adminImportToken: "separate-admin-import-token",
+    allowUnprotectedAdminImports: false,
     cronSecret: CRON_SECRET,
     db: client,
-    now: () => NOW,
+    now: () => now,
     sourceFetch,
   });
 }
@@ -177,7 +230,10 @@ function injectCron(instance: FastifyInstance) {
   });
 }
 
-async function seedActiveBasho(bashoId: string) {
+async function seedLiveBasho(
+  bashoId: string,
+  options: { status?: "active" | "locked"; currentDay?: number } = {},
+) {
   const repositories = createRepositories(client);
 
   await repositories.insertBasho({
@@ -185,8 +241,8 @@ async function seedActiveBasho(bashoId: string) {
     name: "May 2026",
     startDate: "2026-05-10",
     endDate: "2026-05-24",
-    status: "active",
-    currentDay: 2,
+    status: options.status ?? "active",
+    currentDay: options.currentDay ?? 2,
   });
   await repositories.upsertRikishi({
     id: "onosato",
@@ -214,14 +270,14 @@ async function seedActiveBasho(bashoId: string) {
   });
 }
 
-function resultsResponse() {
+function resultsResponse(day = 3) {
   return new Response(
     JSON.stringify({
       torikumi: [
         {
-          id: "202605-3-1-4227-3661",
+          id: `202605-${day}-1-4227-3661`,
           bashoId: "202605",
-          day: 3,
+          day,
           matchNo: 1,
           eastId: 4227,
           eastShikona: "Onosato",

--- a/apps/api/src/routes/scheduled-imports.ts
+++ b/apps/api/src/routes/scheduled-imports.ts
@@ -1,0 +1,62 @@
+import type { FastifyInstance } from "fastify";
+import type { Repositories } from "@fantasy-sumo/db";
+import { runScheduledResultsImport } from "../imports/scheduled-results.js";
+import type { SourceFetch } from "../imports/types.js";
+
+interface RouteContext {
+  cronSecret?: string;
+  now: () => Date;
+  repositories: Repositories;
+  sourceFetch: SourceFetch;
+}
+
+export function registerScheduledImportRoutes(
+  app: FastifyInstance,
+  context: RouteContext,
+) {
+  app.get("/api/cron/import-results", async (request, reply) => {
+    if (context.cronSecret === undefined) {
+      return reply.code(404).send({
+        error: "scheduled-import-disabled",
+        message: "Scheduled result imports are not enabled.",
+      });
+    }
+
+    if (request.headers.authorization !== `Bearer ${context.cronSecret}`) {
+      return reply.code(401).send({
+        error: "scheduled-import-unauthorized",
+        message: "Scheduled result imports require a valid cron secret.",
+      });
+    }
+
+    try {
+      const result = await runScheduledResultsImport(
+        context.repositories,
+        context.sourceFetch,
+        { now: context.now },
+      );
+
+      request.log.info(
+        {
+          bashoId: result.bashoId,
+          day: result.status === "imported" ? result.day : undefined,
+          japanDate: result.japanDate,
+          reason: result.status === "skipped" ? result.reason : undefined,
+          status: result.status,
+        },
+        "Scheduled results import finished.",
+      );
+
+      return result;
+    } catch (error) {
+      request.log.error({ err: error }, "Scheduled results import failed.");
+
+      return reply.code(500).send({
+        status: "failed",
+        error: "scheduled-results-import-failed",
+        message:
+          error instanceof Error ? error.message : "Scheduled import failed.",
+      });
+    }
+  });
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -93,14 +93,19 @@ Current routes:
 - `POST /api/admin/demo/complete`
   - Requires `DEMO_ADMIN_TOKEN`.
   - Applies all deterministic demo results and marks the demo basho complete.
+- `GET /api/cron/import-results`
+  - Requires Vercel's `Authorization: Bearer <CRON_SECRET>` header.
+  - Selects the single active non-demo basho and derives its day from the
+    current calendar date in `Asia/Tokyo`.
+  - Reuses the source adapter and transactional result import service used by
+    the manual admin route.
+  - Returns structured imported/skipped status and logs success or failure.
 
 Current limitations:
 
 - No auth.
 - No dedicated API client package.
-- Admin import endpoints are local-only and unprotected.
-- No scheduled import job yet.
-- No pick-locking rules yet.
+- No admin UI yet.
 
 ## Domain package
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -95,11 +95,13 @@ Current routes:
   - Applies all deterministic demo results and marks the demo basho complete.
 - `GET /api/cron/import-results`
   - Requires Vercel's `Authorization: Bearer <CRON_SECRET>` header.
-  - Selects the single date-eligible non-demo basho, including a locked day-one
-    basho, and derives its day from the current calendar date in `Asia/Tokyo`.
+  - Selects the single date-eligible non-demo basho, including an upcoming or
+    locked day-one basho, and derives its day from the current calendar date in
+    `Asia/Tokyo`.
   - Reuses the source adapter and transactional result import service used by
     the manual admin route.
-  - Moves a locked basho to active with day 1 and completes it with day 15.
+  - Moves an upcoming or locked basho to active with day 1 and completes it
+    with day 15.
   - Returns structured imported/skipped status and logs success or failure.
 
 Current limitations:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -95,10 +95,11 @@ Current routes:
   - Applies all deterministic demo results and marks the demo basho complete.
 - `GET /api/cron/import-results`
   - Requires Vercel's `Authorization: Bearer <CRON_SECRET>` header.
-  - Selects the single active non-demo basho and derives its day from the
-    current calendar date in `Asia/Tokyo`.
+  - Selects the single date-eligible non-demo basho, including a locked day-one
+    basho, and derives its day from the current calendar date in `Asia/Tokyo`.
   - Reuses the source adapter and transactional result import service used by
     the manual admin route.
+  - Moves a locked basho to active with day 1 and completes it with day 15.
   - Returns structured imported/skipped status and logs success or failure.
 
 Current limitations:

--- a/docs/DATA_IMPORT_STRATEGY.md
+++ b/docs/DATA_IMPORT_STRATEGY.md
@@ -279,8 +279,9 @@ For the first local MVP, a failed import can return a structured API error and l
 6. Add small reduced source fixtures for adapter tests and internal JSON fixtures for import-service tests.
 7. Add a protected scheduled production trigger that selects one eligible live
    basho, derives the current day in Japan time, and reuses the result import
-   service. Allow locked-to-active progression on day 1 and complete the basho
-   with day 15. Keep deterministic demo bashos outside this path.
+   service. Allow upcoming-or-locked to active progression on day 1 and
+   complete the basho with day 15. Keep deterministic demo bashos outside this
+   path.
 8. Add fallback source support:
    - Sumo API banzuke as backup if JSA banzuke fails;
    - JSA results adapter if a stable machine-readable result endpoint is confirmed;

--- a/docs/DATA_IMPORT_STRATEGY.md
+++ b/docs/DATA_IMPORT_STRATEGY.md
@@ -277,11 +277,13 @@ For the first local MVP, a failed import can return a structured API error and l
 4. Add repository/service functions that apply validated imports transactionally.
 5. Add local-only admin endpoints or scripts to manually trigger source imports and dry runs.
 6. Add small reduced source fixtures for adapter tests and internal JSON fixtures for import-service tests.
-7. Add fallback source support:
+7. Add a protected scheduled production trigger that selects one active live
+   basho, derives the current day in Japan time, and reuses the result import
+   service. Keep deterministic demo bashos outside this path.
+8. Add fallback source support:
    - Sumo API banzuke as backup if JSA banzuke fails;
    - JSA results adapter if a stable machine-readable result endpoint is confirmed;
    - no SumoDB scraper unless API paths prove inadequate.
-8. Add scheduled execution later, e.g. once per day during active basho, after the triggerable import path is stable.
 
 ## Follow-Up Tickets
 

--- a/docs/DATA_IMPORT_STRATEGY.md
+++ b/docs/DATA_IMPORT_STRATEGY.md
@@ -277,9 +277,10 @@ For the first local MVP, a failed import can return a structured API error and l
 4. Add repository/service functions that apply validated imports transactionally.
 5. Add local-only admin endpoints or scripts to manually trigger source imports and dry runs.
 6. Add small reduced source fixtures for adapter tests and internal JSON fixtures for import-service tests.
-7. Add a protected scheduled production trigger that selects one active live
+7. Add a protected scheduled production trigger that selects one eligible live
    basho, derives the current day in Japan time, and reuses the result import
-   service. Keep deterministic demo bashos outside this path.
+   service. Allow locked-to-active progression on day 1 and complete the basho
+   with day 15. Keep deterministic demo bashos outside this path.
 8. Add fallback source support:
    - Sumo API banzuke as backup if JSA banzuke fails;
    - JSA results adapter if a stable machine-readable result endpoint is confirmed;

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -29,6 +29,7 @@ Set these in Vercel before exposing the app:
 DATABASE_URL=<managed Postgres connection string>
 TEAM_SIZE=2
 ADMIN_IMPORT_TOKEN=<long random token>
+CRON_SECRET=<long random token>
 DEMO_ADMIN_TOKEN=<long random token, only if demo admin controls are needed>
 ```
 
@@ -60,6 +61,54 @@ curl -X POST "https://<deployment>/api/admin/import-banzuke?dryRun=true" \
 ```
 
 The same token can also be supplied with `Authorization: Bearer <token>`.
+
+## Scheduled daily results import
+
+The root `vercel.json` configures one production cron invocation:
+
+```json
+{
+  "path": "/api/cron/import-results",
+  "schedule": "0 10 * * *"
+}
+```
+
+Vercel cron schedules use UTC, so this runs daily at **10:00 UTC / 19:00 JST**.
+That is after the expected end of the top-division bouts. The daily schedule is
+compatible with Vercel Hobby's once-per-day cron limit; manual imports remain
+the recovery path for delayed source data or a missed run.
+
+Set `CRON_SECRET` on the production deployment. Vercel sends it to the cron
+route as `Authorization: Bearer <CRON_SECRET>`. The route is disabled when the
+secret is missing and rejects requests with a missing or incorrect bearer
+token. Cron jobs run on production deployments, not previews.
+
+On each authenticated invocation, the route:
+
+1. finds bashos whose stored lifecycle status is `active`;
+2. excludes the deterministic demo basho;
+3. refuses to import if more than one live basho is active;
+4. calculates the expected basho day from the current date in `Asia/Tokyo` and
+   the stored basho start date;
+5. skips without contacting the source when no live basho is active or the
+   date is outside the active basho's stored date window;
+6. runs the existing Sumo API adapter and transactional daily result import.
+
+Re-running the route on the same Japan calendar day targets the same basho/day.
+The importer replaces only that day's stable result IDs, so retries correct or
+skip existing rows without duplicating scores, teams, or picks. The response
+and Vercel function logs include the status, basho ID, day, Japan date, and skip
+reason when applicable. Source, validation, or ambiguous-active-basho errors
+are logged and return a non-2xx response so Vercel does not record silent
+success.
+
+For a controlled manual check, call the deployed route with the same bearer
+header Vercel uses:
+
+```bash
+curl "https://<deployment>/api/cron/import-results" \
+  -H "Authorization: Bearer $CRON_SECRET"
+```
 
 ## First deployment checklist
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -69,14 +69,16 @@ The root `vercel.json` configures one production cron invocation:
 ```json
 {
   "path": "/api/cron/import-results",
-  "schedule": "0 10 * * *"
+  "schedule": "0 11 * * *"
 }
 ```
 
-Vercel cron schedules use UTC, so this runs daily at **10:00 UTC / 19:00 JST**.
-That is after the expected end of the top-division bouts. The daily schedule is
-compatible with Vercel Hobby's once-per-day cron limit; manual imports remain
-the recovery path for delayed source data or a missed run.
+Vercel cron schedules use UTC. On a Hobby project, this schedule runs once
+between **11:00-11:59 UTC / 20:00-20:59 JST**, because Hobby cron invocation
+precision is hourly. That leaves at least two hours after the expected 18:00
+JST end of the top-division bouts. Vercel does not retry failed cron
+invocations, so manual imports remain the recovery path for delayed or
+incomplete source data, a failed invocation, or a missed run.
 
 Set `CRON_SECRET` on the production deployment. Vercel sends it to the cron
 route as `Authorization: Bearer <CRON_SECRET>`. The route is disabled when the
@@ -85,20 +87,23 @@ token. Cron jobs run on production deployments, not previews.
 
 On each authenticated invocation, the route:
 
-1. finds bashos whose stored lifecycle status is `active`;
+1. finds live bashos whose stored lifecycle status is `locked` or `active`;
 2. excludes the deterministic demo basho;
-3. refuses to import if more than one live basho is active;
-4. calculates the expected basho day from the current date in `Asia/Tokyo` and
+3. allows a `locked` basho to become the day-one target, and otherwise targets
+   the single date-eligible `active` basho;
+4. refuses to import if more than one live basho is eligible;
+5. calculates the expected basho day from the current date in `Asia/Tokyo` and
    the stored basho start date;
-5. skips without contacting the source when no live basho is active or the
+6. skips without contacting the source when no live basho is eligible or the
    date is outside the active basho's stored date window;
-6. runs the existing Sumo API adapter and transactional daily result import.
+7. runs the existing Sumo API adapter and transactional daily result import,
+   moving `locked` to `active` on day 1 and `active` to `complete` on day 15.
 
 Re-running the route on the same Japan calendar day targets the same basho/day.
 The importer replaces only that day's stable result IDs, so retries correct or
 skip existing rows without duplicating scores, teams, or picks. The response
 and Vercel function logs include the status, basho ID, day, Japan date, and skip
-reason when applicable. Source, validation, or ambiguous-active-basho errors
+reason when applicable. Source, validation, or ambiguous-live-basho errors
 are logged and return a non-2xx response so Vercel does not record silent
 success.
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -87,17 +87,19 @@ token. Cron jobs run on production deployments, not previews.
 
 On each authenticated invocation, the route:
 
-1. finds live bashos whose stored lifecycle status is `locked` or `active`;
+1. finds schedulable bashos whose stored lifecycle status is `upcoming`,
+   `locked`, or `active`;
 2. excludes the deterministic demo basho;
-3. allows a `locked` basho to become the day-one target, and otherwise targets
-   the single date-eligible `active` basho;
+3. allows an `upcoming` or `locked` basho to become the day-one target, and
+   otherwise targets the single date-eligible `active` basho;
 4. refuses to import if more than one live basho is eligible;
 5. calculates the expected basho day from the current date in `Asia/Tokyo` and
    the stored basho start date;
 6. skips without contacting the source when no live basho is eligible or the
    date is outside the active basho's stored date window;
 7. runs the existing Sumo API adapter and transactional daily result import,
-   moving `locked` to `active` on day 1 and `active` to `complete` on day 15.
+   moving `upcoming` or `locked` to `active` on day 1 and `active` to
+   `complete` on day 15.
 
 Re-running the route on the same Japan calendar day targets the same basho/day.
 The importer replaces only that day's stable result IDs, so retries correct or

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -22,6 +22,7 @@ export interface BanzukeImportData {
 }
 
 export interface BoutResultsImportData {
+  basho?: Basho;
   bashoId: Basho["id"];
   day: BoutResult["day"];
   rikishi?: readonly Rikishi[];
@@ -302,6 +303,17 @@ function createSqliteRepositories(db: SqliteDatabase): Repositories {
     },
     applyBoutResultsImport: async (importData) => {
       db.transaction((transaction) => {
+        if (importData.basho !== undefined) {
+          transaction
+            .insert(sqlite.basho)
+            .values(toBashoRow(importData.basho))
+            .onConflictDoUpdate({
+              target: sqlite.basho.id,
+              set: toBashoRow(importData.basho),
+            })
+            .run();
+        }
+
         for (const entry of importData.rikishi ?? []) {
           transaction
             .insert(sqlite.rikishi)
@@ -549,6 +561,16 @@ function createPostgresRepositories(db: PostgresDatabase): Repositories {
     },
     applyBoutResultsImport: async (importData) => {
       await db.transaction(async (transaction) => {
+        if (importData.basho !== undefined) {
+          await transaction
+            .insert(pg.basho)
+            .values(toBashoRow(importData.basho))
+            .onConflictDoUpdate({
+              target: pg.basho.id,
+              set: toBashoRow(importData.basho),
+            });
+        }
+
         for (const entry of importData.rikishi ?? []) {
           await transaction
             .insert(pg.rikishi)

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,12 @@
   "buildCommand": "pnpm build",
   "installCommand": "pnpm install --frozen-lockfile",
   "outputDirectory": "apps/web/dist",
+  "crons": [
+    {
+      "path": "/api/cron/import-results",
+      "schedule": "0 10 * * *"
+    }
+  ],
   "rewrites": [
     {
       "source": "/api/(.*)",

--- a/vercel.json
+++ b/vercel.json
@@ -6,7 +6,7 @@
   "crons": [
     {
       "path": "/api/cron/import-results",
-      "schedule": "0 10 * * *"
+      "schedule": "0 11 * * *"
     }
   ],
   "rewrites": [


### PR DESCRIPTION
Closes #44

## Summary
- add a CRON_SECRET-protected Vercel Cron route for daily Makuuchi result imports
- select exactly one active non-demo basho and derive the expected day in Asia/Tokyo
- reuse the existing source adapter and result import service, with atomic basho/result persistence
- log structured import, skip, and failure outcomes and reject ambiguous active-basho state
- configure the production schedule for 10:00 UTC / 19:00 JST and document operation/recovery

## Validation
- PASS: make check PNPM=/opt/homebrew/bin/pnpm
- PASS: /opt/homebrew/bin/pnpm exec tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --skipLibCheck --esModuleInterop api/index.ts
- PASS: make e2e PNPM=/opt/homebrew/bin/pnpm (5 Playwright tests)

## E2E
- Ran the deterministic browser game-loop suite because scheduled result imports feed leaderboard scoring.

## Docs
- updated README.md, docs/ARCHITECTURE.md, docs/DATA_IMPORT_STRATEGY.md, docs/DEPLOYMENT.md, .env.example, and vercel.json

## Non-goals / follow-up
- manual admin imports remain the recovery and catch-up path
- this PR does not add the admin UI from #43 or fallback result sources