### PR TITLE
Separate demo and live basho data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ dev: ## Start the API and Vite web app together.
 demo: ## Reset demo data and start the API and Vite web app.
 	$(PNPM) db:migrate
 	$(PNPM) db:seed:demo
-	$(PNPM) dev
+	VITE_BASHO_MODE=demo $(PNPM) dev
 
 dev-client: ## Start only the Vite web client.
 	$(PNPM) --filter @fantasy-sumo/domain build

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ basho seed instead:
 
 ```bash
 make db-seed-demo
-make dev
+VITE_BASHO_MODE=demo make dev
 ```
 
 Or reset the demo data and start both dev servers in one command:
@@ -79,7 +79,13 @@ Or reset the demo data and start both dev servers in one command:
 make demo
 ```
 
-Demo mode replaces the configured SQLite database contents with fake but stable basho, rikishi, team, and pick data. It starts at day 0 with picks open and no applied results. It does not use live sumo data, but it does exercise the same API, UI, database, and scoring logic as normal local development.
+Demo mode replaces only the fixed demo basho and its dependent banzuke, team,
+pick, and result data with fake but stable fixtures. Live bashos and shared
+rikishi metadata are preserved. The demo starts at day 0 with picks open and no
+applied results. It does not use live sumo data, but it exercises the same API,
+UI, database, and scoring logic as normal local development. The explicit
+`VITE_BASHO_MODE=demo` flag makes the browser request the fixed flagged demo;
+without it, current-basho selection remains live-first.
 
 Progress the deterministic demo basho with:
 
@@ -131,7 +137,10 @@ Useful API endpoints:
 - `POST /api/admin/basho/:bashoId/import-results`
 - `GET /api/cron/import-results`
 
-The demo admin endpoints require `DEMO_ADMIN_TOKEN` and an `x-demo-admin-token` header. They reset and mutate demo data, so do not expose them without that protection.
+The demo admin endpoints require `DEMO_ADMIN_TOKEN` and an
+`x-demo-admin-token` header. They operate only on the fixed basho ID whose
+persisted record is marked `isDemo`; a colliding live record fails closed.
+Keep the token private even though reset is scoped away from live bashos.
 
 The admin import endpoints are local development tools for now. Do not expose them publicly without authentication/protection.
 
@@ -228,7 +237,7 @@ Common targets:
 - `make demo` - reset deterministic demo data, then start the API and web client together.
 - `make dev-client` - start only the Vite web client.
 - `make dev-server` - start only the Fastify API.
-- `make db-seed-demo` - reset the configured SQLite database with deterministic demo data.
+- `make db-seed-demo` - reset the scoped deterministic demo basho data.
 - `make demo-reset` - reset demo progression to day 0 with picks open.
 - `make demo-start` - lock existing demo picks and start the basho without applying results.
 - `make demo-advance-day` - apply the next day of deterministic demo results.

--- a/apps/api/src/imports/adapters.ts
+++ b/apps/api/src/imports/adapters.ts
@@ -81,6 +81,7 @@ export function mapJsaBanzukePayload(
     source: "jsa-banzuke",
     basho: {
       id: bashoId,
+      isDemo: false,
       name: formatJsaBashoName(payload),
       startDate,
       endDate,

--- a/apps/api/src/imports/scheduled-results.ts
+++ b/apps/api/src/imports/scheduled-results.ts
@@ -1,5 +1,5 @@
 import type { Basho } from "@fantasy-sumo/domain";
-import { DEMO_BASHO_ID, type Repositories } from "@fantasy-sumo/db";
+import type { Repositories } from "@fantasy-sumo/db";
 import { fetchSumoApiResultsImport } from "./adapters.js";
 import { importBoutResults } from "./service.js";
 import type { ImportResult, SourceFetch } from "./types.js";
@@ -46,7 +46,7 @@ export async function runScheduledResultsImport(
       (basho.status === "upcoming" ||
         basho.status === "locked" ||
         basho.status === "active") &&
-      basho.id !== DEMO_BASHO_ID,
+      !basho.isDemo,
   );
   const eligibleBashos = scheduledBashos.flatMap((basho) => {
     const day = resolveBashoDay(basho, japanDate);

--- a/apps/api/src/imports/service.test.ts
+++ b/apps/api/src/imports/service.test.ts
@@ -22,6 +22,7 @@ const banzukeCommand: BanzukeImportCommand = {
   source: "test",
   basho: {
     id: "2026-05",
+    isDemo: false,
     name: "May 2026",
     startDate: "2026-05-10",
     endDate: "2026-05-24",

--- a/apps/api/src/imports/service.ts
+++ b/apps/api/src/imports/service.ts
@@ -384,6 +384,7 @@ function summarizeMany<T extends { id: string }>(
 function isEqualBasho(left: Basho, right: Basho) {
   return (
     left.id === right.id &&
+    left.isDemo === right.isDemo &&
     left.name === right.name &&
     left.startDate === right.startDate &&
     left.endDate === right.endDate &&

--- a/apps/api/src/routes/admin-demo.test.ts
+++ b/apps/api/src/routes/admin-demo.test.ts
@@ -6,7 +6,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   DEMO_FINAL_DAY,
   createDatabaseClient,
+  createRepositories,
   runMigrations,
+  seedDatabase,
+  sampleBasho,
   type DatabaseClient,
 } from "@fantasy-sumo/db";
 import { buildApp } from "../app.js";
@@ -163,6 +166,29 @@ describe("admin demo routes", () => {
         }),
       ]),
     );
+  });
+
+  it("preserves live basho data when the demo reset endpoint runs", async () => {
+    const repositories = createRepositories(client);
+    await seedDatabase(repositories);
+
+    const response = await app.inject({
+      headers: demoAdminHeaders,
+      method: "POST",
+      url: "/api/admin/demo/reset",
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(await repositories.getBasho(sampleBasho.id)).toEqual(sampleBasho);
+    expect(
+      await repositories.listFantasyTeamsForBasho(sampleBasho.id),
+    ).not.toHaveLength(0);
+    expect(
+      await repositories.listFantasyPicksForBasho(sampleBasho.id),
+    ).not.toHaveLength(0);
+    expect(
+      await repositories.listBoutResultsForBasho(sampleBasho.id),
+    ).not.toHaveLength(0);
   });
 });
 

--- a/apps/api/src/routes/basho.test.ts
+++ b/apps/api/src/routes/basho.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   createRepositories,
   createDatabaseClient,
+  demoBasho,
   runMigrations,
   seedDatabase,
   sampleBasho,
@@ -54,13 +55,14 @@ describe("basho routes", () => {
 
   it("prefers a locked current basho over a later upcoming basho", async () => {
     const repositories = createRepositories(client);
-    repositories.upsertBasho({
+    await repositories.upsertBasho({
       ...sampleBasho,
       status: "locked",
       currentDay: 1,
     });
-    repositories.insertBasho({
+    await repositories.insertBasho({
       id: "2026-07",
+      isDemo: false,
       name: "July 2026 Future Basho",
       startDate: "2026-07-12",
       endDate: "2026-07-26",
@@ -78,6 +80,67 @@ describe("basho routes", () => {
       id: "2026-05",
       status: "locked",
       currentDay: 1,
+    });
+  });
+
+  it("prefers a live basho over an active demo basho", async () => {
+    const repositories = createRepositories(client);
+    await repositories.insertBasho({
+      ...demoBasho,
+      status: "active",
+      currentDay: 3,
+    });
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/basho/current",
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      id: sampleBasho.id,
+      isDemo: false,
+    });
+  });
+
+  it("returns the flagged demo basho only when demo mode is explicit", async () => {
+    const repositories = createRepositories(client);
+    await repositories.insertBasho({
+      ...demoBasho,
+      status: "active",
+      currentDay: 3,
+    });
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/basho/current?mode=demo",
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      id: demoBasho.id,
+      isDemo: true,
+      status: "active",
+      currentDay: 3,
+    });
+  });
+
+  it("does not treat a live fixed-ID collision as the demo basho", async () => {
+    const repositories = createRepositories(client);
+    await repositories.insertBasho({
+      ...demoBasho,
+      isDemo: false,
+    });
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/basho/current?mode=demo",
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json()).toMatchObject({
+      error: "not-found",
+      message: "The demo basho is not available.",
     });
   });
 

--- a/apps/api/src/routes/basho.ts
+++ b/apps/api/src/routes/basho.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
-import type { Repositories } from "@fantasy-sumo/db";
+import { DEMO_BASHO_ID, type Repositories } from "@fantasy-sumo/db";
 import type { FantasyPick, FantasyTeam } from "@fantasy-sumo/domain";
 import {
   calculateLeaderboard,
@@ -22,25 +22,47 @@ const createTeamBodySchema = z.object({
   rikishiIds: z.array(z.string().trim().min(1)),
 });
 
+const currentBashoQuerySchema = z.object({
+  mode: z.enum(["demo"]).optional(),
+});
+
 export function registerBashoRoutes(
   app: FastifyInstance,
   context: RouteContext,
 ) {
-  app.get("/api/basho/current", async (_request, reply) => {
-    const currentBasho = await findCurrentBasho(context.repositories);
+  app.get<{ Querystring: unknown }>(
+    "/api/basho/current",
+    async (request, reply) => {
+      const parsedQuery = currentBashoQuerySchema.safeParse(request.query);
 
-    if (currentBasho === undefined) {
-      return reply.code(404).send({
-        error: "not-found",
-        message: "No basho is available.",
-      });
-    }
+      if (!parsedQuery.success) {
+        return reply.code(400).send({
+          error: "invalid-request",
+          message: "The current basho mode is invalid.",
+        });
+      }
 
-    return {
-      ...currentBasho,
-      teamSize: context.teamSize,
-    };
-  });
+      const currentBasho =
+        parsedQuery.data.mode === "demo"
+          ? await findDemoBasho(context.repositories)
+          : await findCurrentBasho(context.repositories);
+
+      if (currentBasho === undefined) {
+        return reply.code(404).send({
+          error: "not-found",
+          message:
+            parsedQuery.data.mode === "demo"
+              ? "The demo basho is not available."
+              : "No basho is available.",
+        });
+      }
+
+      return {
+        ...currentBasho,
+        teamSize: context.teamSize,
+      };
+    },
+  );
 
   app.get<{
     Params: { bashoId: string };
@@ -265,11 +287,18 @@ function getBashoTotalDays(basho: { startDate: string; endDate: string }) {
 
 async function findCurrentBasho(repositories: Repositories) {
   const bashos = await repositories.listBashos();
-  const latestFirst = [...bashos].reverse();
+  const liveBashos = bashos.filter((basho) => !basho.isDemo);
+  const candidates = liveBashos.length > 0 ? liveBashos : bashos;
+  const latestFirst = [...candidates].reverse();
 
   return (
     latestFirst.find((basho) => basho.status === "active") ??
     latestFirst.find((basho) => basho.status === "locked") ??
     latestFirst.at(0)
   );
+}
+
+async function findDemoBasho(repositories: Repositories) {
+  const basho = await repositories.getBasho(DEMO_BASHO_ID);
+  return basho?.isDemo === true ? basho : undefined;
 }

--- a/apps/api/src/routes/scheduled-imports.test.ts
+++ b/apps/api/src/routes/scheduled-imports.test.ts
@@ -392,7 +392,7 @@ describe("scheduled result import route", () => {
   });
 
   it("does not treat the deterministic demo basho as a live import target", async () => {
-    await seedLiveBasho(DEMO_BASHO_ID);
+    await seedLiveBasho(DEMO_BASHO_ID, { isDemo: true });
     app = createApp();
 
     const response = await injectCron(app);
@@ -463,6 +463,7 @@ function injectCron(instance: FastifyInstance) {
 async function seedLiveBasho(
   bashoId: string,
   options: {
+    isDemo?: boolean;
     status?: "active" | "locked" | "upcoming";
     currentDay?: number;
     importedDays?: number[];
@@ -473,6 +474,7 @@ async function seedLiveBasho(
 
   await repositories.insertBasho({
     id: bashoId,
+    isDemo: options.isDemo ?? false,
     name: "May 2026",
     startDate: "2026-05-10",
     endDate: "2026-05-24",

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -4,6 +4,7 @@ import { App } from "./App";
 
 const currentBasho = {
   id: "2026-05",
+  isDemo: false,
   name: "May 2026 Sample Basho",
   startDate: "2026-05-10",
   endDate: "2026-05-24",

--- a/apps/web/src/api.test.ts
+++ b/apps/web/src/api.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { getCurrentBashoUrl } from "./api";
+
+describe("getCurrentBashoUrl", () => {
+  it("uses the normal current-basho route by default", () => {
+    expect(getCurrentBashoUrl(undefined)).toBe("/api/basho/current");
+  });
+
+  it("selects the demo basho only in explicit demo mode", () => {
+    expect(getCurrentBashoUrl("demo")).toBe("/api/basho/current?mode=demo");
+  });
+});

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -13,7 +13,15 @@ interface ApiErrorBody {
 }
 
 export async function fetchCurrentBasho(): Promise<Basho> {
-  return getJson<Basho>("/api/basho/current");
+  return getJson<Basho>(getCurrentBashoUrl());
+}
+
+export function getCurrentBashoUrl(
+  mode: string | undefined = import.meta.env.VITE_BASHO_MODE,
+): string {
+  return mode === "demo"
+    ? "/api/basho/current?mode=demo"
+    : "/api/basho/current";
 }
 
 export async function fetchBashoRikishi(

--- a/apps/web/src/components/BashoPanel.test.tsx
+++ b/apps/web/src/components/BashoPanel.test.tsx
@@ -5,6 +5,7 @@ import type { Basho } from "../types";
 
 const basho: Basho = {
   id: "2026-05",
+  isDemo: false,
   name: "May 2026 Sample Basho",
   startDate: "2026-05-10",
   endDate: "2026-05-24",

--- a/apps/web/src/components/LeaderboardPanel.test.tsx
+++ b/apps/web/src/components/LeaderboardPanel.test.tsx
@@ -5,6 +5,7 @@ import type { Basho, LeaderboardEntry, RankedRikishi } from "../types";
 
 const basho: Basho = {
   id: "2026-05",
+  isDemo: false,
   name: "Demo May Basho",
   startDate: "2026-05-10",
   endDate: "2026-05-24",

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -1,5 +1,6 @@
 export interface Basho {
   id: string;
+  isDemo: boolean;
   name: string;
   startDate: string;
   endDate: string;

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_BASHO_MODE?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,6 +159,12 @@ Current behaviour:
   transaction so concurrent refreshes cannot reopen picks.
 - Provides sample seed data for one basho, four rikishi, two fantasy teams, picks, and bout results.
 - Provides deterministic demo seed data for one pickable basho, eight rikishi, four fantasy teams, picks, and a 15-day bout result fixture.
+- Classifies bashos explicitly with `isDemo`. The fixed demo reset transaction
+  requires both the known demo ID and `isDemo: true`, replaces only that
+  basho's dependent data, and preserves live bashos and shared rikishi metadata.
+- Keeps normal current-basho selection live-first. Local demo mode explicitly
+  requests the fixed flagged demo with `VITE_BASHO_MODE=demo`, so mixed live and
+  demo data cannot silently change which environment the browser displays.
 - Provides demo progression API routes and commands that reset to day 0, start/lock picks, advance one day at a time, and complete the basho.
 - Stores basho lifecycle status and current day progress.
 
@@ -177,7 +183,14 @@ pnpm import:results -- --basho 2026-05 --day 1
 pnpm --filter @fantasy-sumo/db db:generate
 ```
 
-`pnpm db:seed:demo` is the preferred fixture reset for local demos, browser smoke checks, and the future Playwright E2E harness. It deliberately replaces the configured SQLite database contents with fake deterministic data while using the same database schema, repositories, API routes, UI, and domain scoring logic as the regular app. It starts with the demo basho in `upcoming`, `currentDay: 0`, and no applied results; use `pnpm demo:start`, `pnpm demo:advance-day`, and `pnpm demo:complete` to exercise the lifecycle.
+`pnpm db:seed:demo` is the preferred fixture reset for local demos, browser
+smoke checks, and the Playwright E2E harness. It replaces only the fixed demo
+basho with fake deterministic data while using the same database schema,
+repositories, API routes, UI, and domain scoring logic as the regular app. It
+starts with the demo basho in `upcoming`, `currentDay: 0`, and no applied
+results; use `pnpm demo:start`, `pnpm demo:advance-day`, and
+`pnpm demo:complete` to exercise the lifecycle. Whole-database reset remains a
+local/test-only helper used by the separate sample seed command.
 
 Current limitations:
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -52,6 +52,26 @@ Keep SQLite locally until there is a concrete reason to standardise development 
 
 The demo admin endpoints already require `DEMO_ADMIN_TOKEN` unless explicitly opened in tests.
 
+Demo administration is also protected at the data boundary. The application
+supports one fixed deterministic demo basho. Reset and progression require its
+known ID and a persisted `isDemo: true` flag; reset fails closed if a live basho
+uses that ID. The scoped reset transaction deletes and recreates only the demo
+basho and its dependent banzuke, teams, picks, and results. It does not clear
+live bashos or overwrite shared rikishi metadata. Scheduled production imports
+exclude every basho marked as demo.
+
+The demo-flag migration deliberately classifies every existing basho as live.
+It never infers destructive permissions from an ID alone. If an operator has a
+verified legacy demo row, they must explicitly mark that row as demo after
+backing up the database, or recreate the deterministic demo fixture in a local
+database that does not contain an ID collision.
+
+`make demo` sets `VITE_BASHO_MODE=demo`, so the browser explicitly requests the
+fixed, flagged demo basho even when the same database also contains live data.
+Normal builds omit this flag and `/api/basho/current` continues to prefer live
+bashos. The explicit demo query still verifies both the fixed ID and `isDemo`
+classification before returning a basho.
+
 The source-backed import endpoints require `ADMIN_IMPORT_TOKEN` by default. They can run without a token only when `NODE_ENV` is `development` or `test`.
 
 ```bash
@@ -103,7 +123,7 @@ On each authenticated invocation, the route calculates the current date in
    day;
 4. after the end date, it keeps a locked or active basho eligible for final-day
    recovery until day 15 completes it;
-5. it fails without mutation when more than one basho is eligible.
+5. it fails without mutation when more than one live basho is eligible.
 
 Rerunning after a successful lock is a safe no-op. Team creation and basho
 reads use only the persisted lifecycle status: `upcoming` keeps picks open,

--- a/docs/E2E_TESTING.md
+++ b/docs/E2E_TESTING.md
@@ -76,7 +76,13 @@ The demo seed command is the intended fixture source:
 make db-seed-demo
 ```
 
-For E2E, run it against a test-only `DATABASE_URL` so the reset cannot delete a developer's default local data. The demo seed uses fake data, but it flows through the real SQLite schema, repositories, Fastify API, React UI, and domain scoring code.
+For E2E, still run against a test-only `DATABASE_URL` so tests remain isolated
+from developer state. Demo reset itself is scoped to the known basho marked
+`isDemo` and cannot clear live bashos. The demo seed uses fake data, but it
+flows through the real SQLite schema, repositories, Fastify API, React UI, and
+domain scoring code. The Playwright web server sets `VITE_BASHO_MODE=demo` so
+the browser explicitly selects that fixture even if live records are also
+present.
 
 The deterministic demo lifecycle can be used as fixture setup:
 

--- a/packages/db/drizzle-pg/0001_basho_demo_flag.sql
+++ b/packages/db/drizzle-pg/0001_basho_demo_flag.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "basho"
+  ADD COLUMN "is_demo" boolean DEFAULT false NOT NULL;

--- a/packages/db/drizzle/0002_rainy_madame_hydra.sql
+++ b/packages/db/drizzle/0002_rainy_madame_hydra.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `basho` ADD `is_demo` integer DEFAULT false NOT NULL;

--- a/packages/db/drizzle/meta/0002_snapshot.json
+++ b/packages/db/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,393 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "bf951e6c-c5c3-4f5f-b355-bcb528b402e0",
+  "prevId": "9d146db8-8f2f-42ea-8d2e-962c5e5de1e1",
+  "tables": {
+    "banzuke_entries": {
+      "name": "banzuke_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "basho_id": {
+          "name": "basho_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rikishi_id": {
+          "name": "rikishi_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rank_order": {
+          "name": "rank_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "banzuke_entries_basho_rikishi_idx": {
+          "name": "banzuke_entries_basho_rikishi_idx",
+          "columns": ["basho_id", "rikishi_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "banzuke_entries_basho_id_basho_id_fk": {
+          "name": "banzuke_entries_basho_id_basho_id_fk",
+          "tableFrom": "banzuke_entries",
+          "tableTo": "basho",
+          "columnsFrom": ["basho_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "banzuke_entries_rikishi_id_rikishi_id_fk": {
+          "name": "banzuke_entries_rikishi_id_rikishi_id_fk",
+          "tableFrom": "banzuke_entries",
+          "tableTo": "rikishi",
+          "columnsFrom": ["rikishi_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "basho": {
+      "name": "basho",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_demo": {
+          "name": "is_demo",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_day": {
+          "name": "current_day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "bout_results": {
+      "name": "bout_results",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "basho_id": {
+          "name": "basho_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "day": {
+          "name": "day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "winner_rikishi_id": {
+          "name": "winner_rikishi_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "loser_rikishi_id": {
+          "name": "loser_rikishi_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kimarite": {
+          "name": "kimarite",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "winner_absent": {
+          "name": "winner_absent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "loser_absent": {
+          "name": "loser_absent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bout_results_basho_id_basho_id_fk": {
+          "name": "bout_results_basho_id_basho_id_fk",
+          "tableFrom": "bout_results",
+          "tableTo": "basho",
+          "columnsFrom": ["basho_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bout_results_winner_rikishi_id_rikishi_id_fk": {
+          "name": "bout_results_winner_rikishi_id_rikishi_id_fk",
+          "tableFrom": "bout_results",
+          "tableTo": "rikishi",
+          "columnsFrom": ["winner_rikishi_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bout_results_loser_rikishi_id_rikishi_id_fk": {
+          "name": "bout_results_loser_rikishi_id_rikishi_id_fk",
+          "tableFrom": "bout_results",
+          "tableTo": "rikishi",
+          "columnsFrom": ["loser_rikishi_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "fantasy_picks": {
+      "name": "fantasy_picks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rikishi_id": {
+          "name": "rikishi_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "fantasy_picks_team_rikishi_idx": {
+          "name": "fantasy_picks_team_rikishi_idx",
+          "columns": ["team_id", "rikishi_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "fantasy_picks_team_id_fantasy_teams_id_fk": {
+          "name": "fantasy_picks_team_id_fantasy_teams_id_fk",
+          "tableFrom": "fantasy_picks",
+          "tableTo": "fantasy_teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fantasy_picks_rikishi_id_rikishi_id_fk": {
+          "name": "fantasy_picks_rikishi_id_rikishi_id_fk",
+          "tableFrom": "fantasy_picks",
+          "tableTo": "rikishi",
+          "columnsFrom": ["rikishi_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "fantasy_teams": {
+      "name": "fantasy_teams",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "basho_id": {
+          "name": "basho_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_name": {
+          "name": "owner_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fantasy_teams_basho_id_basho_id_fk": {
+          "name": "fantasy_teams_basho_id_basho_id_fk",
+          "tableFrom": "fantasy_teams",
+          "tableTo": "basho",
+          "columnsFrom": ["basho_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rikishi": {
+      "name": "rikishi",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shikona": {
+          "name": "shikona",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "heya": {
+          "name": "heya",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1780675200000,
       "tag": "0001_basho_lifecycle",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1784412460850,
+      "tag": "0002_rainy_madame_hydra",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/demo-constants.ts
+++ b/packages/db/src/demo-constants.ts
@@ -1,0 +1,1 @@
+export const DEMO_BASHO_ID = "demo-2026-05";

--- a/packages/db/src/demo-progression.ts
+++ b/packages/db/src/demo-progression.ts
@@ -1,9 +1,9 @@
 import { calculateLeaderboard, type Basho } from "@fantasy-sumo/domain";
-import { demoBasho, demoBoutResults } from "./demo-seed-data.js";
+import { DEMO_BASHO_ID } from "./demo-constants.js";
+import { demoBoutResults } from "./demo-seed-data.js";
 import type { Repositories } from "./repositories.js";
 import { seedDemoDatabase } from "./seed.js";
 
-export const DEMO_BASHO_ID = demoBasho.id;
 export const DEMO_FINAL_DAY = Math.max(
   ...demoBoutResults.map((result) => result.day),
 );
@@ -110,9 +110,9 @@ export async function completeDemoBasho(
 async function requireDemoBasho(repositories: Repositories): Promise<Basho> {
   const basho = await repositories.getBasho(DEMO_BASHO_ID);
 
-  if (basho === undefined) {
+  if (basho === undefined || !basho.isDemo) {
     throw new Error(
-      `Demo basho ${DEMO_BASHO_ID} was not found. Run the demo reset command first.`,
+      `Demo basho ${DEMO_BASHO_ID} was not found or is not marked as demo data. Run the demo reset command first.`,
     );
   }
 

--- a/packages/db/src/demo-seed-data.ts
+++ b/packages/db/src/demo-seed-data.ts
@@ -6,9 +6,11 @@ import type {
   FantasyTeam,
   Rikishi,
 } from "@fantasy-sumo/domain";
+import { DEMO_BASHO_ID } from "./demo-constants.js";
 
 export const demoBasho: Basho = {
-  id: "demo-2026-05",
+  id: DEMO_BASHO_ID,
+  isDemo: true,
   name: "Demo May Basho",
   startDate: "2026-05-10",
   endDate: "2026-05-24",

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -14,8 +14,8 @@ export type {
 export { migrateDatabase, runMigrations } from "./migrate.js";
 export { createRepositories } from "./repositories.js";
 export type { Repositories } from "./repositories.js";
+export { DEMO_BASHO_ID } from "./demo-constants.js";
 export {
-  DEMO_BASHO_ID,
   DEMO_FINAL_DAY,
   advanceDemoBashoDay,
   completeDemoBasho,

--- a/packages/db/src/migrate.test.ts
+++ b/packages/db/src/migrate.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+describe("demo flag migration", () => {
+  it("leaves every existing basho classified as live", () => {
+    const database = new Database(":memory:");
+    database.exec(`
+      CREATE TABLE basho (
+        id text PRIMARY KEY NOT NULL,
+        name text NOT NULL,
+        start_date text NOT NULL,
+        end_date text NOT NULL,
+        status text NOT NULL,
+        current_day integer DEFAULT 0 NOT NULL
+      );
+      INSERT INTO basho VALUES
+        ('demo-2026-05', 'Unverified collision', '2026-05-10', '2026-05-24', 'upcoming', 0),
+        ('2026-05', 'Live basho', '2026-05-10', '2026-05-24', 'upcoming', 0);
+    `);
+
+    const migration = readFileSync(
+      join(packageRoot, "drizzle", "0002_rainy_madame_hydra.sql"),
+      "utf8",
+    ).replaceAll("--> statement-breakpoint", "");
+    database.exec(migration);
+
+    expect(
+      database
+        .prepare("SELECT id, is_demo AS isDemo FROM basho ORDER BY id")
+        .all(),
+    ).toEqual([
+      { id: "2026-05", isDemo: 0 },
+      { id: "demo-2026-05", isDemo: 0 },
+    ]);
+
+    database.close();
+  });
+});

--- a/packages/db/src/repositories.test.ts
+++ b/packages/db/src/repositories.test.ts
@@ -244,6 +244,75 @@ describe("repositories", () => {
     ]);
   });
 
+  it("resets demo data without changing live basho data or shared rikishi", async () => {
+    const repositories = createRepositories(client);
+    await seedDatabase(repositories);
+    await repositories.upsertRikishi({
+      id: "onosato",
+      shikona: "Onosato",
+      heya: "Live Metadata Stable",
+    });
+
+    await seedDemoDatabase(repositories);
+    await completeDemoBasho(repositories);
+    await resetDemoProgression(repositories);
+
+    expect(await repositories.getBasho(sampleBasho.id)).toEqual(sampleBasho);
+    expect(
+      await repositories.listBanzukeEntriesForBasho(sampleBasho.id),
+    ).toHaveLength(4);
+    expect(await repositories.listFantasyTeamsForBasho(sampleBasho.id)).toEqual(
+      sampleFantasyTeams,
+    );
+    expect(
+      await repositories.listFantasyPicksForBasho(sampleBasho.id),
+    ).toHaveLength(4);
+    expect(
+      await repositories.listBoutResultsForBasho(sampleBasho.id),
+    ).toHaveLength(3);
+    expect(
+      (await repositories.listRikishi()).find(
+        (rikishi) => rikishi.id === "onosato",
+      ),
+    ).toMatchObject({ heya: "Live Metadata Stable" });
+    expect(await repositories.getBasho(demoBasho.id)).toEqual(demoBasho);
+  });
+
+  it("fails closed when the demo id belongs to a live basho", async () => {
+    const repositories = createRepositories(client);
+    const collidingLiveBasho = {
+      ...demoBasho,
+      isDemo: false,
+      name: "Live Basho With Colliding ID",
+    };
+    await repositories.insertBasho(collidingLiveBasho);
+
+    await expect(seedDemoDatabase(repositories)).rejects.toThrow(
+      `Refusing to replace live basho ${demoBasho.id} with demo data.`,
+    );
+
+    expect(await repositories.getBasho(demoBasho.id)).toEqual(
+      collidingLiveBasho,
+    );
+  });
+
+  it("rejects resets for any other demo basho id", async () => {
+    const repositories = createRepositories(client);
+
+    await expect(
+      repositories.replaceDemoBashoData({
+        basho: { ...demoBasho, id: "demo-other" },
+        rikishi: [],
+        banzukeEntries: [],
+        fantasyTeams: [],
+        fantasyPicks: [],
+        boutResults: [],
+      }),
+    ).rejects.toThrow(
+      `Demo reset may only replace the fixed basho ${demoBasho.id}.`,
+    );
+  });
+
   it("resets demo progression to a deterministic pre-basho state", async () => {
     await seedDemoDatabase(createRepositories(client));
     const repositories = createRepositories(client);

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -13,6 +13,7 @@ import type {
   PostgresDatabase,
   SqliteDatabase,
 } from "./client.js";
+import { DEMO_BASHO_ID } from "./demo-constants.js";
 import * as pg from "./schema.pg.js";
 import * as sqlite from "./schema.js";
 
@@ -30,8 +31,16 @@ export interface BoutResultsImportData {
   results: readonly BoutResult[];
 }
 
+export interface DemoBashoResetData extends BanzukeImportData {
+  fantasyTeams: readonly FantasyTeam[];
+  fantasyPicks: readonly FantasyPick[];
+  boutResults: readonly BoutResult[];
+}
+
 export interface Repositories {
-  resetData: () => Promise<void>;
+  /** Clears every game record. Production and admin paths must never call this. */
+  resetAllDataForLocalFixtures: () => Promise<void>;
+  replaceDemoBashoData: (resetData: DemoBashoResetData) => Promise<void>;
 
   insertBasho: (entry: Basho) => Promise<void>;
   upsertBasho: (entry: Basho) => Promise<void>;
@@ -87,13 +96,78 @@ export function createRepositories(database: AppDatabase): Repositories {
 
 function createSqliteRepositories(db: SqliteDatabase): Repositories {
   const repositories: Repositories = {
-    resetData: async () => {
+    resetAllDataForLocalFixtures: async () => {
       db.delete(sqlite.fantasyPicks).run();
       db.delete(sqlite.fantasyTeams).run();
       db.delete(sqlite.boutResults).run();
       db.delete(sqlite.banzukeEntries).run();
       db.delete(sqlite.rikishi).run();
       db.delete(sqlite.basho).run();
+    },
+    replaceDemoBashoData: async (resetData) => {
+      assertDemoBashoResetData(resetData);
+
+      db.transaction((transaction) => {
+        const existingBasho = transaction
+          .select({ isDemo: sqlite.basho.isDemo })
+          .from(sqlite.basho)
+          .where(eq(sqlite.basho.id, resetData.basho.id))
+          .get();
+
+        if (existingBasho !== undefined && !existingBasho.isDemo) {
+          throw new Error(
+            `Refusing to replace live basho ${resetData.basho.id} with demo data.`,
+          );
+        }
+
+        transaction
+          .delete(sqlite.basho)
+          .where(
+            and(
+              eq(sqlite.basho.id, resetData.basho.id),
+              eq(sqlite.basho.isDemo, true),
+            ),
+          )
+          .run();
+
+        for (const entry of resetData.rikishi) {
+          transaction
+            .insert(sqlite.rikishi)
+            .values(toRikishiRow(entry))
+            .onConflictDoNothing({ target: sqlite.rikishi.id })
+            .run();
+        }
+
+        transaction
+          .insert(sqlite.basho)
+          .values(toBashoRow(resetData.basho))
+          .run();
+
+        for (const entry of resetData.banzukeEntries) {
+          transaction.insert(sqlite.banzukeEntries).values(entry).run();
+        }
+
+        for (const entry of resetData.fantasyTeams) {
+          transaction
+            .insert(sqlite.fantasyTeams)
+            .values(toFantasyTeamRow(entry))
+            .run();
+        }
+
+        for (const entry of resetData.fantasyPicks) {
+          transaction
+            .insert(sqlite.fantasyPicks)
+            .values(toFantasyPickRow(entry))
+            .run();
+        }
+
+        for (const entry of resetData.boutResults) {
+          transaction
+            .insert(sqlite.boutResults)
+            .values(toBoutResultRow(entry))
+            .run();
+        }
+      });
     },
     insertBasho: async (entry) => {
       db.insert(sqlite.basho).values(toBashoRow(entry)).run();
@@ -407,13 +481,69 @@ function createSqliteRepositories(db: SqliteDatabase): Repositories {
 
 function createPostgresRepositories(db: PostgresDatabase): Repositories {
   const repositories: Repositories = {
-    resetData: async () => {
+    resetAllDataForLocalFixtures: async () => {
       await db.delete(pg.fantasyPicks);
       await db.delete(pg.fantasyTeams);
       await db.delete(pg.boutResults);
       await db.delete(pg.banzukeEntries);
       await db.delete(pg.rikishi);
       await db.delete(pg.basho);
+    },
+    replaceDemoBashoData: async (resetData) => {
+      assertDemoBashoResetData(resetData);
+
+      await db.transaction(async (transaction) => {
+        const existingBasho = (
+          await transaction
+            .select({ isDemo: pg.basho.isDemo })
+            .from(pg.basho)
+            .where(eq(pg.basho.id, resetData.basho.id))
+            .for("update")
+        ).at(0);
+
+        if (existingBasho !== undefined && !existingBasho.isDemo) {
+          throw new Error(
+            `Refusing to replace live basho ${resetData.basho.id} with demo data.`,
+          );
+        }
+
+        await transaction
+          .delete(pg.basho)
+          .where(
+            and(eq(pg.basho.id, resetData.basho.id), eq(pg.basho.isDemo, true)),
+          );
+
+        for (const entry of resetData.rikishi) {
+          await transaction
+            .insert(pg.rikishi)
+            .values(toRikishiRow(entry))
+            .onConflictDoNothing({ target: pg.rikishi.id });
+        }
+
+        await transaction.insert(pg.basho).values(toBashoRow(resetData.basho));
+
+        for (const entry of resetData.banzukeEntries) {
+          await transaction.insert(pg.banzukeEntries).values(entry);
+        }
+
+        for (const entry of resetData.fantasyTeams) {
+          await transaction
+            .insert(pg.fantasyTeams)
+            .values(toFantasyTeamRow(entry));
+        }
+
+        for (const entry of resetData.fantasyPicks) {
+          await transaction
+            .insert(pg.fantasyPicks)
+            .values(toFantasyPickRow(entry));
+        }
+
+        for (const entry of resetData.boutResults) {
+          await transaction
+            .insert(pg.boutResults)
+            .values(toBoutResultRow(entry));
+        }
+      });
     },
     insertBasho: async (entry) => {
       await db.insert(pg.basho).values(toBashoRow(entry));
@@ -708,9 +838,41 @@ function toBashoRow(entry: Basho) {
   };
 }
 
+function assertDemoBashoResetData(resetData: DemoBashoResetData): void {
+  if (resetData.basho.id !== DEMO_BASHO_ID) {
+    throw new Error(
+      `Demo reset may only replace the fixed basho ${DEMO_BASHO_ID}.`,
+    );
+  }
+
+  if (!resetData.basho.isDemo) {
+    throw new Error(
+      `Refusing to replace live basho ${resetData.basho.id} through the demo reset path.`,
+    );
+  }
+
+  if (
+    resetData.banzukeEntries.some(
+      (entry) => entry.bashoId !== resetData.basho.id,
+    ) ||
+    resetData.fantasyTeams.some(
+      (entry) => entry.bashoId !== resetData.basho.id,
+    ) ||
+    resetData.boutResults.some((entry) => entry.bashoId !== resetData.basho.id)
+  ) {
+    throw new Error("Demo reset data must be scoped to one demo basho.");
+  }
+
+  const teamIds = new Set(resetData.fantasyTeams.map((team) => team.id));
+  if (resetData.fantasyPicks.some((pick) => !teamIds.has(pick.teamId))) {
+    throw new Error("Demo reset picks must belong to demo reset teams.");
+  }
+}
+
 function toBasho(row: typeof sqlite.basho.$inferSelect): Basho {
   return {
     id: row.id,
+    isDemo: row.isDemo,
     name: row.name,
     startDate: row.startDate,
     endDate: row.endDate,

--- a/packages/db/src/schema.pg.ts
+++ b/packages/db/src/schema.pg.ts
@@ -8,6 +8,7 @@ import {
 
 export const basho = pgTable("basho", {
   id: text("id").primaryKey(),
+  isDemo: boolean("is_demo").notNull().default(false),
   name: text("name").notNull(),
   startDate: text("start_date").notNull(),
   endDate: text("end_date").notNull(),

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -7,6 +7,7 @@ import {
 
 export const basho = sqliteTable("basho", {
   id: text("id").primaryKey(),
+  isDemo: integer("is_demo", { mode: "boolean" }).notNull().default(false),
   name: text("name").notNull(),
   startDate: text("start_date").notNull(),
   endDate: text("end_date").notNull(),

--- a/packages/db/src/seed-data.ts
+++ b/packages/db/src/seed-data.ts
@@ -9,6 +9,7 @@ import type {
 
 export const sampleBasho: Basho = {
   id: "2026-05",
+  isDemo: false,
   name: "May 2026 Sample Basho",
   startDate: "2026-05-10",
   endDate: "2026-05-24",

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -24,7 +24,7 @@ import {
 } from "./seed-data.js";
 
 export async function seedDatabase(repositories: Repositories): Promise<void> {
-  await replaceSeedData(repositories, {
+  await replaceAllSeedData(repositories, {
     basho: sampleBasho,
     rikishi: sampleRikishi,
     banzukeEntries: sampleBanzukeEntries,
@@ -37,7 +37,7 @@ export async function seedDatabase(repositories: Repositories): Promise<void> {
 export async function seedDemoDatabase(
   repositories: Repositories,
 ): Promise<void> {
-  await replaceSeedData(repositories, {
+  await repositories.replaceDemoBashoData({
     basho: demoBasho,
     rikishi: demoRikishi,
     banzukeEntries: demoBanzukeEntries,
@@ -47,11 +47,11 @@ export async function seedDemoDatabase(
   });
 }
 
-async function replaceSeedData(
+async function replaceAllSeedData(
   repositories: Repositories,
   seedData: SeedData,
 ): Promise<void> {
-  await repositories.resetData();
+  await repositories.resetAllDataForLocalFixtures();
 
   await repositories.applyBanzukeImport({
     basho: seedData.basho,

--- a/packages/domain/src/lifecycle.test.ts
+++ b/packages/domain/src/lifecycle.test.ts
@@ -9,6 +9,7 @@ import {
 
 const baseBasho: Basho = {
   id: "2026-05",
+  isDemo: false,
   name: "May 2026 Basho",
   startDate: "2026-05-10",
   endDate: "2026-05-24",
@@ -43,6 +44,15 @@ describe("basho lifecycle", () => {
       status: "locked",
       currentDay: 3,
     });
+  });
+
+  it("does not let an import change whether an existing basho is a demo", () => {
+    expect(
+      preserveBashoLifecycleProgress(
+        { ...baseBasho, isDemo: true },
+        { ...baseBasho, isDemo: false },
+      ).isDemo,
+    ).toBe(true);
   });
 
   it("labels each lifecycle status for user-facing state", () => {

--- a/packages/domain/src/lifecycle.ts
+++ b/packages/domain/src/lifecycle.ts
@@ -27,6 +27,7 @@ export function preserveBashoLifecycleProgress(
 
   return {
     ...importedBasho,
+    isDemo: existingBasho.isDemo,
     status:
       lifecycleOrder[existingBasho.status] >
       lifecycleOrder[importedBasho.status]

--- a/packages/domain/src/types.ts
+++ b/packages/domain/src/types.ts
@@ -2,6 +2,7 @@ export type BashoStatus = "upcoming" | "locked" | "active" | "complete";
 
 export interface Basho {
   id: string;
+  isDemo: boolean;
   name: string;
   startDate: string;
   endDate: string;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -55,6 +55,7 @@ export default defineConfig({
       command: "pnpm --filter @fantasy-sumo/web dev",
       env: {
         ...process.env,
+        VITE_BASHO_MODE: "demo",
       },
       url: "http://127.0.0.1:7866",
       reuseExistingServer: !process.env.CI,


### PR DESCRIPTION
## Summary

- add an explicit `isDemo` basho classification in the domain, SQLite, and Postgres schemas
- scope deterministic demo reset/progression to the single fixed demo basho and require both its ID and persisted demo flag
- preserve live bashos, teams, picks, results, and shared rikishi metadata during demo resets
- keep normal current-basho and scheduled imports live-only, while local demo mode explicitly selects the flagged demo
- migrate existing rows fail-closed as live and document explicit legacy-demo conversion

## Safety

Destructive demo operations cannot target arbitrary bashos. They fail closed unless the record is both `demo-2026-05` and `isDemo: true`. The reset runs transactionally and no longer uses the whole-database fixture reset.

## Validation

- `make check PNPM=/private/tmp/fantasy-sumo-pnpm24`
  - lint and formatting
  - 129 unit/integration tests
  - all workspace builds
- `E2E_DATABASE_URL=file:/private/tmp/fantasy-sumo-issue41-e2e-v4.sqlite make e2e PNPM=/private/tmp/fantasy-sumo-pnpm24`
  - 21 Playwright scenarios passed across desktop Chromium, mobile Chromium, and mobile WebKit
- dedicated read-only review against `master`: no actionable P1/P2 findings

Closes #41