### PR TITLE
Expand E2E quality loop across desktop and mobile

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,48 @@
+name: Quality
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run main validation
+        run: make check
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium webkit
+
+      - name: Run browser E2E
+        run: make e2e
+
+      - name: Upload Playwright failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-failure-artifacts
+          path: |
+            playwright-report/
+            test-results/
+          if-no-files-found: ignore
+          retention-days: 7

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ e2e: ## Run Playwright E2E tests against deterministic demo data.
 e2e-ui: ## Open the Playwright UI runner.
 	$(PNPM) e2e:ui
 
-e2e-install: ## Install the Chromium browser used by Playwright.
+e2e-install: ## Install the Chromium and WebKit browsers used by Playwright.
 	$(PNPM) e2e:install
 
 db-migrate: ## Apply local database migrations.

--- a/README.md
+++ b/README.md
@@ -101,11 +101,15 @@ make dev
 Run the browser E2E suite:
 
 ```bash
-make e2e-install  # one-time Chromium install
+make e2e-install  # one-time Chromium and WebKit install
 make e2e
 ```
 
 The Playwright suite starts the Fastify API and Vite web app, resets deterministic demo data, and uses a dedicated SQLite database at `packages/db/data/e2e/fantasy-sumo-e2e.sqlite` by default. Override the test database with `E2E_DATABASE_URL=file:./data/e2e/another.sqlite`. Do not point E2E at the default developer database or production data.
+
+The core journey runs in desktop Chrome, emulated mobile Chrome, and emulated
+mobile Safari/WebKit. Failures retain a trace, screenshot, and video under
+`test-results/`; CI also publishes the Playwright report and failure artifacts.
 
 Local URLs:
 

--- a/apps/api/src/routes/admin-demo.test.ts
+++ b/apps/api/src/routes/admin-demo.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { FastifyInstance } from "fastify";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   DEMO_FINAL_DAY,
   createDatabaseClient,
@@ -33,16 +33,52 @@ afterEach(async () => {
 });
 
 describe("admin demo routes", () => {
-  it("rejects demo progression requests without the configured token", async () => {
-    const response = await app.inject({
+  it("rejects demo progression requests with missing or invalid tokens", async () => {
+    const missingTokenResponse = await app.inject({
       method: "POST",
       url: "/api/admin/demo/reset",
     });
 
-    expect(response.statusCode).toBe(401);
-    expect(response.json()).toMatchObject({
+    expect(missingTokenResponse.statusCode).toBe(401);
+    expect(missingTokenResponse.json()).toMatchObject({
       error: "demo-admin-unauthorized",
     });
+
+    const invalidTokenResponse = await app.inject({
+      headers: {
+        "x-demo-admin-token": "wrong-token",
+      },
+      method: "POST",
+      url: "/api/admin/demo/reset",
+    });
+
+    expect(invalidTokenResponse.statusCode).toBe(401);
+    expect(invalidTokenResponse.json()).toMatchObject({
+      error: "demo-admin-unauthorized",
+    });
+  });
+
+  it("hides demo progression routes when no token is configured", async () => {
+    vi.stubEnv("DEMO_ADMIN_TOKEN", "");
+    const disabledApp = buildApp({
+      db: client,
+      now: () => new Date("2026-05-10T00:00:00.000Z"),
+    });
+
+    try {
+      const response = await disabledApp.inject({
+        method: "POST",
+        url: "/api/admin/demo/reset",
+      });
+
+      expect(response.statusCode).toBe(404);
+      expect(response.json()).toMatchObject({
+        error: "demo-admin-disabled",
+      });
+    } finally {
+      await disabledApp.close();
+      vi.unstubAllEnvs();
+    }
   });
 
   it("resets, starts, advances, and completes demo progression", async () => {

--- a/docs/E2E_TESTING.md
+++ b/docs/E2E_TESTING.md
@@ -154,7 +154,19 @@ make e2e-install
 make e2e
 ```
 
-The suite uses Chromium only for now, starts the local Fastify API and Vite web app, and runs with one worker because the tests reset shared deterministic demo data. By default it writes to a test-only SQLite file:
+The suite starts the local Fastify API and Vite web app and runs with one worker
+because the tests reset shared deterministic demo data. The core journey runs
+through three Playwright projects:
+
+- desktop Chromium using the Desktop Chrome device profile;
+- mobile Chromium using the Pixel 5 device profile;
+- mobile WebKit using the iPhone 13 device profile.
+
+These mobile projects emulate mobile browser behaviour, including their
+viewport, user agent, device scale, touch support, and browser engine. They are
+not substitutes for occasional testing on physical devices.
+
+By default the harness writes to a test-only SQLite file:
 
 ```bash
 file:./data/e2e/fantasy-sumo-e2e.sqlite
@@ -167,6 +179,24 @@ E2E_DATABASE_URL=file:./data/e2e/local-run.sqlite make e2e
 ```
 
 Playwright uses ports `3000` for the API and `7866` for Vite. Stop any existing processes on those ports if the harness cannot start them. The protected demo admin controls are enabled with an E2E-only `DEMO_ADMIN_TOKEN` from the Playwright config; no live sumo data sources or production services are used.
+
+The browser suite covers API-backed app loading, team creation, selection
+validation, pick locking, protected demo progression, score refreshes,
+leaderboard ordering, and responsive navigation. Admin-route configuration is
+also covered at the Fastify boundary: missing or invalid credentials are
+rejected, disabled demo routes return `404`, and enabled routes drive the real
+browser lifecycle tests.
+
+On failure Playwright retains a trace, screenshot, and video under
+`test-results/`. In CI, the HTML report and test artifacts are uploaded for
+inspection. Use the trace viewer locally with:
+
+```bash
+pnpm exec playwright show-trace test-results/<result-directory>/trace.zip
+```
+
+The GitHub Actions quality workflow runs `make check` and `make e2e` for pull
+requests and pushes to `master`.
 
 ## Agent Completion Loop
 
@@ -183,6 +213,34 @@ For relevant tickets, a change should not be considered complete until the agent
 If E2E cannot be run because of a local environment, browser install, sandbox, or port constraint, the agent should state that clearly in the PR summary and run the closest lower-level checks instead.
 
 Do not require E2E for documentation-only changes, isolated domain scoring changes, or API-only changes that have no browser journey impact unless the ticket explicitly asks for it.
+
+## Agent-Browser Visual Pass
+
+Use agent-browser as an exploratory visual layer when UI layout, responsive
+behaviour, interaction feedback, or a difficult-to-assert state changes. It
+supplements committed Playwright assertions; it is not a replacement or a CI
+gate.
+
+A useful pass should use separate desktop and mobile sessions and collect both
+semantic and visual evidence:
+
+```bash
+agent-browser --session fantasy-sumo-desktop set viewport 1440 900
+agent-browser --session fantasy-sumo-desktop open http://127.0.0.1:7866
+agent-browser --session fantasy-sumo-desktop snapshot -i
+agent-browser --session fantasy-sumo-desktop screenshot --full
+
+agent-browser --session fantasy-sumo-mobile set device "iPhone 14"
+agent-browser --session fantasy-sumo-mobile open http://127.0.0.1:7866
+agent-browser --session fantasy-sumo-mobile snapshot -i
+agent-browser --session fantasy-sumo-mobile screenshot --full
+```
+
+Exercise the relevant journey, re-snapshot after page changes, and inspect
+console messages, page errors, and API requests when the installed
+agent-browser version supports those debug commands. Report which sessions,
+viewports/devices, and interactions were checked. Close both sessions after the
+pass.
 
 ## What Belongs In E2E
 
@@ -207,13 +265,9 @@ Keep detailed rules and edge cases out of E2E when faster tests cover them bette
 
 E2E should prove that the pieces work together for the main game loop. It should not duplicate every lower-level rule.
 
-## Follow-Up Implementation Ticket
+## Deferred Journeys
 
-The Playwright implementation work is tracked in GitHub issue #23. That ticket should:
-
-- add Playwright and browser installation instructions;
-- add root `pnpm e2e` and `pnpm e2e:ui` scripts;
-- add `make e2e` and optionally `make e2e-ui`;
-- configure deterministic E2E database setup/reset;
-- cover the first smoke, create-team, leaderboard, and validation flows listed above;
-- document any sandbox or port requirements needed by Codex.
+Authentication, current-user team retrieval, pick editing, and browser-driven
+admin/import controls do not exist in the current UI. Add their E2E journeys in
+the feature tickets that introduce those behaviours instead of encoding
+speculative tests here.

--- a/e2e/mvp-game-loop.spec.ts
+++ b/e2e/mvp-game-loop.spec.ts
@@ -69,6 +69,69 @@ test("shows completed demo leaderboard entries in score order", async ({
   await expect(page.getByText(/wins/).first()).toBeVisible();
 });
 
+test("locks team selection after the demo basho starts", async ({
+  page,
+  request,
+}) => {
+  const unauthorizedResponse = await request.post("/api/admin/demo/start");
+  expect(unauthorizedResponse.status()).toBe(401);
+
+  const startResponse = await request.post("/api/admin/demo/start", {
+    headers: demoAdminHeaders,
+  });
+  await expect(startResponse).toBeOK();
+
+  await page.goto("/");
+
+  await expect(
+    page.getByText("This basho has started, so picks are locked."),
+  ).toBeVisible();
+  await expect(page.getByLabel("Team name")).toBeDisabled();
+  await expect(page.getByRole("button", { name: /Onosato/ })).toBeDisabled();
+  await expect(
+    page.getByRole("button", { name: "Submit team" }),
+  ).toBeDisabled();
+
+  const lockedTeamResponse = await request.post(
+    "/api/basho/demo-2026-05/teams",
+    {
+      data: {
+        displayName: "Late Stable",
+        rikishiIds: ["onosato", "hoshoryu"],
+      },
+    },
+  );
+  expect(lockedTeamResponse.status()).toBe(409);
+  expect(await lockedTeamResponse.json()).toMatchObject({
+    error: "picks-locked",
+  });
+});
+
+test("advances the demo basho and refreshes scored leaderboard state", async ({
+  page,
+  request,
+}) => {
+  const startResponse = await request.post("/api/admin/demo/start", {
+    headers: demoAdminHeaders,
+  });
+  await expect(startResponse).toBeOK();
+
+  const advanceResponse = await request.post("/api/admin/demo/advance-day", {
+    headers: demoAdminHeaders,
+  });
+  await expect(advanceResponse).toBeOK();
+
+  await page.goto("/");
+  await page.getByRole("button", { name: "Leaderboard" }).click();
+
+  await expect(page.getByText("Demo May Basho - Day 1 of 15")).toBeVisible();
+  await expect(page.getByText("Status: Scoring in progress")).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: /Dohyo Dreamers.*1 pts/ }),
+  ).toBeVisible();
+  await expect(page.getByText(/1 win/).first()).toBeVisible();
+});
+
 test("prevents incomplete and overfull team submissions", async ({ page }) => {
   await page.goto("/");
 
@@ -90,45 +153,38 @@ test("prevents incomplete and overfull team submissions", async ({ page }) => {
   await expect(submitButton).toBeDisabled();
 });
 
-test("keeps navigation, ranks, and core views usable at supported widths", async ({
+test("keeps navigation, ranks, and core views usable on the emulated device", async ({
   page,
 }) => {
-  for (const viewport of [
-    { width: 375, height: 812 },
-    { width: 768, height: 1024 },
-    { width: 1280, height: 900 },
-  ]) {
-    await page.setViewportSize(viewport);
-    await page.goto("/");
+  await page.goto("/");
 
-    await expect(
-      page.getByRole("navigation", { name: "Primary navigation" }),
-    ).toBeVisible();
+  await expect(
+    page.getByRole("navigation", { name: "Primary navigation" }),
+  ).toBeVisible();
 
-    const longRank = page.getByText("Maegashira #1", { exact: true });
-    await expect(longRank).toBeVisible();
-    expect(
-      await longRank.evaluate(
-        (element) => element.scrollWidth <= element.clientWidth,
-      ),
-    ).toBe(true);
+  const longRank = page.getByText("Maegashira #1", { exact: true });
+  await expect(longRank).toBeVisible();
+  expect(
+    await longRank.evaluate(
+      (element) => element.scrollWidth <= element.clientWidth,
+    ),
+  ).toBe(true);
 
-    expect(
-      await page.evaluate(
-        () => document.documentElement.scrollWidth <= window.innerWidth,
-      ),
-    ).toBe(true);
+  expect(
+    await page.evaluate(
+      () => document.documentElement.scrollWidth <= window.innerWidth,
+    ),
+  ).toBe(true);
 
-    await page.getByRole("button", { name: "Leaderboard" }).click();
-    await expect(
-      page.getByRole("heading", { name: "Follow the leaderboard" }),
-    ).toBeVisible();
-    expect(
-      await page.evaluate(
-        () => document.documentElement.scrollWidth <= window.innerWidth,
-      ),
-    ).toBe(true);
-  }
+  await page.getByRole("button", { name: "Leaderboard" }).click();
+  await expect(
+    page.getByRole("heading", { name: "Follow the leaderboard" }),
+  ).toBeVisible();
+  expect(
+    await page.evaluate(
+      () => document.documentElement.scrollWidth <= window.innerWidth,
+    ),
+  ).toBe(true);
 });
 
 async function resetDemo(request: APIRequestContext) {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "import:results": "pnpm --filter @fantasy-sumo/api import:results",
     "e2e": "playwright test",
     "e2e:ui": "playwright test --ui",
-    "e2e:install": "playwright install chromium",
+    "e2e:install": "playwright install chromium webkit",
     "test": "pnpm --filter @fantasy-sumo/domain build && pnpm -r --if-present test",
     "lint": "eslint .",
     "format": "prettier --write .",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,12 +20,22 @@ export default defineConfig({
   reporter: process.env.CI ? [["list"], ["html", { open: "never" }]] : "list",
   use: {
     baseURL: "http://127.0.0.1:7866",
-    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    trace: "retain-on-failure",
+    video: "retain-on-failure",
   },
   projects: [
     {
-      name: "chromium",
+      name: "desktop-chromium",
       use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "mobile-chromium",
+      use: { ...devices["Pixel 5"] },
+    },
+    {
+      name: "mobile-webkit",
+      use: { ...devices["iPhone 13"] },
     },
   ],
   webServer: [


### PR DESCRIPTION
Closes #45

## Summary

- run the core Fantasy Sumo journey in desktop Chromium, mobile Chromium, and mobile WebKit
- cover browser-level pick locking, protected demo progression, and scored leaderboard refreshes
- retain Playwright traces, screenshots, and videos on failure
- verify missing, invalid, disabled, and valid demo-admin configurations at the appropriate API/browser boundaries
- run the main validation and multi-browser E2E suites in GitHub Actions, with failure artifacts uploaded
- document the agent-browser visual loop and defer journeys for UI features that do not exist yet

## Validation

- make check PNPM=pnpm — passed
- pnpm --dir apps/api exec vitest run src/routes/admin-demo.test.ts — passed (3 tests)
- make e2e PNPM=pnpm — passed (21 tests across desktop Chromium, mobile Chromium, and mobile WebKit)
- agent-browser 0.32.2 desktop 1440x900 pass — team selection, submission, leaderboard expansion, console and page errors checked
- agent-browser 0.32.2 emulated iPhone 14 pass — responsive selection, submission, leaderboard, locked state, console and page errors checked
- dedicated pre-handoff review — one P2 documentation/credential-coverage mismatch fixed; final pass found no remaining actionable findings

## E2E and visual evidence

Playwright uses the isolated deterministic E2E SQLite database and one worker. The agent-browser pass used a separate isolated SQLite database. No live sumo source or production data was used.

The mobile full-page screenshot path showed a sticky-header stitching artifact; a normal viewport capture confirmed the live UI rendered correctly.

## Documentation

- updated README.md with the Chromium/WebKit install and artifact behaviour
- expanded docs/E2E_TESTING.md with the device matrix, lifecycle/admin coverage, CI evidence, failure debugging, agent-browser workflow, and deferred journeys

## Explicit non-goals

Authentication, current-user team retrieval, pick editing, and browser-driven admin/import controls remain deferred until those UI features exist.
