### PR TITLE
Canonicalize production migration history

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,6 +154,10 @@ Current behaviour:
   production deployment.
 - Defines SQLite and Postgres MVP schemas with Drizzle table definitions.
 - Includes SQLite migration SQL in `packages/db/drizzle` and Postgres migration SQL in `packages/db/drizzle-pg`.
+- Preserves the production-applied `owner_user_id` compatibility column and
+  unique index in the Postgres schema and migration history. The paused auth
+  feature does not currently read or write this nullable field. Retaining it
+  avoids rewriting deployed history or applying a destructive rollback.
 - Uses `DATABASE_URL` to select the adapter: `file:` and `:memory:` use SQLite; `postgres:` and `postgresql:` use Postgres.
 - Exposes an async repository contract so API/domain workflows do not depend on a concrete database driver.
 - Provides repository functions for reading and writing basho, rikishi, banzuke entries, fantasy teams, fantasy picks, and bout results.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -160,6 +160,17 @@ historical SQL cannot be inferred from the current checkout. SQL line endings
 are normalized before hashing so LF and CRLF checkouts of the same migration
 produce the same checksum.
 
+Production applied `0001_team_owner_user.sql` before its auth feature rollout
+was paused until after the current tournament. The nullable `owner_user_id`
+column and its unique `(basho_id, owner_user_id)` index are intentionally
+retained as backward-compatible groundwork: current application code does not
+read or write the field, and no authentication setup is required until the
+feature resumes. That immutable production history remains canonical, so the
+demo classification change follows it as `0002_basho_demo_flag.sql`. That
+migration tolerates the demo column already existing in an environment that
+applied the superseded demo migration identity.
+Do not delete the ownership ledger row or reuse its filename for different SQL.
+
 ### Legacy checksum investigation
 
 If migration stops because an existing ledger row has no checksum, do not copy

--- a/packages/db/drizzle-pg/0001_basho_demo_flag.sql
+++ b/packages/db/drizzle-pg/0001_basho_demo_flag.sql
@@ -1,2 +1,0 @@
-ALTER TABLE "basho"
-  ADD COLUMN "is_demo" boolean DEFAULT false NOT NULL;

--- a/packages/db/drizzle-pg/0001_team_owner_user.sql
+++ b/packages/db/drizzle-pg/0001_team_owner_user.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "fantasy_teams" ADD COLUMN "owner_user_id" text;
+
+CREATE UNIQUE INDEX "fantasy_teams_basho_owner_user_idx"
+  ON "fantasy_teams" ("basho_id", "owner_user_id");

--- a/packages/db/drizzle-pg/0002_basho_demo_flag.sql
+++ b/packages/db/drizzle-pg/0002_basho_demo_flag.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "basho"
+  ADD COLUMN IF NOT EXISTS "is_demo" boolean DEFAULT false NOT NULL;

--- a/packages/db/src/migrate.test.ts
+++ b/packages/db/src/migrate.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import Database from "better-sqlite3";
@@ -44,6 +44,42 @@ describe("demo flag migration", () => {
 });
 
 describe("Postgres migration ledger", () => {
+  it("preserves the deployed production migration identities and order", () => {
+    const migrationsFolder = join(packageRoot, "drizzle-pg");
+    const migrationFiles = readdirSync(migrationsFolder)
+      .filter((file) => file.endsWith(".sql"))
+      .sort();
+
+    expect(migrationFiles).toEqual([
+      "0000_initial.sql",
+      "0001_team_owner_user.sql",
+      "0002_basho_demo_flag.sql",
+    ]);
+    const initialMigration = readFileSync(
+      join(migrationsFolder, "0000_initial.sql"),
+      "utf8",
+    );
+    const ownerMigration = readFileSync(
+      join(migrationsFolder, "0001_team_owner_user.sql"),
+      "utf8",
+    );
+    const demoMigration = readFileSync(
+      join(migrationsFolder, "0002_basho_demo_flag.sql"),
+      "utf8",
+    );
+
+    expect(getMigrationChecksum(initialMigration)).toBe(
+      "355dc080c83437a8a07343062a0d60be1513c3c2c03f0602aaff4fc3963d2ad8",
+    );
+    expect(getMigrationChecksum(ownerMigration)).toBe(
+      "c16e0d8c8951cc4f8b1e0e2fd961a07934249f8d81416ec7a8fa8853a66f1c76",
+    );
+    expect(getMigrationChecksum(demoMigration)).toBe(
+      "c71762adeff7df2b1d4e9f92dfc4773291fb9b33ee25518b22aac7edd0d6ea42",
+    );
+    expect(demoMigration).toContain("ADD COLUMN IF NOT EXISTS");
+  });
+
   it("uses stable content checksums and detects changed SQL", () => {
     const checksum = getMigrationChecksum("SELECT 1;\n");
 

--- a/packages/db/src/schema.pg.ts
+++ b/packages/db/src/schema.pg.ts
@@ -45,16 +45,26 @@ export const banzukeEntries = pgTable(
   ],
 );
 
-export const fantasyTeams = pgTable("fantasy_teams", {
-  id: text("id").primaryKey(),
-  bashoId: text("basho_id")
-    .notNull()
-    .references(() => basho.id, { onDelete: "cascade" }),
-  displayName: text("display_name").notNull(),
-  ownerName: text("owner_name"),
-  createdAt: text("created_at"),
-  lockedAt: text("locked_at"),
-});
+export const fantasyTeams = pgTable(
+  "fantasy_teams",
+  {
+    id: text("id").primaryKey(),
+    bashoId: text("basho_id")
+      .notNull()
+      .references(() => basho.id, { onDelete: "cascade" }),
+    displayName: text("display_name").notNull(),
+    ownerName: text("owner_name"),
+    ownerUserId: text("owner_user_id"),
+    createdAt: text("created_at"),
+    lockedAt: text("locked_at"),
+  },
+  (table) => [
+    uniqueIndex("fantasy_teams_basho_owner_user_idx").on(
+      table.bashoId,
+      table.ownerUserId,
+    ),
+  ],
+);
 
 export const fantasyPicks = pgTable(
   "fantasy_picks",


### PR DESCRIPTION
## Summary

- restores the production-applied `0001_team_owner_user.sql` as canonical migration history
- renumbers the demo flag migration to `0002_basho_demo_flag.sql` and makes it safe for environments where the demo column already exists
- models the paused ownership groundwork in the Postgres schema without activating authentication
- pins all canonical Postgres migration filenames and checksums in regression coverage
- documents that the auth rollout remains paused until after the current tournament

## Root cause

Production had already applied the ownership SQL and recorded `0001_team_owner_user.sql`, while `master` reused the `0001` sequence for the demo flag. The checksum-protected runner therefore could not safely reconcile the deployed ledger with the checkout.

## Production follow-up

After verifying the existing schema and taking or confirming a backup, record the trusted checksums for the two existing filename-only ledger rows before rerunning migrations:

```sql
BEGIN;

UPDATE "__fantasy_sumo_migrations"
SET "checksum" = '355dc080c83437a8a07343062a0d60be1513c3c2c03f0602aaff4fc3963d2ad8'
WHERE "id" = '0000_initial.sql'
  AND "checksum" IS NULL;

UPDATE "__fantasy_sumo_migrations"
SET "checksum" = 'c16e0d8c8951cc4f8b1e0e2fd961a07934249f8d81416ec7a8fa8853a66f1c76'
WHERE "id" = '0001_team_owner_user.sql'
  AND "checksum" IS NULL;

COMMIT;
```

Each update should affect exactly one row. After this PR is merged, rerun `pnpm --filter @fantasy-sumo/db db:migrate`; it will apply `0002_basho_demo_flag.sql`.

PR #52 remains paused and is not merged by this change. Its auth rollout can be rebased and completed after the current tournament without rewriting the production ownership migration.

## Validation

- `PATH=/Users/james.carr/.nvm/versions/node/v24.14.1/bin:$PATH pnpm --filter @fantasy-sumo/db test`
- `PATH=/Users/james.carr/.nvm/versions/node/v24.14.1/bin:$PATH make check PNPM=pnpm`
- dedicated read-only review against `origin/master` with no remaining P1/P2 findings

E2E was not run because this change does not affect the browser game loop.
