### PR TITLE
Add guarded PR review and feedback loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,13 @@ Avoid overbuilding. A working single-user/local MVP is preferable to a half-fini
 - Keep data import logic separate from scoring logic.
 - Once an E2E harness exists, use it to validate completion for changes that affect the browser game loop.
 
+## Review guidelines
+
+- Prioritize correctness, security, data integrity, basho lifecycle enforcement, transactional races, missed-cron recovery, deployment authentication, and SQLite/Postgres parity.
+- Require focused regression coverage when a change affects scoring, imports, pick locking, persistence, or production scheduling.
+- Treat unsupported product expansion, style-only preferences, and cleanup unrelated to the PR as non-blocking follow-up work.
+- Flag any path that can reopen picks, lose or duplicate results, partially commit imports, expose protected admin actions, or behave differently on Neon Postgres.
+
 ## Legacy hazards to handle carefully
 
 - The removed legacy database connection used hard-coded local credentials. Do not reintroduce credentials in source.
@@ -62,8 +69,13 @@ Avoid overbuilding. A working single-user/local MVP is preferable to a half-fini
 8. Use `make db-seed-demo` or `make demo` when a deterministic browser-flow fixture is useful, especially for future E2E validation. These commands reset the configured local SQLite data.
 9. Prefer the Makefile command layer for common workflows: `make test`, `make lint`, `make build`, and `make check`.
 10. Keep PRs focused on the next MVP slice; do not rebuild the full product in one change.
+11. Before calling a non-trivial code change ready, use `skills/fantasy-sumo-pr-review-loop/SKILL.md` to run a dedicated review against the base branch.
 
 For issue-to-PR work, use the repo-local process in `skills/fantasy-sumo-issue-loop/SKILL.md`. It can be invoked with a prompt such as: "Use the Fantasy Sumo issue loop on #44."
+
+For pre-handoff review, PR comment follow-up, or scheduled PR babysitting, use `skills/fantasy-sumo-pr-review-loop/SKILL.md`.
+
+After opening a `codex/*` pull request, start a PR-scoped scheduled babysitter when Codex automations are available. Run it in an isolated worktree, limit automatic fixes to the safe scope in the review-loop skill, and stop it when the PR is merged or closed. Never auto-merge.
 
 ## Definition of done for future changes
 
@@ -75,3 +87,5 @@ A change is ready when:
 - It includes tests for scoring/data rules where practical.
 - It runs relevant E2E coverage when browser game-loop behaviour changes and an E2E harness exists.
 - It updates docs if it changes product rules, architecture, setup, or data assumptions.
+- It has passed a dedicated review against the base branch, with accepted findings fixed and revalidated.
+- It has no unresolved actionable P1/P2 review threads; ambiguous or higher-risk findings are explicitly handed back to the user.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ Avoid overbuilding. A working single-user/local MVP is preferable to a half-fini
 - Keep basho lifecycle and pick-locking rules in the domain/API layer; UI state should mirror those rules, not replace API enforcement.
 - Keep data import logic separate from scoring logic.
 - Once an E2E harness exists, use it to validate completion for changes that affect the browser game loop.
+- Run relevant E2E before the initial handoff for browser-game-loop changes. When meaningful UI or interaction risk remains, add an agent-browser visual pass when available; it supplements rather than replaces E2E.
 
 ## Review guidelines
 
@@ -70,6 +71,7 @@ Avoid overbuilding. A working single-user/local MVP is preferable to a half-fini
 9. Prefer the Makefile command layer for common workflows: `make test`, `make lint`, `make build`, and `make check`.
 10. Keep PRs focused on the next MVP slice; do not rebuild the full product in one change.
 11. Before calling a non-trivial code change ready, use `skills/fantasy-sumo-pr-review-loop/SKILL.md` to run a dedicated review against the base branch.
+12. Open completed, validated PRs ready for review so the automatic Codex GitHub review runs. Use draft PRs only for explicitly requested checkpoints or work that is incomplete, blocked, or missing required validation.
 
 For issue-to-PR work, use the repo-local process in `skills/fantasy-sumo-issue-loop/SKILL.md`. It can be invoked with a prompt such as: "Use the Fantasy Sumo issue loop on #44."
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ It is close to a local playable loop, but still needs a friendlier admin UI befo
 Start here:
 
 - `AGENTS.md` - guidance for AI coding agents working on the repo.
-- `skills/fantasy-sumo-issue-loop/SKILL.md` - repo-local issue-to-draft-PR loop for agents. Invoke it with a prompt like: "Use the Fantasy Sumo issue loop on #44."
+- `skills/fantasy-sumo-issue-loop/SKILL.md` - repo-local issue-to-PR loop for agents. Invoke it with a prompt like: "Use the Fantasy Sumo issue loop on #44."
 - `docs/PROJECT_BRIEF.md` - product intent and MVP definition.
 - `docs/ARCHITECTURE.md` - current architecture and suggested future boundaries.
 - `docs/adr/0001-rebuild-architecture.md` - accepted rebuild architecture decision.

--- a/skills/fantasy-sumo-issue-loop/SKILL.md
+++ b/skills/fantasy-sumo-issue-loop/SKILL.md
@@ -6,7 +6,7 @@ Use this skill when the user asks to work an issue through the Fantasy Sumo repo
 Use the Fantasy Sumo issue loop on #44.
 ```
 
-This is a repo-local adapter for Fantasy Sumo's current architecture, data safety rules, and completion evidence. Keep it lightweight. It should help one issue become one focused draft PR; it should not automate issue intake, reviews, merges, or deployment.
+This is a repo-local adapter for Fantasy Sumo's current architecture, data safety rules, and completion evidence. Keep it lightweight. It should help one issue become one focused draft PR; hand pre-handoff review and later PR feedback to `skills/fantasy-sumo-pr-review-loop/SKILL.md`. It should not automate issue intake, merges, or deployment.
 
 ## Baseline Rules
 
@@ -86,6 +86,8 @@ For documentation-only changes, `make check` is usually sufficient if it covers 
 
 For changes that touch repo-root Vercel handlers such as `api/index.ts`, also run a direct TypeScript compile probe for that path or the relevant deployment build check, because root handlers may not be covered by package-level builds.
 
+After checks pass for a non-trivial code change, invoke `skills/fantasy-sumo-pr-review-loop/SKILL.md` in pre-handoff mode. Address accepted findings, revalidate, and record any finding that requires user input before calling the PR ready.
+
 ## E2E Rules
 
 Read `docs/E2E_TESTING.md` before adding or relying on E2E coverage.
@@ -114,11 +116,13 @@ Open a draft PR when the issue slice is implemented and relevant checks have bee
 - docs updated, if any;
 - known follow-up work or explicit non-goals.
 
-Do not mark the PR ready for review until required checks and issue-specific acceptance criteria are satisfied.
+Do not mark the PR ready for review until required checks, issue-specific acceptance criteria, and the pre-handoff review gate are satisfied.
+
+When Codex automations are available, start a PR-scoped scheduled babysitter after opening the draft PR. Invoke `skills/fantasy-sumo-pr-review-loop/SKILL.md` in scheduled mode, use an isolated worktree, and stop monitoring when the PR is merged or closed. The generated task prompt must explicitly authorize the skill's limited safe-fix writes: edit the PR branch, commit, push without force, reply to addressed review threads, and resolve only those addressed threads. It must repeat that merge, close, approval, branch deletion, and high-risk or ambiguous fixes are not authorized. If automation is unavailable, state that review follow-up remains manual.
 
 ## Automation Boundary
 
-This skill is manual or semi-manual. It does not create a fully automatic "new issue equals new PR" system.
+This skill is manual or semi-manual. It does not create a fully automatic "new issue equals new PR" system. After the draft PR exists, use `skills/fantasy-sumo-pr-review-loop/SKILL.md` for thread-aware feedback follow-up or a guarded scheduled babysitter.
 
 A later queue can add automation with safer constraints:
 

--- a/skills/fantasy-sumo-issue-loop/SKILL.md
+++ b/skills/fantasy-sumo-issue-loop/SKILL.md
@@ -6,11 +6,11 @@ Use this skill when the user asks to work an issue through the Fantasy Sumo repo
 Use the Fantasy Sumo issue loop on #44.
 ```
 
-This is a repo-local adapter for Fantasy Sumo's current architecture, data safety rules, and completion evidence. Keep it lightweight. It should help one issue become one focused draft PR; hand pre-handoff review and later PR feedback to `skills/fantasy-sumo-pr-review-loop/SKILL.md`. It should not automate issue intake, merges, or deployment.
+This is a repo-local adapter for Fantasy Sumo's current architecture, data safety rules, and completion evidence. Keep it lightweight. It should help one issue become one focused PR; hand pre-handoff review and later PR feedback to `skills/fantasy-sumo-pr-review-loop/SKILL.md`. It should not automate issue intake, merges, or deployment.
 
 ## Baseline Rules
 
-Start by reading `AGENTS.md`. It is the baseline rule set for this repo. This skill narrows that guidance into a repeatable issue-to-draft-PR loop.
+Start by reading `AGENTS.md`. It is the baseline rule set for this repo. This skill narrows that guidance into a repeatable issue-to-PR loop.
 
 Also read the current issue and any linked issues, pull requests, or review comments before planning implementation. Use GitHub issue and PR data as the source of truth for acceptance criteria when it conflicts with older local notes.
 
@@ -101,13 +101,17 @@ Run targeted E2E or `make e2e` once the harness exists when the change affects:
 - database seed/reset behaviour used by the browser game loop;
 - basho lifecycle UI behaviour.
 
+Run this coverage before the initial PR handoff, not only after review feedback. When a change materially affects visual layout, interaction, responsive behaviour, or a state that Playwright assertions do not represent well, add an agent-browser visual pass when the tooling is available. The visual pass supplements E2E and does not replace it.
+
 Use deterministic local test data and a test-only `DATABASE_URL`. Do not run default E2E against live sumo sources or production data.
 
 If E2E is skipped, record the reason in the PR summary. Acceptable reasons include documentation-only changes, harness not yet implemented, local browser install constraints, sandbox/port constraints, or a change that has no browser game-loop impact.
 
-## Draft PR
+## Pull Request
 
-Open a draft PR when the issue slice is implemented and relevant checks have been attempted. The PR body should include:
+Open the PR ready for review once the issue slice is complete, required checks and E2E have passed or have an accepted skip reason, and the pre-handoff review gate is satisfied. This allows the automatic Codex GitHub review to run immediately. Open a draft only when the user explicitly requests a checkpoint or the work is knowingly incomplete, blocked, or missing required validation.
+
+The PR body should include:
 
 - the issue number it closes or addresses;
 - a concise implementation summary;
@@ -116,19 +120,19 @@ Open a draft PR when the issue slice is implemented and relevant checks have bee
 - docs updated, if any;
 - known follow-up work or explicit non-goals.
 
-Do not mark the PR ready for review until required checks, issue-specific acceptance criteria, and the pre-handoff review gate are satisfied.
+Do not mark a draft ready for review until required checks, issue-specific acceptance criteria, and the pre-handoff review gate are satisfied. Once those gates pass, convert it to ready rather than leaving it in draft.
 
-When Codex automations are available, start a PR-scoped scheduled babysitter after opening the draft PR. Invoke `skills/fantasy-sumo-pr-review-loop/SKILL.md` in scheduled mode, use an isolated worktree, and stop monitoring when the PR is merged or closed. The generated task prompt must explicitly authorize the skill's limited safe-fix writes: edit the PR branch, commit, push without force, reply to addressed review threads, and resolve only those addressed threads. It must repeat that merge, close, approval, branch deletion, and high-risk or ambiguous fixes are not authorized. If automation is unavailable, state that review follow-up remains manual.
+When Codex automations are available, start a PR-scoped scheduled babysitter after opening the PR. Invoke `skills/fantasy-sumo-pr-review-loop/SKILL.md` in scheduled mode, use an isolated worktree, and stop monitoring when the PR is merged or closed. The generated task prompt must explicitly authorize the skill's limited safe-fix writes: edit the PR branch, commit, push without force, reply to addressed review threads, and resolve only those addressed threads. It must repeat that merge, close, approval, branch deletion, and high-risk or ambiguous fixes are not authorized. If automation is unavailable, state that review follow-up remains manual.
 
 ## Automation Boundary
 
-This skill is manual or semi-manual. It does not create a fully automatic "new issue equals new PR" system. After the draft PR exists, use `skills/fantasy-sumo-pr-review-loop/SKILL.md` for thread-aware feedback follow-up or a guarded scheduled babysitter.
+This skill is manual or semi-manual. It does not create a fully automatic "new issue equals new PR" system. After the PR exists, use `skills/fantasy-sumo-pr-review-loop/SKILL.md` for thread-aware feedback follow-up or a guarded scheduled babysitter.
 
 A later queue can add automation with safer constraints:
 
 - only labelled issues, such as `ready-for-agent`, are eligible;
 - one issue is handled per branch and PR;
-- PRs open as drafts;
+- PRs open ready for review after their handoff gates pass; drafts are reserved for incomplete or blocked work;
 - checks and E2E evidence are required before review;
 - nothing auto-merges.
 

--- a/skills/fantasy-sumo-pr-review-loop/SKILL.md
+++ b/skills/fantasy-sumo-pr-review-loop/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: fantasy-sumo-pr-review-loop
+description: Review Fantasy Sumo branch changes before handoff and safely address actionable GitHub pull request feedback. Use for dedicated pre-handoff code reviews, unresolved PR review threads, repeated Codex review findings, or scheduled PR babysitting after a pull request is open.
+---
+
+# Fantasy Sumo PR Review Loop
+
+Keep review fixes focused, independently checked, and traceable to their GitHub threads. Read `AGENTS.md` first and preserve the issue or PR's existing intent.
+
+## Choose the Mode
+
+- **Pre-handoff review:** review the complete branch diff against its base before calling a change ready.
+- **PR feedback:** inspect unresolved review threads and address safe, actionable findings.
+- **Scheduled babysitting:** repeat PR feedback mode in an isolated worktree until the PR closes or user input is required.
+
+## Pre-handoff Review
+
+1. Identify the base branch and confirm the worktree contains only intended changes.
+2. Run the relevant focused tests and `make check` before review. On this macOS workspace, use `make check PNPM=/opt/homebrew/bin/pnpm` when the fallback pnpm cannot find `node`.
+3. Select every applicable review target:
+   - review committed branch changes with **Review against a base branch**;
+   - review staged, unstaged, and untracked changes with **Review uncommitted changes**;
+   - run both when the branch has commits and additional worktree changes. A base-branch review does not include uncommitted work.
+   - in a scheduled or agent workflow, delegate each applicable target to a separate read-only reviewer agent with no edit or GitHub-write authority;
+   - use `codex review --base <base>` or `codex review --uncommitted` only when the user explicitly authorizes that CLI review and environment policy permits repository data to be sent. Never retry or bypass a denied data-export action.
+4. Treat the review as read-only. Triage findings before editing:
+   - fix high-confidence correctness, security, data-integrity, lifecycle, and regression findings;
+   - reject findings contradicted by repository behavior or tests, recording the evidence;
+   - stop for product decisions or scope changes.
+5. Apply accepted fixes, rerun focused checks and `make check`, then run one final dedicated review pass.
+6. Limit one run to two review-and-fix passes. Report remaining findings rather than looping indefinitely.
+
+## PR Feedback
+
+1. Resolve the PR from the current branch or explicit PR number.
+2. Read thread-aware GitHub review state, including resolution and outdated status. Prefer the connected GitHub review-thread tool; fall back to GitHub GraphQL through `gh`. On this macOS workspace, use `/opt/homebrew/bin/gh` when Homebrew is absent from `PATH`. Never classify from a flat comment list alone.
+3. Group unresolved comments by behavior and classify them:
+   - **Safe to address:** clear P1/P2 correctness defects within PR intent, with a deterministic validation path;
+   - **Needs user input:** P0 findings, ambiguous product behavior, conflicting comments, migrations, new dependencies, new services or cost, secrets, auth-policy changes, destructive data work, or material API changes;
+   - **Non-blocking:** advisory, style-only, duplicate, outdated, or already-fixed comments.
+4. Explain the actionable scope before editing unless the calling prompt explicitly authorizes all safe findings.
+5. Keep every edit traceable to a selected thread. Add focused regression coverage at the seam the reviewer identified.
+6. Run focused checks, `make check` (using the Homebrew pnpm override above when needed), and `make e2e` when the change affects the browser game loop.
+
+## Publishing an Authorized Fix
+
+Only publish when the user or scheduled-task prompt explicitly authorizes GitHub writes.
+
+1. Confirm the branch and cleanly separate unrelated local changes.
+2. Verify Git identity is `Phugsy <263059804+Phugsy@users.noreply.github.com>`; stop on a mismatch.
+3. Commit one coherent review batch and push the PR branch.
+4. Reply to each addressed top-level review thread with the commit hash, concise rationale, and validation evidence.
+5. Resolve only threads fully addressed by that commit.
+6. Re-read thread-aware review state and current checks. Report any new or unresolved feedback.
+
+Never merge, close the PR, delete branches, force-push, or broaden the PR. Leave those actions to the user.
+
+## Scheduled Babysitting
+
+Run in a dedicated worktree. On each invocation:
+
+1. Find open Fantasy Sumo PRs authored from `codex/*` branches, or use the explicit PR supplied by the task.
+2. Fetch the PR remote branch, check it out cleanly in the worktree, and record its remote head SHA. Stop if the worktree is dirty or the branch cannot fast-forward to that SHA.
+3. If no unresolved actionable P1/P2 feedback exists, make no changes and report a clean poll.
+4. Address at most one coherent safe batch per PR and validate it as above.
+5. Immediately before committing or pushing, fetch the PR branch again and compare its remote head SHA with the recorded SHA. If it changed during the run, do not commit or push; preserve the diff for inspection and notify the user so the next run can restart from the new head. Never force-push.
+6. When the head is unchanged and the task prompt explicitly authorizes the limited writes, commit, push, reply, and resolve as above.
+7. Stop and notify the user when a finding needs user input, validation fails, the branch changed unexpectedly, or repository access is unavailable.
+8. Stop monitoring a PR after it is merged or closed, and pause or delete the PR-scoped automation when the scheduling surface permits it.
+
+Do not use scheduled runs to approve or merge pull requests.

--- a/skills/fantasy-sumo-pr-review-loop/SKILL.md
+++ b/skills/fantasy-sumo-pr-review-loop/SKILL.md
@@ -17,6 +17,8 @@ Keep review fixes focused, independently checked, and traceable to their GitHub 
 
 1. Identify the base branch and confirm the worktree contains only intended changes.
 2. Run the relevant focused tests and `make check` before review. On this macOS workspace, use `make check PNPM=/opt/homebrew/bin/pnpm` when the fallback pnpm cannot find `node`.
+   - When the change affects the browser game loop, run the relevant Playwright coverage or `make e2e` before the initial handoff. Do not defer this until PR feedback arrives.
+   - When the change materially affects UI layout, interaction, responsive behaviour, or a state that assertions may not represent well, also run an agent-browser visual pass when that tooling is available. Treat visual inspection as a supplement to E2E, never a replacement.
 3. Select every applicable review target:
    - review committed branch changes with **Review against a base branch**;
    - review staged, unstaged, and untracked changes with **Review uncommitted changes**;
@@ -40,7 +42,7 @@ Keep review fixes focused, independently checked, and traceable to their GitHub 
    - **Non-blocking:** advisory, style-only, duplicate, outdated, or already-fixed comments.
 4. Explain the actionable scope before editing unless the calling prompt explicitly authorizes all safe findings.
 5. Keep every edit traceable to a selected thread. Add focused regression coverage at the seam the reviewer identified.
-6. Run focused checks, `make check` (using the Homebrew pnpm override above when needed), and `make e2e` when the change affects the browser game loop.
+6. Run focused checks, `make check` (using the Homebrew pnpm override above when needed), and `make e2e` when the change affects the browser game loop. Add an agent-browser visual pass when the UI risk warrants it and the tooling is available.
 
 ## Publishing an Authorized Fix
 

--- a/skills/fantasy-sumo-pr-review-loop/SKILL.md
+++ b/skills/fantasy-sumo-pr-review-loop/SKILL.md
@@ -49,7 +49,7 @@ Keep review fixes focused, independently checked, and traceable to their GitHub 
 Only publish when the user or scheduled-task prompt explicitly authorizes GitHub writes.
 
 1. Confirm the branch and cleanly separate unrelated local changes.
-2. Verify Git identity is `Phugsy <263059804+Phugsy@users.noreply.github.com>`; stop on a mismatch.
+2. Verify Git identity is `Phugsy <263059804+Phugsy@users.noreply.github.com>` and `/opt/homebrew/bin/gh api user --jq .login` returns `Phugsy`; stop if either identity mismatches or the authenticated GitHub actor cannot be verified.
 3. Commit one coherent review batch and push the PR branch.
 4. Reply to each addressed top-level review thread with the commit hash, concise rationale, and validation evidence.
 5. Resolve only threads fully addressed by that commit.
@@ -61,7 +61,7 @@ Never merge, close the PR, delete branches, force-push, or broaden the PR. Leave
 
 Run in a dedicated worktree. On each invocation:
 
-1. Find open Fantasy Sumo PRs authored from `codex/*` branches, or use the explicit PR supplied by the task.
+1. Require the scheduled task to supply exactly one explicit PR number. Never discover or scan other open PRs in scheduled mode; stop and request a corrected task if the PR number is missing or ambiguous.
 2. Fetch the PR remote branch, check it out cleanly in the worktree, and record its remote head SHA. Stop if the worktree is dirty or the branch cannot fast-forward to that SHA.
 3. If no unresolved actionable P1/P2 feedback exists, make no changes and report a clean poll.
 4. Address at most one coherent safe batch per PR and validate it as above.

--- a/skills/fantasy-sumo-pr-review-loop/agents/openai.yaml
+++ b/skills/fantasy-sumo-pr-review-loop/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Fantasy Sumo PR Review Loop"
+  short_description: "Review and safely address Fantasy Sumo PR feedback"
+  default_prompt: "Use $fantasy-sumo-pr-review-loop to review the current PR and safely address actionable feedback."


### PR DESCRIPTION
## Summary

- add repository review guidelines for automatic Codex reviews
- require a dedicated pre-handoff review before non-trivial changes are called ready
- require relevant Playwright E2E before the initial handoff when the browser game loop changes
- recommend an agent-browser visual pass for meaningful UI or interaction risk when available, as a supplement to E2E
- open completed and validated PRs ready for review so automatic Codex GitHub review runs; reserve drafts for incomplete, blocked, or explicitly requested checkpoints
- add a reusable PR review loop for thread-aware triage, safe fixes, validation, replies, and resolution
- let the issue loop start a PR-scoped scheduled babysitter in an isolated worktree when that capability is available

## Safety boundaries

- automatically address only clear, testable P1/P2 findings within the PR intent
- stop for P0, ambiguous product decisions, migrations, dependencies, services, secrets, auth policy, destructive work, or material API changes
- verify the configured Phugsy identity and remote head SHA before publishing
- never merge, approve, close, delete branches, or force-push

## Validation

- `quick_validate.py skills/fantasy-sumo-pr-review-loop` — passed
- independent forward test of the new skill — passed after fixing review-target, authorization, and remote-head freshness gaps
- `make check PNPM=/opt/homebrew/bin/pnpm` — passed, including 117 tests and builds
- `pnpm format:check` — passed as part of `make check`
- E2E skipped because this PR changes repository workflow documentation only and does not change the browser game loop

## Follow-up

- #45 tracks the E2E harness and now records the initial-handoff E2E and optional visual-pass requirements
- #63 tracks moving guarded review remediation to an event-driven GitHub Actions workflow, including a measured cost pilot and security controls

## Notes

The GitHub automatic-review setting was already working. This PR defines the guarded remediation workflow and makes ready-for-review the default once handoff gates pass; it does not change product behavior.
