### PR TITLE
Show day-by-day fantasy score progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The current codebase has been reset onto the clean rebuild foundation described 
 
 At present, the app has the first local playable foundations:
 
-- A Vite + React front end for creating a fantasy team from seeded basho data and viewing leaderboard standings with recent form and day-by-day score history.
+- A Vite + React front end for creating a fantasy team from seeded basho data and viewing leaderboard standings with recent team scores and expandable rikishi result history.
 - A Fastify API with health, basho, rikishi, team, and leaderboard endpoints.
 - A shared TypeScript domain package with MVP types, lifecycle rules, validation, scoring, and leaderboard logic.
 - A swappable Drizzle database package with local SQLite, production Postgres, repositories, migrations, sample seed data, and deterministic demo data.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The current codebase has been reset onto the clean rebuild foundation described 
 
 At present, the app has the first local playable foundations:
 
-- A Vite + React front end for creating a fantasy team from seeded basho data and viewing leaderboard standings.
+- A Vite + React front end for creating a fantasy team from seeded basho data and viewing leaderboard standings with recent form and day-by-day score history.
 - A Fastify API with health, basho, rikishi, team, and leaderboard endpoints.
 - A shared TypeScript domain package with MVP types, lifecycle rules, validation, scoring, and leaderboard logic.
 - A swappable Drizzle database package with local SQLite, production Postgres, repositories, migrations, sample seed data, and deterministic demo data.
@@ -162,6 +162,12 @@ serializes with the production lock update so an in-flight submission cannot
 slip through the transition.
 The protected daily cron normally persists the lock and stamps existing teams
 on the evening before day 0, where day 0 is the calendar day before the basho.
+
+Leaderboard entries include the latest scored day's points and chronological
+score history. Each history entry contains the daily score, cumulative score,
+and the win, loss, absence, or missing-result contribution for every pick. The
+history includes only days with stored results, so missing imports and future
+days are not presented as scored.
 
 Useful checks:
 

--- a/apps/api/src/routes/basho.test.ts
+++ b/apps/api/src/routes/basho.test.ts
@@ -397,6 +397,32 @@ describe("basho routes", () => {
         rank: 2,
       },
     ]);
+    expect(response.json().leaderboard[0]).toMatchObject({
+      latestDayScore: {
+        day: 2,
+        score: 1,
+      },
+      scoreHistory: [
+        {
+          day: 1,
+          dailyScore: 1,
+          cumulativeScore: 1,
+          rikishiScores: [
+            { rikishiId: "kirishima", outcome: "loss", score: 0 },
+            { rikishiId: "onosato", outcome: "win", score: 1 },
+          ],
+        },
+        {
+          day: 2,
+          dailyScore: 1,
+          cumulativeScore: 2,
+          rikishiScores: [
+            { rikishiId: "kirishima", outcome: "win", score: 1 },
+            { rikishiId: "onosato", outcome: "no-result", score: 0 },
+          ],
+        },
+      ],
+    });
   });
 
   it("returns clear 404 errors for unknown basho and teams", async () => {

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -167,7 +167,12 @@ describe("App", () => {
     expect(screen.getByText("East Side")).toBeInTheDocument();
     expect(screen.getByText("2 pts")).toBeInTheDocument();
     expect(screen.getAllByText("Tied on score")).toHaveLength(2);
-    expect(screen.getAllByText("Onosato")).toHaveLength(3);
+    expect(screen.getByText("Onosato")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(
+        "Recent results for Onosato: day 1 Win, day 2 No result",
+      ),
+    ).toBeInTheDocument();
     expect(screen.getAllByText("1 win")).toHaveLength(2);
   });
 

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "./App";
+import type { LeaderboardEntry } from "./types";
 
 const currentBasho = {
   id: "2026-05",
@@ -37,12 +38,36 @@ const rankedRikishi = [
   },
 ];
 
-const leaderboard = [
+const leaderboard: LeaderboardEntry[] = [
   {
     rank: 1,
     teamId: "team-east",
     displayName: "East Side",
     score: 2,
+    latestDayScore: {
+      day: 2,
+      score: 1,
+    },
+    scoreHistory: [
+      {
+        day: 1,
+        dailyScore: 1,
+        cumulativeScore: 1,
+        rikishiScores: [
+          { rikishiId: "onosato", outcome: "win", score: 1 },
+          { rikishiId: "kirishima", outcome: "loss", score: 0 },
+        ],
+      },
+      {
+        day: 2,
+        dailyScore: 1,
+        cumulativeScore: 2,
+        rikishiScores: [
+          { rikishiId: "onosato", outcome: "no-result", score: 0 },
+          { rikishiId: "kirishima", outcome: "win", score: 1 },
+        ],
+      },
+    ],
     rikishiScores: [
       {
         rikishiId: "onosato",
@@ -61,6 +86,30 @@ const leaderboard = [
     teamId: "team-west",
     displayName: "West Side",
     score: 1,
+    latestDayScore: {
+      day: 2,
+      score: 0,
+    },
+    scoreHistory: [
+      {
+        day: 1,
+        dailyScore: 1,
+        cumulativeScore: 1,
+        rikishiScores: [
+          { rikishiId: "kotozakura", outcome: "win", score: 1 },
+          { rikishiId: "hoshoryu", outcome: "loss", score: 0 },
+        ],
+      },
+      {
+        day: 2,
+        dailyScore: 0,
+        cumulativeScore: 1,
+        rikishiScores: [
+          { rikishiId: "kotozakura", outcome: "no-result", score: 0 },
+          { rikishiId: "hoshoryu", outcome: "loss", score: 0 },
+        ],
+      },
+    ],
     rikishiScores: [
       {
         rikishiId: "kotozakura",
@@ -79,6 +128,7 @@ const leaderboard = [
     teamId: "team-tie",
     displayName: "Tie Side",
     score: 1,
+    scoreHistory: [],
     rikishiScores: [],
   },
 ];
@@ -117,7 +167,7 @@ describe("App", () => {
     expect(screen.getByText("East Side")).toBeInTheDocument();
     expect(screen.getByText("2 pts")).toBeInTheDocument();
     expect(screen.getAllByText("Tied on score")).toHaveLength(2);
-    expect(screen.getByText("Onosato")).toBeInTheDocument();
+    expect(screen.getAllByText("Onosato")).toHaveLength(3);
     expect(screen.getAllByText("1 win")).toHaveLength(2);
   });
 
@@ -453,6 +503,7 @@ function mockStaleInitialLeaderboardFetch(
             teamId: "team-east-stand",
             displayName: "East Stand Heroes",
             score: 4,
+            scoreHistory: [],
             rikishiScores: [
               {
                 rikishiId: "onosato",

--- a/apps/web/src/components/LeaderboardPanel.css
+++ b/apps/web/src/components/LeaderboardPanel.css
@@ -88,12 +88,48 @@
   color: var(--muted);
 }
 
+.recent-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 7px;
+}
+
+.form-day {
+  display: grid;
+  grid-template-columns: auto auto;
+  gap: 3px;
+  align-items: baseline;
+  padding: 3px 6px;
+  border-radius: 999px;
+  background: var(--moss-light);
+  color: var(--ink);
+  font-size: 0.78rem;
+}
+
+.form-day small {
+  margin: 0;
+  font-size: 0.68rem;
+}
+
 .leaderboard-score {
+  display: grid;
+  gap: 1px;
   justify-self: end;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.leaderboard-score small {
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.leaderboard-score strong {
   color: var(--indigo);
   font-size: 1.05rem;
   font-weight: 900;
-  white-space: nowrap;
 }
 
 .score-breakdown {
@@ -105,7 +141,12 @@
   color: var(--muted);
 }
 
-.score-breakdown ul {
+.score-breakdown h3 {
+  margin: 12px 0 8px;
+  font-size: 0.96rem;
+}
+
+.score-totals-list {
   display: grid;
   gap: 8px;
   margin: 0;
@@ -113,7 +154,7 @@
   list-style: none;
 }
 
-.score-breakdown li {
+.score-totals-list > li {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 92px 72px;
   gap: 12px;
@@ -125,21 +166,88 @@
   color: var(--ink);
 }
 
-.score-breakdown strong,
-.score-breakdown small {
+.score-totals-list strong,
+.score-totals-list small {
   display: block;
   overflow-wrap: anywhere;
 }
 
-.score-breakdown small {
+.score-totals-list small {
   color: var(--muted);
 }
 
-.score-breakdown li > span:nth-child(2),
-.score-breakdown li > span:nth-child(3) {
+.score-totals-list > li > span:nth-child(2),
+.score-totals-list > li > span:nth-child(3) {
   justify-self: end;
   font-weight: 800;
   white-space: nowrap;
+}
+
+.score-history {
+  margin-top: 16px;
+  padding-top: 2px;
+  border-top: 1px solid var(--clay-light);
+}
+
+.score-history .unscored-days {
+  margin: 8px 0 0;
+  padding: 8px 10px;
+  border-radius: 7px;
+  background: #f4f1ec;
+  font-size: 0.82rem;
+}
+
+.score-history > ol,
+.score-day > ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.score-history > ol {
+  display: grid;
+  gap: 8px;
+}
+
+.score-day {
+  overflow: hidden;
+  border: 1px solid var(--clay-light);
+  border-radius: 9px;
+}
+
+.score-day-heading {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 4px 12px;
+  padding: 9px 11px;
+  background: #fffaf5;
+}
+
+.score-day-heading span {
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.score-day > ul {
+  display: grid;
+  gap: 1px;
+  background: var(--clay-light);
+}
+
+.score-day > ul > li {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 82px 34px;
+  gap: 8px;
+  padding: 8px 11px;
+  background: #ffffff;
+  font-size: 0.86rem;
+}
+
+.score-day > ul > li > span:nth-child(2),
+.score-day > ul > li > strong {
+  justify-self: end;
 }
 
 @media (max-width: 640px) {
@@ -154,20 +262,20 @@
     padding-left: 12px;
   }
 
-  .score-breakdown li {
+  .score-totals-list > li {
     grid-template-columns: minmax(0, 1fr) auto;
   }
 
-  .score-breakdown li > span:nth-child(2),
-  .score-breakdown li > span:nth-child(3) {
+  .score-totals-list > li > span:nth-child(2),
+  .score-totals-list > li > span:nth-child(3) {
     grid-column: 2;
   }
 
-  .score-breakdown li > span:nth-child(2) {
+  .score-totals-list > li > span:nth-child(2) {
     grid-row: 1;
   }
 
-  .score-breakdown li > span:nth-child(3) {
+  .score-totals-list > li > span:nth-child(3) {
     grid-row: 2;
   }
 }
@@ -181,7 +289,15 @@
     font-size: 1rem;
   }
 
-  .leaderboard-score {
+  .leaderboard-score strong {
     font-size: 0.94rem;
+  }
+
+  .recent-form {
+    gap: 3px;
+  }
+
+  .form-day {
+    padding: 2px 5px;
   }
 }

--- a/apps/web/src/components/LeaderboardPanel.css
+++ b/apps/web/src/components/LeaderboardPanel.css
@@ -155,99 +155,125 @@
 }
 
 .score-totals-list > li {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 92px 72px;
-  gap: 12px;
-  align-items: center;
-  min-height: 50px;
-  padding: 10px 12px;
+  overflow: hidden;
   border-radius: 9px;
   background: var(--moss-light);
-  color: var(--ink);
 }
 
-.score-totals-list strong,
-.score-totals-list small {
+.rikishi-score-summary {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto 92px 72px;
+  gap: 12px;
+  align-items: center;
+  width: 100%;
+  min-height: 50px;
+  padding: 10px 12px;
+  border: 0;
+  background: transparent;
+  color: var(--ink);
+  text-align: left;
+}
+
+.rikishi-score-summary:hover,
+.rikishi-score-summary[aria-expanded="true"] {
+  background: rgb(53 91 80 / 8%);
+}
+
+.rikishi-score-summary:focus-visible {
+  outline: 3px solid var(--focus);
+  outline-offset: -3px;
+}
+
+.rikishi-score-summary strong,
+.rikishi-score-summary small {
   display: block;
   overflow-wrap: anywhere;
 }
 
-.score-totals-list small {
+.rikishi-score-summary small {
   color: var(--muted);
 }
 
-.score-totals-list > li > span:nth-child(2),
-.score-totals-list > li > span:nth-child(3) {
+.rikishi-wins,
+.rikishi-points {
   justify-self: end;
   font-weight: 800;
   white-space: nowrap;
 }
 
-.score-history {
-  margin-top: 16px;
-  padding-top: 2px;
-  border-top: 1px solid var(--clay-light);
+.recent-rikishi-results {
+  display: flex;
+  gap: 5px;
+  justify-self: end;
 }
 
-.score-history .unscored-days {
-  margin: 8px 0 0;
-  padding: 8px 10px;
-  border-radius: 7px;
-  background: #f4f1ec;
-  font-size: 0.82rem;
+.result-tile {
+  display: inline-grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  font-weight: 900;
 }
 
-.score-history > ol,
-.score-day > ul {
+.result-win {
+  background: #63d778;
+  color: #11351a;
+}
+
+.result-loss {
+  background: var(--vermilion);
+  color: #ffffff;
+}
+
+.result-absent {
+  background: #f5c54b;
+  color: #3e2d00;
+}
+
+.result-no-result {
+  background: #d8dee1;
+  color: #34434a;
+}
+
+.rikishi-result-history {
+  padding: 10px 12px 12px;
+  border-top: 1px solid rgb(53 91 80 / 14%);
+  background: #f3f7f5;
+}
+
+.rikishi-result-history h4 {
+  margin: 0 0 8px;
+  color: var(--indigo);
+  font-size: 0.86rem;
+}
+
+.rikishi-result-history > ol {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
   margin: 0;
   padding: 0;
   list-style: none;
 }
 
-.score-history > ol {
+.rikishi-result-history > ol > li {
   display: grid;
-  gap: 8px;
+  grid-template-rows: auto 30px auto;
+  gap: 3px;
+  justify-items: center;
+  min-width: 38px;
 }
 
-.score-day {
-  overflow: hidden;
-  border: 1px solid var(--clay-light);
-  border-radius: 9px;
-}
-
-.score-day-heading {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  gap: 4px 12px;
-  padding: 9px 11px;
-  background: #fffaf5;
-}
-
-.score-day-heading span {
+.rikishi-result-history > ol small {
   color: var(--muted);
-  font-size: 0.82rem;
+  font-size: 0.68rem;
   font-weight: 800;
 }
 
-.score-day > ul {
-  display: grid;
-  gap: 1px;
-  background: var(--clay-light);
-}
-
-.score-day > ul > li {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 82px 34px;
-  gap: 8px;
-  padding: 8px 11px;
-  background: #ffffff;
-  font-size: 0.86rem;
-}
-
-.score-day > ul > li > span:nth-child(2),
-.score-day > ul > li > strong {
-  justify-self: end;
+.rikishi-result-history > ol strong {
+  font-size: 0.72rem;
 }
 
 @media (max-width: 640px) {
@@ -262,21 +288,29 @@
     padding-left: 12px;
   }
 
-  .score-totals-list > li {
-    grid-template-columns: minmax(0, 1fr) auto;
+  .rikishi-score-summary {
+    grid-template-columns: minmax(0, 1fr) auto auto;
+    gap: 8px;
   }
 
-  .score-totals-list > li > span:nth-child(2),
-  .score-totals-list > li > span:nth-child(3) {
+  .recent-rikishi-results {
     grid-column: 2;
+    grid-row: 1 / span 2;
   }
 
-  .score-totals-list > li > span:nth-child(2) {
+  .rikishi-wins {
+    grid-column: 3;
     grid-row: 1;
   }
 
-  .score-totals-list > li > span:nth-child(3) {
+  .rikishi-points {
+    grid-column: 3;
     grid-row: 2;
+  }
+
+  .form-day:nth-last-child(n + 4),
+  .recent-rikishi-results .result-tile:nth-last-child(n + 4) {
+    display: none;
   }
 }
 
@@ -299,5 +333,23 @@
 
   .form-day {
     padding: 2px 5px;
+  }
+
+  .form-day:nth-last-child(n + 3) {
+    display: none;
+  }
+
+  .rikishi-score-summary {
+    gap: 6px;
+    padding-right: 9px;
+    padding-left: 9px;
+  }
+
+  .recent-rikishi-results {
+    gap: 3px;
+  }
+
+  .recent-rikishi-results .result-tile:nth-last-child(n + 3) {
+    display: none;
   }
 }

--- a/apps/web/src/components/LeaderboardPanel.test.tsx
+++ b/apps/web/src/components/LeaderboardPanel.test.tsx
@@ -97,23 +97,27 @@ describe("LeaderboardPanel", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Status: Scoring in progress")).toBeInTheDocument();
     expect(screen.getByText("East Side")).toBeInTheDocument();
-    expect(screen.getAllByText("Onosato")).toHaveLength(3);
-    expect(screen.getAllByText("Kirishima")).toHaveLength(3);
+    expect(screen.getByText("Onosato")).toBeInTheDocument();
+    expect(screen.getByText("Kirishima")).toBeInTheDocument();
     expect(screen.getAllByText("1 win")).toHaveLength(2);
     expect(screen.getByText("Day 4 +1")).toBeInTheDocument();
     expect(screen.getByLabelText(/Recent form: day 3 \+1/)).toBeInTheDocument();
     expect(
-      screen.getByRole("region", { name: "Day-by-day score history" }),
-    ).toBeInTheDocument();
-    expect(screen.getByText("+1 today · 2 total")).toBeInTheDocument();
-    expect(screen.getAllByText("Win")).toHaveLength(2);
-    expect(screen.getAllByText("Loss")).toHaveLength(2);
-    expect(
-      screen.getByText("Days 1–2 are awaiting results."),
+      screen.getByLabelText(
+        "Recent results for Onosato: day 3 Win, day 4 Loss",
+      ),
     ).toBeInTheDocument();
     expect(
-      screen.getByText("Days 5–15 are not scored yet."),
+      screen.queryByRole("region", { name: "Day-by-day score history" }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Onosato/ }));
+
+    expect(
+      screen.getByRole("region", { name: "Onosato result history" }),
     ).toBeInTheDocument();
+    expect(screen.getByLabelText("Day 3: Win, +1 point")).toBeInTheDocument();
+    expect(screen.getByLabelText("Day 4: Loss, 0 points")).toBeInTheDocument();
   });
 
   it("requests expansion changes when a team row is clicked", () => {
@@ -214,26 +218,29 @@ describe("LeaderboardPanel", () => {
     expect(screen.getByText("Status: Final scores")).toBeInTheDocument();
   });
 
-  it("identifies missing current days separately from future days", () => {
+  it("limits compact team and rikishi form to the five latest results", () => {
+    const sixDays = Array.from({ length: 6 }, (_, index) => ({
+      day: index + 1,
+      dailyScore: 1,
+      cumulativeScore: index + 1,
+      rikishiScores: [
+        { rikishiId: "onosato", outcome: "win" as const, score: 1 },
+        { rikishiId: "kirishima", outcome: "loss" as const, score: 0 },
+      ],
+    }));
+
     render(
       <LeaderboardPanel
-        basho={{ ...basho, currentDay: 3 }}
+        basho={{ ...basho, currentDay: 6 }}
         createdTeam={null}
         errorMessage={null}
         expandedTeamId="team-east"
         leaderboard={[
           {
             ...leaderboard[0]!,
-            latestDayScore: { day: 1, score: 1 },
-            score: 1,
-            scoreHistory: [
-              {
-                day: 1,
-                dailyScore: 1,
-                cumulativeScore: 1,
-                rikishiScores: [],
-              },
-            ],
+            latestDayScore: { day: 6, score: 1 },
+            score: 6,
+            scoreHistory: sixDays,
           },
         ]}
         loadState="ready"
@@ -244,10 +251,19 @@ describe("LeaderboardPanel", () => {
     );
 
     expect(
-      screen.getByText("Days 2–3 are awaiting results."),
+      screen.getByLabelText(
+        "Recent form: day 2 +1, day 3 +1, day 4 +1, day 5 +1, day 6 +1",
+      ),
     ).toBeInTheDocument();
     expect(
-      screen.getByText("Days 4–15 are not scored yet."),
+      screen.getByLabelText(
+        "Recent results for Onosato: day 2 Win, day 3 Win, day 4 Win, day 5 Win, day 6 Win",
+      ),
     ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Onosato/ }));
+
+    expect(screen.getByLabelText("Day 1: Win, +1 point")).toBeInTheDocument();
+    expect(screen.getByLabelText("Day 6: Win, +1 point")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/LeaderboardPanel.test.tsx
+++ b/apps/web/src/components/LeaderboardPanel.test.tsx
@@ -37,6 +37,30 @@ const leaderboard: LeaderboardEntry[] = [
     teamId: "team-east",
     displayName: "East Side",
     score: 2,
+    latestDayScore: {
+      day: 4,
+      score: 1,
+    },
+    scoreHistory: [
+      {
+        day: 3,
+        dailyScore: 1,
+        cumulativeScore: 1,
+        rikishiScores: [
+          { rikishiId: "onosato", outcome: "win", score: 1 },
+          { rikishiId: "kirishima", outcome: "loss", score: 0 },
+        ],
+      },
+      {
+        day: 4,
+        dailyScore: 1,
+        cumulativeScore: 2,
+        rikishiScores: [
+          { rikishiId: "onosato", outcome: "loss", score: 0 },
+          { rikishiId: "kirishima", outcome: "win", score: 1 },
+        ],
+      },
+    ],
     rikishiScores: [
       {
         rikishiId: "onosato",
@@ -73,9 +97,23 @@ describe("LeaderboardPanel", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Status: Scoring in progress")).toBeInTheDocument();
     expect(screen.getByText("East Side")).toBeInTheDocument();
-    expect(screen.getByText("Onosato")).toBeInTheDocument();
-    expect(screen.getByText("Kirishima")).toBeInTheDocument();
+    expect(screen.getAllByText("Onosato")).toHaveLength(3);
+    expect(screen.getAllByText("Kirishima")).toHaveLength(3);
     expect(screen.getAllByText("1 win")).toHaveLength(2);
+    expect(screen.getByText("Day 4 +1")).toBeInTheDocument();
+    expect(screen.getByLabelText(/Recent form: day 3 \+1/)).toBeInTheDocument();
+    expect(
+      screen.getByRole("region", { name: "Day-by-day score history" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("+1 today · 2 total")).toBeInTheDocument();
+    expect(screen.getAllByText("Win")).toHaveLength(2);
+    expect(screen.getAllByText("Loss")).toHaveLength(2);
+    expect(
+      screen.getByText("Days 1–2 are awaiting results."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Days 5–15 are not scored yet."),
+    ).toBeInTheDocument();
   });
 
   it("requests expansion changes when a team row is clicked", () => {
@@ -128,7 +166,14 @@ describe("LeaderboardPanel", () => {
         createdTeam={null}
         errorMessage={null}
         expandedTeamId={null}
-        leaderboard={[{ ...leaderboard[0]!, score: 0 }]}
+        leaderboard={[
+          {
+            ...leaderboard[0]!,
+            score: 0,
+            latestDayScore: undefined,
+            scoreHistory: [],
+          },
+        ]}
         loadState="ready"
         onToggleTeam={vi.fn()}
         rikishi={rikishi}
@@ -167,5 +212,42 @@ describe("LeaderboardPanel", () => {
       screen.getByText("Demo May Basho - Complete, final leaderboard"),
     ).toBeInTheDocument();
     expect(screen.getByText("Status: Final scores")).toBeInTheDocument();
+  });
+
+  it("identifies missing current days separately from future days", () => {
+    render(
+      <LeaderboardPanel
+        basho={{ ...basho, currentDay: 3 }}
+        createdTeam={null}
+        errorMessage={null}
+        expandedTeamId="team-east"
+        leaderboard={[
+          {
+            ...leaderboard[0]!,
+            latestDayScore: { day: 1, score: 1 },
+            score: 1,
+            scoreHistory: [
+              {
+                day: 1,
+                dailyScore: 1,
+                cumulativeScore: 1,
+                rikishiScores: [],
+              },
+            ],
+          },
+        ]}
+        loadState="ready"
+        onToggleTeam={vi.fn()}
+        rikishi={rikishi}
+        totalDays={15}
+      />,
+    );
+
+    expect(
+      screen.getByText("Days 2–3 are awaiting results."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Days 4–15 are not scored yet."),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/LeaderboardPanel.tsx
+++ b/apps/web/src/components/LeaderboardPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useId, useMemo, useState } from "react";
 import type {
   Basho,
   CreatedTeamResponse,
@@ -86,24 +86,20 @@ export function LeaderboardPanel({
             {getEmptyScoringMessage(basho)}
           </div>
           {renderLeaderboardList({
-            currentDay: basho.currentDay,
             expandedTeamId,
             leaderboard,
             onToggleTeam,
             rikishiById,
             tiedScoreCounts,
-            totalDays,
           })}
         </>
       ) : (
         renderLeaderboardList({
-          currentDay: basho.currentDay,
           expandedTeamId,
           leaderboard,
           onToggleTeam,
           rikishiById,
           tiedScoreCounts,
-          totalDays,
         })
       )}
     </section>
@@ -111,21 +107,17 @@ export function LeaderboardPanel({
 }
 
 function renderLeaderboardList({
-  currentDay,
   expandedTeamId,
   leaderboard,
   onToggleTeam,
   rikishiById,
   tiedScoreCounts,
-  totalDays,
 }: {
-  currentDay?: number;
   expandedTeamId: string | null;
   leaderboard: LeaderboardEntry[];
   onToggleTeam: (teamId: string) => void;
   rikishiById: Map<string, RankedRikishi>;
   tiedScoreCounts: Map<number, number>;
-  totalDays?: number;
 }) {
   return (
     <ol className="leaderboard-list">
@@ -165,34 +157,19 @@ function renderLeaderboardList({
                   <p>No picks recorded for this team.</p>
                 ) : (
                   <ul className="score-totals-list">
-                    {entry.rikishiScores.map((score) => {
-                      const pickedRikishi = rikishiById.get(score.rikishiId);
-
-                      return (
-                        <li key={score.rikishiId}>
-                          <span>
-                            <strong>
-                              {pickedRikishi?.shikona ?? score.rikishiId}
-                            </strong>
-                            <small>
-                              {pickedRikishi?.rank ?? "Unranked pick"}
-                            </small>
-                          </span>
-                          <span>
-                            {score.wins} win{score.wins === 1 ? "" : "s"}
-                          </span>
-                          <span>{score.score} pts</span>
-                        </li>
-                      );
-                    })}
+                    {entry.rikishiScores.map((score) => (
+                      <RikishiScoreRow
+                        key={score.rikishiId}
+                        pickedRikishi={rikishiById.get(score.rikishiId)}
+                        results={getRikishiResults(
+                          entry.scoreHistory,
+                          score.rikishiId,
+                        )}
+                        score={score}
+                      />
+                    ))}
                   </ul>
                 )}
-                <ScoreHistory
-                  currentDay={currentDay}
-                  rikishiById={rikishiById}
-                  scoreHistory={entry.scoreHistory}
-                  totalDays={totalDays}
-                />
               </div>
             )}
           </li>
@@ -200,6 +177,127 @@ function renderLeaderboardList({
       })}
     </ol>
   );
+}
+
+type RikishiResult = {
+  day: number;
+  outcome: LeaderboardEntry["scoreHistory"][number]["rikishiScores"][number]["outcome"];
+  score: number;
+};
+
+function RikishiScoreRow({
+  pickedRikishi,
+  results,
+  score,
+}: {
+  pickedRikishi?: RankedRikishi;
+  results: RikishiResult[];
+  score: LeaderboardEntry["rikishiScores"][number];
+}) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const historyId = useId();
+  const shikona = pickedRikishi?.shikona ?? score.rikishiId;
+
+  return (
+    <li className="rikishi-score">
+      <button
+        type="button"
+        className="rikishi-score-summary"
+        onClick={() => setIsExpanded((current) => !current)}
+        aria-controls={historyId}
+        aria-expanded={isExpanded}
+      >
+        <span className="rikishi-identity">
+          <strong>{shikona}</strong>
+          <small>{pickedRikishi?.rank ?? "Unranked pick"}</small>
+        </span>
+        <RecentRikishiResults results={results} shikona={shikona} />
+        <span className="rikishi-wins">
+          {score.wins} win{score.wins === 1 ? "" : "s"}
+        </span>
+        <span className="rikishi-points">{score.score} pts</span>
+      </button>
+      {isExpanded && (
+        <section
+          className="rikishi-result-history"
+          id={historyId}
+          aria-label={`${shikona} result history`}
+        >
+          <h4>{shikona} results</h4>
+          {results.length === 0 ? (
+            <p>No results recorded yet.</p>
+          ) : (
+            <ol>
+              {results.map((result) => (
+                <li
+                  key={result.day}
+                  aria-label={`Day ${result.day}: ${formatOutcome(result.outcome)}, ${formatPoints(result.score)}`}
+                >
+                  <small>Day {result.day}</small>
+                  <ResultTile outcome={result.outcome} />
+                  <strong>{formatSignedScore(result.score)}</strong>
+                </li>
+              ))}
+            </ol>
+          )}
+        </section>
+      )}
+    </li>
+  );
+}
+
+function RecentRikishiResults({
+  results,
+  shikona,
+}: {
+  results: RikishiResult[];
+  shikona: string;
+}) {
+  const recentResults = results.slice(-5);
+
+  if (recentResults.length === 0) {
+    return <span className="recent-rikishi-results" />;
+  }
+
+  return (
+    <span
+      className="recent-rikishi-results"
+      aria-label={`Recent results for ${shikona}: ${recentResults
+        .map((result) => `day ${result.day} ${formatOutcome(result.outcome)}`)
+        .join(", ")}`}
+    >
+      {recentResults.map((result) => (
+        <ResultTile key={result.day} outcome={result.outcome} />
+      ))}
+    </span>
+  );
+}
+
+function ResultTile({ outcome }: { outcome: RikishiResult["outcome"] }) {
+  return (
+    <span
+      className={`result-tile result-${outcome}`}
+      aria-hidden="true"
+      title={formatOutcome(outcome)}
+    >
+      {formatOutcomeInitial(outcome)}
+    </span>
+  );
+}
+
+function getRikishiResults(
+  scoreHistory: LeaderboardEntry["scoreHistory"],
+  rikishiId: string,
+): RikishiResult[] {
+  return scoreHistory.flatMap((day) => {
+    const result = day.rikishiScores.find(
+      (candidate) => candidate.rikishiId === rikishiId,
+    );
+
+    return result === undefined
+      ? []
+      : [{ day: day.day, outcome: result.outcome, score: result.score }];
+  });
 }
 
 function RecentForm({
@@ -232,118 +330,12 @@ function RecentForm({
   );
 }
 
-function ScoreHistory({
-  currentDay,
-  rikishiById,
-  scoreHistory,
-  totalDays,
-}: {
-  currentDay?: number;
-  rikishiById: Map<string, RankedRikishi>;
-  scoreHistory: LeaderboardEntry["scoreHistory"];
-  totalDays?: number;
-}) {
-  const unscoredCopy = getUnscoredDaysCopy(
-    scoreHistory.map((entry) => entry.day),
-    currentDay,
-    totalDays,
-  );
-
-  return (
-    <section className="score-history" aria-label="Day-by-day score history">
-      <h3>Day-by-day score</h3>
-      {scoreHistory.length === 0 ? (
-        <p>No scored days yet.</p>
-      ) : (
-        <ol>
-          {[...scoreHistory].reverse().map((day) => (
-            <li className="score-day" key={day.day}>
-              <div className="score-day-heading">
-                <strong>Day {day.day}</strong>
-                <span>
-                  {formatSignedScore(day.dailyScore)} today ·{" "}
-                  {day.cumulativeScore} total
-                </span>
-              </div>
-              <ul>
-                {day.rikishiScores.map((score) => (
-                  <li key={score.rikishiId}>
-                    <span>
-                      {rikishiById.get(score.rikishiId)?.shikona ??
-                        score.rikishiId}
-                    </span>
-                    <span>{formatOutcome(score.outcome)}</span>
-                    <strong>{formatSignedScore(score.score)}</strong>
-                  </li>
-                ))}
-              </ul>
-            </li>
-          ))}
-        </ol>
-      )}
-      {unscoredCopy.map((copy) => (
-        <p className="unscored-days" key={copy}>
-          {copy}
-        </p>
-      ))}
-    </section>
-  );
-}
-
-function getUnscoredDaysCopy(
-  scoredDays: number[],
-  currentDay = 0,
-  totalDays?: number,
-): string[] {
-  const scoredDaySet = new Set(scoredDays);
-  const latestScoredDay = scoredDays.reduce(
-    (latestDay, day) => Math.max(latestDay, day),
-    0,
-  );
-  const progressDay = Math.max(currentDay, latestScoredDay);
-  const missingCurrentDays = Array.from(
-    { length: progressDay },
-    (_, index) => index + 1,
-  ).filter((day) => !scoredDaySet.has(day));
-  const copy: string[] = [];
-
-  if (missingCurrentDays.length > 0) {
-    copy.push(
-      `${formatDayRange(missingCurrentDays)} ${missingCurrentDays.length === 1 ? "is" : "are"} awaiting results.`,
-    );
-  }
-
-  if (totalDays !== undefined && progressDay < totalDays) {
-    const futureDays = Array.from(
-      { length: totalDays - progressDay },
-      (_, index) => progressDay + index + 1,
-    );
-    copy.push(
-      `${formatDayRange(futureDays)} ${futureDays.length === 1 ? "is" : "are"} not scored yet.`,
-    );
-  }
-
-  return copy;
-}
-
-function formatDayRange(days: number[]): string {
-  if (days.length === 1) {
-    return `Day ${days[0]}`;
-  }
-
-  const isContinuous = days.every(
-    (day, index) => index === 0 || day === days[index - 1]! + 1,
-  );
-
-  if (isContinuous) {
-    return `Days ${days[0]}–${days.at(-1)}`;
-  }
-
-  return `Days ${days.join(", ")}`;
-}
-
 function formatSignedScore(score: number): string {
   return score > 0 ? `+${score}` : `${score}`;
+}
+
+function formatPoints(score: number): string {
+  return `${formatSignedScore(score)} point${Math.abs(score) === 1 ? "" : "s"}`;
 }
 
 function formatOutcome(
@@ -358,6 +350,19 @@ function formatOutcome(
       return "Absent";
     case "no-result":
       return "No result";
+  }
+}
+
+function formatOutcomeInitial(outcome: RikishiResult["outcome"]): string {
+  switch (outcome) {
+    case "win":
+      return "W";
+    case "loss":
+      return "L";
+    case "absent":
+      return "A";
+    case "no-result":
+      return "–";
   }
 }
 

--- a/apps/web/src/components/LeaderboardPanel.tsx
+++ b/apps/web/src/components/LeaderboardPanel.tsx
@@ -86,20 +86,24 @@ export function LeaderboardPanel({
             {getEmptyScoringMessage(basho)}
           </div>
           {renderLeaderboardList({
+            currentDay: basho.currentDay,
             expandedTeamId,
             leaderboard,
             onToggleTeam,
             rikishiById,
             tiedScoreCounts,
+            totalDays,
           })}
         </>
       ) : (
         renderLeaderboardList({
+          currentDay: basho.currentDay,
           expandedTeamId,
           leaderboard,
           onToggleTeam,
           rikishiById,
           tiedScoreCounts,
+          totalDays,
         })
       )}
     </section>
@@ -107,17 +111,21 @@ export function LeaderboardPanel({
 }
 
 function renderLeaderboardList({
+  currentDay,
   expandedTeamId,
   leaderboard,
   onToggleTeam,
   rikishiById,
   tiedScoreCounts,
+  totalDays,
 }: {
+  currentDay?: number;
   expandedTeamId: string | null;
   leaderboard: LeaderboardEntry[];
   onToggleTeam: (teamId: string) => void;
   rikishiById: Map<string, RankedRikishi>;
   tiedScoreCounts: Map<number, number>;
+  totalDays?: number;
 }) {
   return (
     <ol className="leaderboard-list">
@@ -137,16 +145,26 @@ function renderLeaderboardList({
               <span className="leaderboard-team">
                 <strong>{entry.displayName}</strong>
                 {isTied && <small>Tied on score</small>}
+                <RecentForm scoreHistory={entry.scoreHistory} />
               </span>
-              <span className="leaderboard-score">{entry.score} pts</span>
+              <span className="leaderboard-score">
+                {entry.latestDayScore !== undefined && (
+                  <small>
+                    Day {entry.latestDayScore.day}{" "}
+                    {formatSignedScore(entry.latestDayScore.score)}
+                  </small>
+                )}
+                <strong>{entry.score} pts</strong>
+              </span>
             </button>
 
             {isExpanded && (
               <div className="score-breakdown">
+                <h3>Tournament totals</h3>
                 {entry.rikishiScores.length === 0 ? (
                   <p>No picks recorded for this team.</p>
                 ) : (
-                  <ul>
+                  <ul className="score-totals-list">
                     {entry.rikishiScores.map((score) => {
                       const pickedRikishi = rikishiById.get(score.rikishiId);
 
@@ -169,6 +187,12 @@ function renderLeaderboardList({
                     })}
                   </ul>
                 )}
+                <ScoreHistory
+                  currentDay={currentDay}
+                  rikishiById={rikishiById}
+                  scoreHistory={entry.scoreHistory}
+                  totalDays={totalDays}
+                />
               </div>
             )}
           </li>
@@ -176,6 +200,165 @@ function renderLeaderboardList({
       })}
     </ol>
   );
+}
+
+function RecentForm({
+  scoreHistory,
+}: {
+  scoreHistory: LeaderboardEntry["scoreHistory"];
+}) {
+  const recentDays = scoreHistory.slice(-5);
+
+  if (recentDays.length === 0) {
+    return null;
+  }
+
+  return (
+    <span
+      className="recent-form"
+      aria-label={`Recent form: ${recentDays
+        .map(
+          (entry) => `day ${entry.day} ${formatSignedScore(entry.dailyScore)}`,
+        )
+        .join(", ")}`}
+    >
+      {recentDays.map((entry) => (
+        <span className="form-day" key={entry.day} aria-hidden="true">
+          <small>D{entry.day}</small>
+          <strong>{formatSignedScore(entry.dailyScore)}</strong>
+        </span>
+      ))}
+    </span>
+  );
+}
+
+function ScoreHistory({
+  currentDay,
+  rikishiById,
+  scoreHistory,
+  totalDays,
+}: {
+  currentDay?: number;
+  rikishiById: Map<string, RankedRikishi>;
+  scoreHistory: LeaderboardEntry["scoreHistory"];
+  totalDays?: number;
+}) {
+  const unscoredCopy = getUnscoredDaysCopy(
+    scoreHistory.map((entry) => entry.day),
+    currentDay,
+    totalDays,
+  );
+
+  return (
+    <section className="score-history" aria-label="Day-by-day score history">
+      <h3>Day-by-day score</h3>
+      {scoreHistory.length === 0 ? (
+        <p>No scored days yet.</p>
+      ) : (
+        <ol>
+          {[...scoreHistory].reverse().map((day) => (
+            <li className="score-day" key={day.day}>
+              <div className="score-day-heading">
+                <strong>Day {day.day}</strong>
+                <span>
+                  {formatSignedScore(day.dailyScore)} today ·{" "}
+                  {day.cumulativeScore} total
+                </span>
+              </div>
+              <ul>
+                {day.rikishiScores.map((score) => (
+                  <li key={score.rikishiId}>
+                    <span>
+                      {rikishiById.get(score.rikishiId)?.shikona ??
+                        score.rikishiId}
+                    </span>
+                    <span>{formatOutcome(score.outcome)}</span>
+                    <strong>{formatSignedScore(score.score)}</strong>
+                  </li>
+                ))}
+              </ul>
+            </li>
+          ))}
+        </ol>
+      )}
+      {unscoredCopy.map((copy) => (
+        <p className="unscored-days" key={copy}>
+          {copy}
+        </p>
+      ))}
+    </section>
+  );
+}
+
+function getUnscoredDaysCopy(
+  scoredDays: number[],
+  currentDay = 0,
+  totalDays?: number,
+): string[] {
+  const scoredDaySet = new Set(scoredDays);
+  const latestScoredDay = scoredDays.reduce(
+    (latestDay, day) => Math.max(latestDay, day),
+    0,
+  );
+  const progressDay = Math.max(currentDay, latestScoredDay);
+  const missingCurrentDays = Array.from(
+    { length: progressDay },
+    (_, index) => index + 1,
+  ).filter((day) => !scoredDaySet.has(day));
+  const copy: string[] = [];
+
+  if (missingCurrentDays.length > 0) {
+    copy.push(
+      `${formatDayRange(missingCurrentDays)} ${missingCurrentDays.length === 1 ? "is" : "are"} awaiting results.`,
+    );
+  }
+
+  if (totalDays !== undefined && progressDay < totalDays) {
+    const futureDays = Array.from(
+      { length: totalDays - progressDay },
+      (_, index) => progressDay + index + 1,
+    );
+    copy.push(
+      `${formatDayRange(futureDays)} ${futureDays.length === 1 ? "is" : "are"} not scored yet.`,
+    );
+  }
+
+  return copy;
+}
+
+function formatDayRange(days: number[]): string {
+  if (days.length === 1) {
+    return `Day ${days[0]}`;
+  }
+
+  const isContinuous = days.every(
+    (day, index) => index === 0 || day === days[index - 1]! + 1,
+  );
+
+  if (isContinuous) {
+    return `Days ${days[0]}–${days.at(-1)}`;
+  }
+
+  return `Days ${days.join(", ")}`;
+}
+
+function formatSignedScore(score: number): string {
+  return score > 0 ? `+${score}` : `${score}`;
+}
+
+function formatOutcome(
+  outcome: LeaderboardEntry["scoreHistory"][number]["rikishiScores"][number]["outcome"],
+): string {
+  switch (outcome) {
+    case "win":
+      return "Win";
+    case "loss":
+      return "Loss";
+    case "absent":
+      return "Absent";
+    case "no-result":
+      return "No result";
+  }
 }
 
 function formatBashoHeadline(basho: Basho, totalDays?: number): string {

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -45,12 +45,28 @@ export interface LeaderboardEntry {
   displayName: string;
   score: number;
   rikishiScores: RikishiScore[];
+  latestDayScore?: {
+    day: number;
+    score: number;
+  };
+  scoreHistory: TeamScoreHistoryEntry[];
 }
 
 export interface RikishiScore {
   rikishiId: string;
   wins: number;
   score: number;
+}
+
+export interface TeamScoreHistoryEntry {
+  day: number;
+  dailyScore: number;
+  cumulativeScore: number;
+  rikishiScores: Array<{
+    rikishiId: string;
+    outcome: "win" | "loss" | "absent" | "no-result";
+    score: number;
+  }>;
 }
 
 export type LoadState = "loading" | "ready" | "empty" | "error";

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -42,8 +42,8 @@ Current behaviour:
 - Lets a player select and deselect rikishi up to the API-configured team size.
 - Captures a display/team name and submits the team to the API.
 - Shows ordered team standings with the latest daily score, compact five-day
-  form, and expandable picked-rikishi tournament totals and day-by-day score
-  breakdowns.
+  team form, and expandable picked-rikishi tournament totals. Each rikishi row
+  shows up to five recent outcomes and expands to the full result history.
 - Shows loading, empty, success, and API error states.
 - Has Vitest coverage through React Testing Library.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -41,7 +41,9 @@ Current behaviour:
 - Fetches leaderboard standings from the Fastify API.
 - Lets a player select and deselect rikishi up to the API-configured team size.
 - Captures a display/team name and submits the team to the API.
-- Shows ordered team standings with expandable picked-rikishi score breakdowns.
+- Shows ordered team standings with the latest daily score, compact five-day
+  form, and expandable picked-rikishi tournament totals and day-by-day score
+  breakdowns.
 - Shows loading, empty, success, and API error states.
 - Has Vitest coverage through React Testing Library.
 
@@ -74,6 +76,11 @@ Current routes:
   - Returns a fantasy team and its picks.
 - `GET /api/basho/:bashoId/leaderboard`
   - Returns leaderboard entries calculated with the domain scoring module.
+  - Includes the latest scored day's points and chronological daily/cumulative
+    history for each team.
+  - Each day records every pick's `win`, `loss`, `absent`, or `no-result`
+    outcome and fantasy-point contribution. Days without stored results are
+    omitted rather than presented as scored.
 - `POST /api/admin/import-banzuke`
   - Fetches current Makuuchi banzuke data from the Japan Sumo Association `indexAjax` endpoint.
   - Maps source payloads into local `Basho`, `Rikishi`, and `BanzukeEntry` records.
@@ -133,6 +140,9 @@ Current behaviour:
 - Scores a rikishi as one point per win.
 - Scores a team as the sum of all wins by the team's picked rikishi.
 - Supports optional day-bounded scoring with `throughDay` so callers can calculate standings after a specific basho day without relying on an implicit "latest" result.
+- Derives chronological team score history from stored bout results, including
+  daily and cumulative totals plus per-pick outcomes, for reuse by the
+  leaderboard and future progress visualisations.
 - Calculates a leaderboard ordered by score descending.
 - Allows tied team scores and orders ties deterministically by display name, then team id.
 - Validates duplicate picks and exact team size when a team size is supplied.

--- a/e2e/mvp-game-loop.spec.ts
+++ b/e2e/mvp-game-loop.spec.ts
@@ -53,7 +53,7 @@ test("shows completed demo leaderboard entries in score order", async ({
   await page.goto("/");
   await page.getByRole("button", { name: "Leaderboard" }).click();
 
-  const leaderboardRows = page.getByRole("button").filter({ hasText: /pts/ });
+  const leaderboardRows = page.locator(".leaderboard-summary");
   await expect(leaderboardRows).toHaveCount(4);
 
   const rowTexts = await leaderboardRows.allTextContents();
@@ -139,15 +139,23 @@ test("advances the demo basho and refreshes scored leaderboard state", async ({
   await expect(
     page.getByLabel("Recent form: day 1 +1, day 2 +1").first(),
   ).toBeVisible();
+  await expect(
+    page.getByLabel("Recent results for Wakatakakage: day 1 Win, day 2 Loss"),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("region", { name: "Day-by-day score history" }),
+  ).toHaveCount(0);
+
+  await page
+    .getByRole("button", { name: /Wakatakakage.*1 win.*1 pts/ })
+    .click();
 
   const history = page.getByRole("region", {
-    name: "Day-by-day score history",
+    name: "Wakatakakage result history",
   });
   await expect(history).toBeVisible();
-  await expect(history.getByText("Day 2", { exact: true })).toBeVisible();
-  await expect(history.getByText("+1 today · 2 total")).toBeVisible();
-  await expect(history.getByText("Win").first()).toBeVisible();
-  await expect(history.getByText("Loss").first()).toBeVisible();
+  await expect(history.getByLabel("Day 1: Win, +1 point")).toBeVisible();
+  await expect(history.getByLabel("Day 2: Loss, 0 points")).toBeVisible();
 });
 
 test("prevents incomplete and overfull team submissions", async ({ page }) => {

--- a/e2e/mvp-game-loop.spec.ts
+++ b/e2e/mvp-game-loop.spec.ts
@@ -120,16 +120,34 @@ test("advances the demo basho and refreshes scored leaderboard state", async ({
     headers: demoAdminHeaders,
   });
   await expect(advanceResponse).toBeOK();
+  const secondAdvanceResponse = await request.post(
+    "/api/admin/demo/advance-day",
+    {
+      headers: demoAdminHeaders,
+    },
+  );
+  await expect(secondAdvanceResponse).toBeOK();
 
   await page.goto("/");
   await page.getByRole("button", { name: "Leaderboard" }).click();
 
-  await expect(page.getByText("Demo May Basho - Day 1 of 15")).toBeVisible();
+  await expect(page.getByText("Demo May Basho - Day 2 of 15")).toBeVisible();
   await expect(page.getByText("Status: Scoring in progress")).toBeVisible();
   await expect(
-    page.getByRole("button", { name: /Dohyo Dreamers.*1 pts/ }),
+    page.getByRole("button", { name: /Dohyo Dreamers.*Day 2.*2 pts/ }),
   ).toBeVisible();
-  await expect(page.getByText(/1 win/).first()).toBeVisible();
+  await expect(
+    page.getByLabel("Recent form: day 1 +1, day 2 +1").first(),
+  ).toBeVisible();
+
+  const history = page.getByRole("region", {
+    name: "Day-by-day score history",
+  });
+  await expect(history).toBeVisible();
+  await expect(history.getByText("Day 2", { exact: true })).toBeVisible();
+  await expect(history.getByText("+1 today · 2 total")).toBeVisible();
+  await expect(history.getByText("Win").first()).toBeVisible();
+  await expect(history.getByText("Loss").first()).toBeVisible();
 });
 
 test("prevents incomplete and overfull team submissions", async ({ page }) => {

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -10,9 +10,12 @@ export type {
   PickValidationErrorCode,
   PickValidationOptions,
   Rikishi,
+  RikishiDayOutcome,
+  RikishiDayScore,
   RikishiScore,
   ScoringOptions,
   TeamScore,
+  TeamScoreHistoryEntry,
 } from "./types.js";
 export {
   canEditFantasyPicks,
@@ -27,6 +30,7 @@ export {
 export {
   calculateRikishiScore,
   calculateTeamScore,
+  calculateTeamScoreHistory,
   countPickedRikishiWins,
 } from "./scoring.js";
 export { validateFantasyPicks } from "./validation.js";

--- a/packages/domain/src/leaderboard.test.ts
+++ b/packages/domain/src/leaderboard.test.ts
@@ -86,6 +86,24 @@ describe("calculateLeaderboard", () => {
     ]);
   });
 
+  it("includes the latest daily score and full score history", () => {
+    const [leader] = calculateLeaderboard(teams, picks, results);
+
+    expect(leader).toMatchObject({
+      teamId: "team-a",
+      score: 2,
+      latestDayScore: {
+        day: 3,
+        score: 0,
+      },
+      scoreHistory: [
+        { day: 1, dailyScore: 1, cumulativeScore: 1 },
+        { day: 2, dailyScore: 1, cumulativeScore: 2 },
+        { day: 3, dailyScore: 0, cumulativeScore: 2 },
+      ],
+    });
+  });
+
   it("can calculate leaderboard standings through a specific basho day", () => {
     expect(
       calculateLeaderboard(teams, picks, results, {

--- a/packages/domain/src/leaderboard.ts
+++ b/packages/domain/src/leaderboard.ts
@@ -1,4 +1,4 @@
-import { calculateTeamScore } from "./scoring.js";
+import { calculateTeamScore, calculateTeamScoreHistory } from "./scoring.js";
 import type {
   BoutResult,
   FantasyPick,
@@ -15,7 +15,29 @@ export function calculateLeaderboard(
   options: ScoringOptions = {},
 ): LeaderboardEntry[] {
   const sortedScores = teams
-    .map((team) => calculateTeamScore(team, picks, boutResults, options))
+    .map((team) => {
+      const teamScore = calculateTeamScore(team, picks, boutResults, options);
+      const scoreHistory = calculateTeamScoreHistory(
+        team,
+        picks,
+        boutResults,
+        options,
+      );
+      const latestHistory = scoreHistory.at(-1);
+
+      return {
+        ...teamScore,
+        ...(latestHistory === undefined
+          ? {}
+          : {
+              latestDayScore: {
+                day: latestHistory.day,
+                score: latestHistory.dailyScore,
+              },
+            }),
+        scoreHistory,
+      };
+    })
     .sort(compareLeaderboardEntries);
 
   return sortedScores.map((entry, index) => ({

--- a/packages/domain/src/scoring.test.ts
+++ b/packages/domain/src/scoring.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   calculateRikishiScore,
   calculateTeamScore,
+  calculateTeamScoreHistory,
   countPickedRikishiWins,
 } from "./scoring.js";
 import type { BoutResult, FantasyPick, FantasyTeam } from "./types.js";
@@ -147,5 +148,124 @@ describe("calculateTeamScore", () => {
         throughDay: 2,
       }).score,
     ).toBe(1);
+  });
+});
+
+describe("calculateTeamScoreHistory", () => {
+  const picks: FantasyPick[] = [
+    {
+      teamId: team.id,
+      rikishiId: "kotozakura",
+    },
+    {
+      teamId: team.id,
+      rikishiId: "onosato",
+    },
+  ];
+
+  it("groups daily contributions and cumulative scores by basho day", () => {
+    expect(calculateTeamScoreHistory(team, picks, results)).toEqual([
+      {
+        day: 1,
+        dailyScore: 1,
+        cumulativeScore: 1,
+        rikishiScores: [
+          { rikishiId: "kotozakura", outcome: "win", score: 1 },
+          { rikishiId: "onosato", outcome: "no-result", score: 0 },
+        ],
+      },
+      {
+        day: 2,
+        dailyScore: 0,
+        cumulativeScore: 1,
+        rikishiScores: [
+          { rikishiId: "kotozakura", outcome: "loss", score: 0 },
+          { rikishiId: "onosato", outcome: "no-result", score: 0 },
+        ],
+      },
+      {
+        day: 3,
+        dailyScore: 1,
+        cumulativeScore: 2,
+        rikishiScores: [
+          { rikishiId: "kotozakura", outcome: "loss", score: 0 },
+          { rikishiId: "onosato", outcome: "win", score: 1 },
+        ],
+      },
+    ]);
+  });
+
+  it("returns only scored days through the requested boundary", () => {
+    expect(
+      calculateTeamScoreHistory(team, picks, results, { throughDay: 2 }),
+    ).toHaveLength(2);
+    expect(
+      calculateTeamScoreHistory(team, picks, [], { throughDay: 2 }),
+    ).toEqual([]);
+  });
+
+  it("does not invent history entries for days with no stored results", () => {
+    expect(calculateTeamScoreHistory(team, picks, [results[2]!])).toEqual([
+      {
+        day: 3,
+        dailyScore: 1,
+        cumulativeScore: 1,
+        rikishiScores: [
+          { rikishiId: "kotozakura", outcome: "loss", score: 0 },
+          { rikishiId: "onosato", outcome: "win", score: 1 },
+        ],
+      },
+    ]);
+  });
+
+  it("does not award points for an absence", () => {
+    expect(
+      calculateTeamScoreHistory(team, picks, [
+        {
+          id: "bout-absent",
+          bashoId: team.bashoId,
+          day: 1,
+          winnerRikishiId: "onosato",
+          loserRikishiId: "kotozakura",
+          winnerAbsent: true,
+        },
+      ]),
+    ).toEqual([
+      {
+        day: 1,
+        dailyScore: 0,
+        cumulativeScore: 0,
+        rikishiScores: [
+          { rikishiId: "kotozakura", outcome: "loss", score: 0 },
+          { rikishiId: "onosato", outcome: "absent", score: 0 },
+        ],
+      },
+    ]);
+  });
+
+  it("keeps daily history aligned when a rikishi has multiple stored wins", () => {
+    const duplicateDayResults: BoutResult[] = [
+      results[0]!,
+      {
+        id: "bout-1-rematch",
+        bashoId: team.bashoId,
+        day: 1,
+        winnerRikishiId: "kotozakura",
+        loserRikishiId: "onosato",
+      },
+    ];
+    const history = calculateTeamScoreHistory(team, picks, duplicateDayResults);
+
+    expect(history[0]).toMatchObject({
+      dailyScore: 2,
+      cumulativeScore: 2,
+      rikishiScores: [
+        { rikishiId: "kotozakura", outcome: "win", score: 2 },
+        { rikishiId: "onosato", outcome: "loss", score: 0 },
+      ],
+    });
+    expect(history.at(-1)?.cumulativeScore).toBe(
+      calculateTeamScore(team, picks, duplicateDayResults).score,
+    );
   });
 });

--- a/packages/domain/src/scoring.ts
+++ b/packages/domain/src/scoring.ts
@@ -3,9 +3,11 @@ import type {
   FantasyPick,
   FantasyTeam,
   Rikishi,
+  RikishiDayScore,
   RikishiScore,
   ScoringOptions,
   TeamScore,
+  TeamScoreHistoryEntry,
 } from "./types.js";
 
 export function countPickedRikishiWins(
@@ -54,13 +56,89 @@ export function calculateTeamScore(
   };
 }
 
+export function calculateTeamScoreHistory(
+  team: FantasyTeam,
+  picks: readonly FantasyPick[],
+  boutResults: readonly BoutResult[],
+  options: ScoringOptions = {},
+): TeamScoreHistoryEntry[] {
+  const scoredResults = filterResultsThroughDay(boutResults, options);
+  const scoredDays = [
+    ...new Set(scoredResults.map((result) => result.day)),
+  ].sort((left, right) => left - right);
+  const teamPicks = picks.filter((pick) => pick.teamId === team.id);
+  let cumulativeScore = 0;
+
+  return scoredDays.map((day) => {
+    const dayResults = scoredResults.filter((result) => result.day === day);
+    const rikishiScores = teamPicks.map((pick) =>
+      calculateRikishiDayScore(pick.rikishiId, dayResults),
+    );
+    const dailyScore = rikishiScores.reduce(
+      (total, score) => total + score.score,
+      0,
+    );
+    cumulativeScore += dailyScore;
+
+    return {
+      day,
+      dailyScore,
+      cumulativeScore,
+      rikishiScores,
+    };
+  });
+}
+
+function calculateRikishiDayScore(
+  rikishiId: Rikishi["id"],
+  dayResults: readonly BoutResult[],
+): RikishiDayScore {
+  const results = dayResults.filter(
+    (entry) =>
+      entry.winnerRikishiId === rikishiId || entry.loserRikishiId === rikishiId,
+  );
+  const score = results.filter(
+    (result) =>
+      result.winnerRikishiId === rikishiId && result.winnerAbsent !== true,
+  ).length;
+
+  if (results.length === 0) {
+    return { rikishiId, outcome: "no-result", score: 0 };
+  }
+
+  if (score > 0) {
+    return { rikishiId, outcome: "win", score };
+  }
+
+  if (
+    results.some(
+      (result) =>
+        (result.winnerRikishiId === rikishiId &&
+          result.winnerAbsent === true) ||
+        (result.loserRikishiId === rikishiId && result.loserAbsent === true),
+    )
+  ) {
+    return { rikishiId, outcome: "absent", score: 0 };
+  }
+
+  return { rikishiId, outcome: "loss", score: 0 };
+}
+
 function filterResultsForScoring(
+  boutResults: readonly BoutResult[],
+  options: ScoringOptions,
+): BoutResult[] {
+  return filterResultsThroughDay(boutResults, options).filter(
+    (result) => result.winnerAbsent !== true,
+  );
+}
+
+function filterResultsThroughDay(
   boutResults: readonly BoutResult[],
   options: ScoringOptions,
 ): BoutResult[] {
   return boutResults.filter(
     (result) =>
-      result.winnerAbsent !== true &&
-      (options.throughDay === undefined || result.day <= options.throughDay),
+      options.throughDay === undefined || result.day <= options.throughDay,
   );
 }

--- a/packages/domain/src/types.ts
+++ b/packages/domain/src/types.ts
@@ -56,6 +56,21 @@ export interface RikishiScore {
   score: number;
 }
 
+export type RikishiDayOutcome = "win" | "loss" | "absent" | "no-result";
+
+export interface RikishiDayScore {
+  rikishiId: Rikishi["id"];
+  outcome: RikishiDayOutcome;
+  score: number;
+}
+
+export interface TeamScoreHistoryEntry {
+  day: BoutResult["day"];
+  dailyScore: number;
+  cumulativeScore: number;
+  rikishiScores: RikishiDayScore[];
+}
+
 export interface ScoringOptions {
   throughDay?: BoutResult["day"];
 }
@@ -69,6 +84,11 @@ export interface TeamScore {
 
 export interface LeaderboardEntry extends TeamScore {
   rank: number;
+  latestDayScore?: {
+    day: BoutResult["day"];
+    score: number;
+  };
+  scoreHistory: TeamScoreHistoryEntry[];
 }
 
 export type PickValidationErrorCode = "duplicate-pick" | "invalid-team-size";


### PR DESCRIPTION
Closes #36.

## Summary

- derive chronological daily and cumulative fantasy score history in the domain layer
- expose each team’s latest daily score and per-rikishi win, loss, absence, or no-result contribution through the leaderboard API
- show the latest score and compact five-day form on leaderboard rows
- add an expandable, responsive day-by-day breakdown with clear missing/current and future unscored-day states
- keep history totals aligned with normal scoring even if a rikishi has multiple stored bouts on one day

## Validation

- `make check` — passed (deployment contract, lint, formatting, 138 unit/API/component tests, and builds)
- `make e2e` — passed (21 Playwright tests across desktop Chromium, mobile Chromium, and mobile WebKit)
- agent-browser visual pass — passed at 1440×900 and iPhone 14; no error overlays, browser errors, or horizontal overflow
- dedicated pre-handoff review — two findings fixed and final review completed with no actionable P1/P2 findings

## Documentation

- updated `README.md` and `docs/ARCHITECTURE.md` with the leaderboard history response and UI behaviour

## Follow-up / non-goals

- the tournament progress graph remains separate follow-up issue #55 and can reuse this score-history shape
- this change does not alter scoring rules, result imports, persistence, authentication, or pick locking
