### PR TITLE
Fix Vercel function TypeScript target

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -130,6 +130,9 @@ jobs:
       - name: Build prepared preview deployment
         run: pnpm dlx vercel@56.3.2 build
 
+      - name: Type-check Vercel function entrypoint
+        run: pnpm exec tsc -p tsconfig.json
+
       - name: Require current pull request head
         if: github.event_name == 'pull_request'
         env:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -126,6 +126,9 @@ jobs:
       - name: Build prepared production deployment
         run: pnpm dlx vercel@56.3.2 build --prod
 
+      - name: Type-check Vercel function entrypoint
+        run: pnpm exec tsc -p tsconfig.json
+
       - name: Require latest published production release
         if: github.event_name == 'release'
         env:

--- a/scripts/verify-deployment-workflows.mjs
+++ b/scripts/verify-deployment-workflows.mjs
@@ -3,10 +3,12 @@ import { readFileSync } from "node:fs";
 const previewPath = ".github/workflows/deploy-preview.yml";
 const productionPath = ".github/workflows/deploy-production.yml";
 const smokePath = "scripts/smoke-deployment.mjs";
+const tsconfigPath = "tsconfig.json";
 const vercelPath = "vercel.json";
 const preview = readFileSync(previewPath, "utf8");
 const production = readFileSync(productionPath, "utf8");
 const smoke = readFileSync(smokePath, "utf8");
+const tsconfig = JSON.parse(readFileSync(tsconfigPath, "utf8"));
 const vercelConfig = JSON.parse(readFileSync(vercelPath, "utf8"));
 
 function requireText(source, file, description, pattern) {
@@ -99,6 +101,12 @@ for (const [source, file, environment, concurrencyGroup] of [
     /DATABASE_URL: \$\{\{ secrets\.DATABASE_URL \}\}/,
   );
   requireText(deployJob, file, "pin the Vercel CLI", /vercel@56\.3\.2/);
+  requireText(
+    deployJob,
+    file,
+    "type-check the Vercel function entrypoint",
+    /Type-check Vercel function entrypoint\s*\n\s*run: pnpm exec tsc -p tsconfig\.json/,
+  );
   forbidText(
     deployJobPreamble,
     file,
@@ -153,6 +161,18 @@ for (const [source, file, environment, concurrencyGroup] of [
     file,
     "publish an observable workflow summary",
     /GITHUB_STEP_SUMMARY/,
+  );
+  requireOrder(
+    deployJob,
+    file,
+    `Build prepared ${environment.toLowerCase()} deployment`,
+    "Type-check Vercel function entrypoint",
+  );
+  requireOrder(
+    deployJob,
+    file,
+    "Type-check Vercel function entrypoint",
+    `Apply ${environment.toLowerCase()} database migrations`,
   );
   requireOrder(
     deployJob,
@@ -240,6 +260,20 @@ requireText(
 if (vercelConfig.git?.deploymentEnabled !== false) {
   throw new Error(
     `${vercelPath} must disable automatic Git deployments so they cannot bypass migration-gated GitHub Actions.`,
+  );
+}
+
+if (
+  tsconfig.extends !== "./tsconfig.base.json" ||
+  !tsconfig.compilerOptions?.lib?.includes("ES2022") ||
+  !tsconfig.compilerOptions?.typeRoots?.includes(
+    "./apps/api/node_modules/@types",
+  ) ||
+  !tsconfig.compilerOptions?.types?.includes("node") ||
+  !tsconfig.include?.includes("api/**/*.ts")
+) {
+  throw new Error(
+    `${tsconfigPath} must apply the shared ES2022 and Node.js TypeScript configuration to the Vercel function entrypoint.`,
   );
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "typeRoots": ["./apps/api/node_modules/@types"],
+    "types": ["node"]
+  },
+  "include": ["api/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- add a root `tsconfig.json` so Vercel's `/api` function compiler uses the repository's ES2022 and Node.js settings
- explicitly type-check the Vercel function entrypoint after the prepared build and before either environment can migrate or deploy
- extend the deployment contract to preserve the build → type-check → migration → deployment ordering

## Context

The first production workflow run emitted TS2550 for `Basho[].at(0)` because Vercel compiles root `/api` functions using the project-root TypeScript configuration, which the repository did not have. Vercel still returned success from the prepared-build step, so the explicit post-build check ensures future diagnostics block before database or deployment changes.

This PR does not modify database state or credentials. The separate Production `DATABASE_URL` authentication failure has been corrected in the GitHub environment.

## Validation

- `pnpm build`
- `pnpm exec tsc -p tsconfig.json`
- `pnpm deployment:verify`
- `make check PNPM=/opt/homebrew/bin/pnpm`
- independent read-only review: no remaining actionable P1/P2 findings
