### PR TITLE
Add tournament progress chart to the leaderboard

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -164,7 +164,7 @@ describe("App", () => {
     expect(
       screen.getByRole("heading", { name: "Leaderboard" }),
     ).toBeInTheDocument();
-    expect(screen.getByText("East Side")).toBeInTheDocument();
+    expect(screen.getAllByText("East Side").length).toBeGreaterThan(0);
     expect(screen.getByText("2 pts")).toBeInTheDocument();
     expect(screen.getAllByText("Tied on score")).toHaveLength(2);
     expect(screen.getByText("Onosato")).toBeInTheDocument();

--- a/apps/web/src/components/DailyScoreBadge.css
+++ b/apps/web/src/components/DailyScoreBadge.css
@@ -1,0 +1,13 @@
+.daily-score-badge {
+  display: inline-flex;
+  min-width: 26px;
+  align-items: center;
+  justify-content: center;
+  padding: 2px 7px;
+  border-radius: 999px;
+  background: var(--vermilion);
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 900;
+  line-height: 1.25;
+}

--- a/apps/web/src/components/DailyScoreBadge.test.tsx
+++ b/apps/web/src/components/DailyScoreBadge.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { DailyScoreBadge } from "./DailyScoreBadge";
+
+describe("DailyScoreBadge", () => {
+  it("formats positive and zero daily scores", () => {
+    const { rerender } = render(<DailyScoreBadge score={2} />);
+
+    expect(screen.getByText("+2")).toHaveClass("daily-score-badge");
+
+    rerender(<DailyScoreBadge score={0} />);
+
+    expect(screen.getByText("0")).toHaveClass("daily-score-badge");
+  });
+});

--- a/apps/web/src/components/DailyScoreBadge.tsx
+++ b/apps/web/src/components/DailyScoreBadge.tsx
@@ -1,0 +1,13 @@
+import "./DailyScoreBadge.css";
+
+interface DailyScoreBadgeProps {
+  score: number;
+}
+
+export function DailyScoreBadge({ score }: DailyScoreBadgeProps) {
+  return (
+    <span className="daily-score-badge">
+      {score > 0 ? `+${score}` : `${score}`}
+    </span>
+  );
+}

--- a/apps/web/src/components/LeaderboardPanel.css
+++ b/apps/web/src/components/LeaderboardPanel.css
@@ -126,6 +126,13 @@
   font-weight: 800;
 }
 
+.leaderboard-score .leaderboard-latest-day {
+  display: inline-flex;
+  gap: 5px;
+  align-items: center;
+  justify-content: flex-end;
+}
+
 .leaderboard-score strong {
   color: var(--indigo);
   font-size: 1.05rem;

--- a/apps/web/src/components/LeaderboardPanel.test.tsx
+++ b/apps/web/src/components/LeaderboardPanel.test.tsx
@@ -110,6 +110,16 @@ describe("LeaderboardPanel", () => {
     expect(
       screen.queryByRole("region", { name: "Day-by-day score history" }),
     ).not.toBeInTheDocument();
+    const leaderboardList = document.querySelector(".leaderboard-list");
+    const progressChart = screen.getByRole("region", {
+      name: "Score progress",
+    });
+
+    expect(leaderboardList).not.toBeNull();
+    expect(
+      leaderboardList!.compareDocumentPosition(progressChart) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
 
     fireEvent.click(screen.getByRole("button", { name: /Onosato/ }));
 

--- a/apps/web/src/components/LeaderboardPanel.test.tsx
+++ b/apps/web/src/components/LeaderboardPanel.test.tsx
@@ -100,7 +100,18 @@ describe("LeaderboardPanel", () => {
     expect(screen.getByText("Onosato")).toBeInTheDocument();
     expect(screen.getByText("Kirishima")).toBeInTheDocument();
     expect(screen.getAllByText("1 win")).toHaveLength(2);
-    expect(screen.getByText("Day 4 +1")).toBeInTheDocument();
+    const leaderboardList =
+      document.querySelector<HTMLElement>(".leaderboard-list");
+    expect(leaderboardList).not.toBeNull();
+    const leaderboardSummary = within(leaderboardList!).getByRole("button", {
+      name: /East Side/,
+    });
+    expect(within(leaderboardSummary).getByText("Day 4")).toBeInTheDocument();
+    expect(
+      within(leaderboardSummary).getByText("+1", {
+        selector: ".daily-score-badge",
+      }),
+    ).toBeInTheDocument();
     expect(screen.getByLabelText(/Recent form: day 3 \+1/)).toBeInTheDocument();
     expect(
       screen.getByLabelText(
@@ -110,12 +121,10 @@ describe("LeaderboardPanel", () => {
     expect(
       screen.queryByRole("region", { name: "Day-by-day score history" }),
     ).not.toBeInTheDocument();
-    const leaderboardList = document.querySelector(".leaderboard-list");
     const progressChart = screen.getByRole("region", {
       name: "Score progress",
     });
 
-    expect(leaderboardList).not.toBeNull();
     expect(
       leaderboardList!.compareDocumentPosition(progressChart) &
         Node.DOCUMENT_POSITION_FOLLOWING,

--- a/apps/web/src/components/LeaderboardPanel.test.tsx
+++ b/apps/web/src/components/LeaderboardPanel.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { LeaderboardPanel } from "./LeaderboardPanel";
 import type { Basho, LeaderboardEntry, RankedRikishi } from "../types";
@@ -96,7 +96,7 @@ describe("LeaderboardPanel", () => {
       screen.getByText("Demo May Basho - Day 4 of 15"),
     ).toBeInTheDocument();
     expect(screen.getByText("Status: Scoring in progress")).toBeInTheDocument();
-    expect(screen.getByText("East Side")).toBeInTheDocument();
+    expect(screen.getAllByText("East Side").length).toBeGreaterThan(0);
     expect(screen.getByText("Onosato")).toBeInTheDocument();
     expect(screen.getByText("Kirishima")).toBeInTheDocument();
     expect(screen.getAllByText("1 win")).toHaveLength(2);
@@ -137,7 +137,11 @@ describe("LeaderboardPanel", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /East Side/ }));
+    fireEvent.click(
+      within(screen.getByRole("list")).getByRole("button", {
+        name: /East Side/,
+      }),
+    );
 
     expect(onToggleTeam).toHaveBeenCalledWith("team-east");
   });

--- a/apps/web/src/components/LeaderboardPanel.tsx
+++ b/apps/web/src/components/LeaderboardPanel.tsx
@@ -7,6 +7,7 @@ import type {
   RankedRikishi,
 } from "../types";
 import { getBashoLifecycleLabel } from "../lifecycle";
+import { DailyScoreBadge } from "./DailyScoreBadge";
 import { TournamentProgressChart } from "./TournamentProgressChart";
 import "./LeaderboardPanel.css";
 
@@ -152,9 +153,9 @@ function renderLeaderboardList({
               </span>
               <span className="leaderboard-score">
                 {entry.latestDayScore !== undefined && (
-                  <small>
-                    Day {entry.latestDayScore.day}{" "}
-                    {formatSignedScore(entry.latestDayScore.score)}
+                  <small className="leaderboard-latest-day">
+                    <span>Day {entry.latestDayScore.day}</span>
+                    <DailyScoreBadge score={entry.latestDayScore.score} />
                   </small>
                 )}
                 <strong>{entry.score} pts</strong>

--- a/apps/web/src/components/LeaderboardPanel.tsx
+++ b/apps/web/src/components/LeaderboardPanel.tsx
@@ -83,10 +83,6 @@ export function LeaderboardPanel({
         </div>
       ) : isPreScoringLeaderboard(basho, leaderboard) ? (
         <>
-          <TournamentProgressChart
-            currentTeamId={createdTeam?.team.id}
-            leaderboard={leaderboard}
-          />
           <div className="state-panel leaderboard-empty">
             {getEmptyScoringMessage(basho)}
           </div>
@@ -97,13 +93,13 @@ export function LeaderboardPanel({
             rikishiById,
             tiedScoreCounts,
           })}
-        </>
-      ) : (
-        <>
           <TournamentProgressChart
             currentTeamId={createdTeam?.team.id}
             leaderboard={leaderboard}
           />
+        </>
+      ) : (
+        <>
           {renderLeaderboardList({
             expandedTeamId,
             leaderboard,
@@ -111,6 +107,10 @@ export function LeaderboardPanel({
             rikishiById,
             tiedScoreCounts,
           })}
+          <TournamentProgressChart
+            currentTeamId={createdTeam?.team.id}
+            leaderboard={leaderboard}
+          />
         </>
       )}
     </section>

--- a/apps/web/src/components/LeaderboardPanel.tsx
+++ b/apps/web/src/components/LeaderboardPanel.tsx
@@ -7,6 +7,7 @@ import type {
   RankedRikishi,
 } from "../types";
 import { getBashoLifecycleLabel } from "../lifecycle";
+import { TournamentProgressChart } from "./TournamentProgressChart";
 import "./LeaderboardPanel.css";
 
 interface LeaderboardPanelProps {
@@ -82,6 +83,10 @@ export function LeaderboardPanel({
         </div>
       ) : isPreScoringLeaderboard(basho, leaderboard) ? (
         <>
+          <TournamentProgressChart
+            currentTeamId={createdTeam?.team.id}
+            leaderboard={leaderboard}
+          />
           <div className="state-panel leaderboard-empty">
             {getEmptyScoringMessage(basho)}
           </div>
@@ -94,13 +99,19 @@ export function LeaderboardPanel({
           })}
         </>
       ) : (
-        renderLeaderboardList({
-          expandedTeamId,
-          leaderboard,
-          onToggleTeam,
-          rikishiById,
-          tiedScoreCounts,
-        })
+        <>
+          <TournamentProgressChart
+            currentTeamId={createdTeam?.team.id}
+            leaderboard={leaderboard}
+          />
+          {renderLeaderboardList({
+            expandedTeamId,
+            leaderboard,
+            onToggleTeam,
+            rikishiById,
+            tiedScoreCounts,
+          })}
+        </>
       )}
     </section>
   );

--- a/apps/web/src/components/TournamentProgressChart.css
+++ b/apps/web/src/components/TournamentProgressChart.css
@@ -1,0 +1,275 @@
+.progress-chart {
+  margin-bottom: 18px;
+  padding: 18px;
+  border: 1px solid var(--clay-light);
+  border-radius: 10px;
+  background: #fff;
+}
+
+.progress-chart-heading {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.progress-chart h3 {
+  margin: 0;
+  color: var(--indigo);
+  font-size: 1.08rem;
+}
+
+.latest-day-badge {
+  flex: none;
+  padding: 5px 9px;
+  border-radius: 999px;
+  background: var(--vermilion);
+  color: #fff;
+  font-size: 0.76rem;
+  font-weight: 900;
+}
+
+.progress-chart-intro,
+.progress-chart-note,
+.progress-chart-empty > p,
+.progress-chart-no-selection {
+  color: var(--muted);
+  font-size: 0.88rem;
+}
+
+.progress-chart-intro {
+  margin: 8px 0 12px;
+}
+
+.progress-chart-filters {
+  display: flex;
+  gap: 7px;
+  overflow-x: auto;
+  padding: 2px 2px 8px;
+  scrollbar-width: thin;
+}
+
+.progress-chart-filters button {
+  display: inline-flex;
+  flex: none;
+  gap: 7px;
+  align-items: center;
+  padding: 6px 9px;
+  border: 1px solid var(--clay-light);
+  border-radius: 999px;
+  background: var(--paper);
+  color: var(--ink);
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.progress-chart-filters button[aria-pressed="false"] {
+  color: var(--muted);
+  text-decoration: line-through;
+}
+
+.progress-chart-filters button.current-team {
+  border-color: var(--vermilion);
+  box-shadow: 0 0 0 2px rgb(168 64 50 / 14%);
+}
+
+.progress-chart-filters button:focus-visible,
+.score-history-table summary:focus-visible {
+  outline: 3px solid var(--focus);
+  outline-offset: 2px;
+}
+
+.progress-chart-filters small {
+  color: var(--vermilion-dark);
+}
+
+.series-swatch {
+  width: 18px;
+  height: 4px;
+  border-radius: 999px;
+}
+
+.progress-chart-filters .show-all-teams {
+  border-color: transparent;
+  color: var(--focus);
+  text-decoration: none;
+}
+
+.progress-chart-scroll {
+  overflow-x: auto;
+  margin-top: 4px;
+  border-radius: 8px;
+  scrollbar-width: thin;
+}
+
+.progress-chart-scroll:focus-visible {
+  outline: 3px solid var(--focus);
+  outline-offset: -3px;
+}
+
+.progress-chart-plot {
+  display: block;
+  width: 100%;
+  min-width: 660px;
+  height: auto;
+}
+
+.chart-grid-line {
+  stroke: #e8e0d4;
+  stroke-width: 1;
+}
+
+.chart-day-tick {
+  stroke: #ede6dc;
+  stroke-width: 1;
+}
+
+.chart-latest-line {
+  stroke: var(--vermilion);
+  stroke-dasharray: 4 5;
+  stroke-width: 2;
+}
+
+.chart-axis-label {
+  fill: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.chart-axis-title {
+  fill: var(--indigo);
+  font-size: 11px;
+  font-weight: 900;
+}
+
+.chart-series {
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 3;
+}
+
+.chart-series.current-team {
+  filter: drop-shadow(0 0 3px rgb(168 64 50 / 32%));
+  stroke-width: 5;
+}
+
+.chart-point-target {
+  cursor: pointer;
+  outline: none;
+}
+
+.chart-point-hit {
+  fill: transparent;
+}
+
+.chart-point {
+  stroke: #fff;
+  stroke-width: 2;
+}
+
+.chart-point-target:focus .chart-point,
+.chart-point.active {
+  stroke: var(--ink);
+  stroke-width: 3;
+}
+
+.progress-chart-detail {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px 12px;
+  margin: 6px 0 0;
+  padding: 10px 12px;
+  border-left: 4px solid var(--vermilion);
+  border-radius: 7px;
+  background: var(--paper-warm);
+  font-size: 0.84rem;
+}
+
+.progress-chart-detail span {
+  color: var(--muted);
+}
+
+.progress-chart-detail span:first-of-type {
+  color: var(--vermilion-dark);
+  font-weight: 900;
+}
+
+.progress-chart-note,
+.progress-chart-no-selection,
+.progress-chart-empty > p {
+  margin: 10px 0 0;
+}
+
+.progress-chart-no-selection {
+  padding: 38px 14px;
+  border: 1px dashed var(--clay-light);
+  border-radius: 8px;
+  text-align: center;
+}
+
+.score-history-table {
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px solid var(--clay-light);
+}
+
+.score-history-table summary {
+  width: fit-content;
+  color: var(--focus);
+  cursor: pointer;
+  font-size: 0.84rem;
+  font-weight: 900;
+}
+
+.score-history-table > div {
+  overflow-x: auto;
+  margin-top: 10px;
+}
+
+.score-history-table table {
+  width: 100%;
+  min-width: 520px;
+  border-collapse: collapse;
+  font-size: 0.78rem;
+}
+
+.score-history-table caption {
+  padding-bottom: 7px;
+  color: var(--muted);
+  text-align: left;
+}
+
+.score-history-table th,
+.score-history-table td {
+  padding: 7px 9px;
+  border: 1px solid var(--clay-light);
+  text-align: center;
+  white-space: nowrap;
+}
+
+.score-history-table th:first-child {
+  position: sticky;
+  left: 0;
+  background: var(--paper);
+  text-align: left;
+}
+
+@media (max-width: 640px) {
+  .progress-chart {
+    margin-right: -4px;
+    margin-left: -4px;
+    padding: 14px;
+  }
+
+  .progress-chart-heading {
+    align-items: center;
+  }
+
+  .progress-chart-plot {
+    min-width: 620px;
+  }
+
+  .progress-chart-scroll {
+    margin-right: -14px;
+  }
+}

--- a/apps/web/src/components/TournamentProgressChart.css
+++ b/apps/web/src/components/TournamentProgressChart.css
@@ -167,14 +167,25 @@
   fill: transparent;
 }
 
+.chart-point-focus-ring {
+  fill: none;
+  pointer-events: none;
+  stroke: transparent;
+  stroke-width: 0;
+}
+
 .chart-point {
   stroke: #fff;
   stroke-width: 2;
 }
 
-.chart-point-target:focus .chart-point,
 .chart-point.active {
   stroke: var(--ink);
+  stroke-width: 3;
+}
+
+.chart-point-target:focus-visible .chart-point-focus-ring {
+  stroke: var(--focus);
   stroke-width: 3;
 }
 
@@ -190,7 +201,7 @@
   font-size: 0.84rem;
 }
 
-.progress-chart-detail span {
+.progress-chart-detail > span {
   color: var(--muted);
 }
 
@@ -203,20 +214,6 @@
   display: inline-flex;
   gap: 5px;
   align-items: center;
-}
-
-.progress-chart-detail .progress-chart-daily-score-badge {
-  display: inline-flex;
-  min-width: 26px;
-  align-items: center;
-  justify-content: center;
-  padding: 2px 7px;
-  border-radius: 999px;
-  background: var(--vermilion);
-  color: #fff;
-  font-size: 0.75rem;
-  font-weight: 900;
-  line-height: 1.25;
 }
 
 .progress-chart-note,

--- a/apps/web/src/components/TournamentProgressChart.css
+++ b/apps/web/src/components/TournamentProgressChart.css
@@ -1,5 +1,5 @@
 .progress-chart {
-  margin-bottom: 18px;
+  margin-top: 18px;
   padding: 18px;
   border: 1px solid var(--clay-light);
   border-radius: 10px;

--- a/apps/web/src/components/TournamentProgressChart.css
+++ b/apps/web/src/components/TournamentProgressChart.css
@@ -189,9 +189,29 @@
   color: var(--muted);
 }
 
-.progress-chart-detail span:first-of-type {
+.progress-chart-detail .progress-chart-day {
   color: var(--vermilion-dark);
   font-weight: 900;
+}
+
+.progress-chart-daily-score {
+  display: inline-flex;
+  gap: 5px;
+  align-items: center;
+}
+
+.progress-chart-detail .progress-chart-daily-score-badge {
+  display: inline-flex;
+  min-width: 26px;
+  align-items: center;
+  justify-content: center;
+  padding: 2px 7px;
+  border-radius: 999px;
+  background: var(--vermilion);
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 900;
+  line-height: 1.25;
 }
 
 .progress-chart-note,

--- a/apps/web/src/components/TournamentProgressChart.css
+++ b/apps/web/src/components/TournamentProgressChart.css
@@ -84,9 +84,14 @@
 }
 
 .series-swatch {
-  width: 18px;
-  height: 4px;
-  border-radius: 999px;
+  flex: none;
+  width: 28px;
+  height: 6px;
+  overflow: visible;
+}
+
+.series-swatch line {
+  stroke-linecap: round;
 }
 
 .progress-chart-filters .show-all-teams {

--- a/apps/web/src/components/TournamentProgressChart.test.tsx
+++ b/apps/web/src/components/TournamentProgressChart.test.tsx
@@ -49,7 +49,12 @@ describe("TournamentProgressChart", () => {
     expect(detail).not.toBeNull();
     expect(within(detail!).getByText("Your team")).toBeInTheDocument();
     expect(within(detail!).getByText("Day 1")).toBeInTheDocument();
-    expect(within(detail!).getByText("+1 that day")).toBeInTheDocument();
+    expect(detail).toHaveTextContent("+1 that day");
+    expect(
+      within(detail!).getByText("+1", {
+        selector: ".progress-chart-daily-score-badge",
+      }),
+    ).toBeInTheDocument();
     expect(within(detail!).getByText("1 cumulative pts")).toBeInTheDocument();
   });
 

--- a/apps/web/src/components/TournamentProgressChart.test.tsx
+++ b/apps/web/src/components/TournamentProgressChart.test.tsx
@@ -43,6 +43,9 @@ describe("TournamentProgressChart", () => {
       name: "#2 West Side, day 1: +1 that day, 1 cumulative points",
     });
     fireEvent.focus(westDayOne);
+    expect(
+      westDayOne.querySelector(".chart-point-focus-ring"),
+    ).toBeInTheDocument();
 
     const detail = screen.getByText("#2 West Side", {
       selector: ".progress-chart-detail strong",
@@ -53,7 +56,7 @@ describe("TournamentProgressChart", () => {
     expect(detail).toHaveTextContent("+1 that day");
     expect(
       within(detail!).getByText("+1", {
-        selector: ".progress-chart-daily-score-badge",
+        selector: ".daily-score-badge",
       }),
     ).toBeInTheDocument();
     expect(within(detail!).getByText("1 cumulative pts")).toBeInTheDocument();
@@ -66,7 +69,7 @@ describe("TournamentProgressChart", () => {
     const westFilter = screen.getByRole("button", { name: "#2 West Side" });
     expect(westFilter.querySelector(".series-swatch line")).toHaveAttribute(
       "stroke-dasharray",
-      "10 5",
+      "3 4",
     );
     fireEvent.click(eastFilter);
 
@@ -153,6 +156,37 @@ describe("TournamentProgressChart", () => {
     expect(westDayOne).toHaveFocus();
     expect(eastDayTwo).toHaveAttribute("tabindex", "-1");
     expect(westDayOne).toHaveAttribute("tabindex", "0");
+  });
+
+  it("keeps series styles distinct after the color palette repeats", () => {
+    const sevenTeams = Array.from({ length: 7 }, (_, index) =>
+      createEntry({
+        teamId: `team-${index + 1}`,
+        displayName: `Stable ${index + 1}`,
+        dailyScores: [1, 1],
+        rank: index + 1,
+      }),
+    );
+    const { container } = render(
+      <TournamentProgressChart leaderboard={sevenTeams} />,
+    );
+    const swatches = Array.from(
+      container.querySelectorAll<SVGLineElement>(".series-swatch line"),
+    );
+    const signatures = swatches.map(
+      (swatch) =>
+        `${swatch.getAttribute("stroke")}|${swatch.getAttribute("stroke-dasharray") ?? "solid"}`,
+    );
+
+    expect(swatches).toHaveLength(7);
+    expect(new Set(signatures).size).toBe(7);
+    expect(swatches[0]).toHaveAttribute(
+      "stroke",
+      swatches[6]?.getAttribute("stroke"),
+    );
+    expect(swatches[0]?.getAttribute("stroke-dasharray")).not.toBe(
+      swatches[6]?.getAttribute("stroke-dasharray"),
+    );
   });
 
   it("shows empty and single-day guidance", () => {

--- a/apps/web/src/components/TournamentProgressChart.test.tsx
+++ b/apps/web/src/components/TournamentProgressChart.test.tsx
@@ -13,6 +13,7 @@ const leaderboard: LeaderboardEntry[] = [
     teamId: "team-west",
     displayName: "West Side",
     dailyScores: [1, 0],
+    rank: 2,
   }),
 ];
 
@@ -35,15 +36,15 @@ describe("TournamentProgressChart", () => {
       }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "West Side, your team" }),
+      screen.getByRole("button", { name: "#2 West Side, your team" }),
     ).toHaveAttribute("aria-pressed", "true");
 
     const westDayOne = screen.getByRole("button", {
-      name: "West Side, day 1: +1 that day, 1 cumulative points",
+      name: "#2 West Side, day 1: +1 that day, 1 cumulative points",
     });
     fireEvent.focus(westDayOne);
 
-    const detail = screen.getByText("West Side", {
+    const detail = screen.getByText("#2 West Side", {
       selector: ".progress-chart-detail strong",
     }).parentElement;
     expect(detail).not.toBeNull();
@@ -61,14 +62,18 @@ describe("TournamentProgressChart", () => {
   it("filters overlapping teams and restores every series", () => {
     render(<TournamentProgressChart leaderboard={leaderboard} />);
 
-    const eastFilter = screen.getByRole("button", { name: "East Side" });
-    const westFilter = screen.getByRole("button", { name: "West Side" });
+    const eastFilter = screen.getByRole("button", { name: "#1 East Side" });
+    const westFilter = screen.getByRole("button", { name: "#2 West Side" });
+    expect(westFilter.querySelector(".series-swatch line")).toHaveAttribute(
+      "stroke-dasharray",
+      "10 5",
+    );
     fireEvent.click(eastFilter);
 
     expect(eastFilter).toHaveAttribute("aria-pressed", "false");
     expect(
       screen.queryByRole("button", {
-        name: "East Side, day 1: +1 that day, 1 cumulative points",
+        name: "#1 East Side, day 1: +1 that day, 1 cumulative points",
       }),
     ).not.toBeInTheDocument();
 
@@ -94,9 +99,60 @@ describe("TournamentProgressChart", () => {
       within(table).getByRole("columnheader", { name: "Day 1" }),
     ).toBeInTheDocument();
     expect(
-      within(table).getByRole("rowheader", { name: "East Side" }),
+      within(table).getByRole("rowheader", { name: "#1 East Side" }),
     ).toBeInTheDocument();
     expect(within(table).getByText("+1 / 2")).toBeInTheDocument();
+  });
+
+  it("uses ranks to disambiguate duplicate team names", () => {
+    render(
+      <TournamentProgressChart
+        leaderboard={leaderboard.map((entry) => ({
+          ...entry,
+          displayName: "Shared Stable",
+        }))}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "#1 Shared Stable" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "#2 Shared Stable" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "#2 Shared Stable, day 1: +1 that day, 1 cumulative points",
+      }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("View score history table"));
+    expect(
+      screen.getByRole("rowheader", { name: "#1 Shared Stable" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("rowheader", { name: "#2 Shared Stable" }),
+    ).toBeInTheDocument();
+  });
+
+  it("uses one tab stop and arrow keys to navigate chart points", () => {
+    render(<TournamentProgressChart leaderboard={leaderboard} />);
+
+    const eastDayTwo = screen.getByRole("button", {
+      name: "#1 East Side, day 2: +1 that day, 2 cumulative points",
+    });
+    const westDayOne = screen.getByRole("button", {
+      name: "#2 West Side, day 1: +1 that day, 1 cumulative points",
+    });
+
+    expect(eastDayTwo).toHaveAttribute("tabindex", "0");
+    expect(westDayOne).toHaveAttribute("tabindex", "-1");
+
+    fireEvent.keyDown(eastDayTwo, { key: "ArrowRight" });
+
+    expect(westDayOne).toHaveFocus();
+    expect(eastDayTwo).toHaveAttribute("tabindex", "-1");
+    expect(westDayOne).toHaveAttribute("tabindex", "0");
   });
 
   it("shows empty and single-day guidance", () => {
@@ -136,10 +192,12 @@ describe("TournamentProgressChart", () => {
 function createEntry({
   dailyScores,
   displayName,
+  rank = 1,
   teamId,
 }: {
   dailyScores: number[];
   displayName: string;
+  rank?: number;
   teamId: string;
 }): LeaderboardEntry {
   let cumulativeScore = 0;
@@ -154,7 +212,7 @@ function createEntry({
   });
 
   return {
-    rank: 1,
+    rank,
     teamId,
     displayName,
     score: cumulativeScore,

--- a/apps/web/src/components/TournamentProgressChart.test.tsx
+++ b/apps/web/src/components/TournamentProgressChart.test.tsx
@@ -1,0 +1,163 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { LeaderboardEntry } from "../types";
+import { TournamentProgressChart } from "./TournamentProgressChart";
+
+const leaderboard: LeaderboardEntry[] = [
+  createEntry({
+    teamId: "team-east",
+    displayName: "East Side",
+    dailyScores: [1, 1],
+  }),
+  createEntry({
+    teamId: "team-west",
+    displayName: "West Side",
+    dailyScores: [1, 0],
+  }),
+];
+
+describe("TournamentProgressChart", () => {
+  it("shows cumulative progress, the latest day, and inspectable points", () => {
+    render(
+      <TournamentProgressChart
+        currentTeamId="team-west"
+        leaderboard={leaderboard}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Score progress" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Latest: Day 2")).toBeInTheDocument();
+    expect(
+      screen.getByRole("group", {
+        name: /^Cumulative fantasy score progress/,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "West Side, your team" }),
+    ).toHaveAttribute("aria-pressed", "true");
+
+    const westDayOne = screen.getByRole("button", {
+      name: "West Side, day 1: +1 that day, 1 cumulative points",
+    });
+    fireEvent.focus(westDayOne);
+
+    const detail = screen.getByText("West Side", {
+      selector: ".progress-chart-detail strong",
+    }).parentElement;
+    expect(detail).not.toBeNull();
+    expect(within(detail!).getByText("Your team")).toBeInTheDocument();
+    expect(within(detail!).getByText("Day 1")).toBeInTheDocument();
+    expect(within(detail!).getByText("+1 that day")).toBeInTheDocument();
+    expect(within(detail!).getByText("1 cumulative pts")).toBeInTheDocument();
+  });
+
+  it("filters overlapping teams and restores every series", () => {
+    render(<TournamentProgressChart leaderboard={leaderboard} />);
+
+    const eastFilter = screen.getByRole("button", { name: "East Side" });
+    const westFilter = screen.getByRole("button", { name: "West Side" });
+    fireEvent.click(eastFilter);
+
+    expect(eastFilter).toHaveAttribute("aria-pressed", "false");
+    expect(
+      screen.queryByRole("button", {
+        name: "East Side, day 1: +1 that day, 1 cumulative points",
+      }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(westFilter);
+    expect(
+      screen.getByText("Choose at least one team above to show its progress."),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show all" }));
+    expect(eastFilter).toHaveAttribute("aria-pressed", "true");
+    expect(westFilter).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("provides a directly readable score-history table", () => {
+    render(<TournamentProgressChart leaderboard={leaderboard} />);
+
+    fireEvent.click(screen.getByText("View score history table"));
+
+    const table = screen.getByRole("table", {
+      name: "Daily and cumulative fantasy points",
+    });
+    expect(
+      within(table).getByRole("columnheader", { name: "Day 1" }),
+    ).toBeInTheDocument();
+    expect(
+      within(table).getByRole("rowheader", { name: "East Side" }),
+    ).toBeInTheDocument();
+    expect(within(table).getByText("+1 / 2")).toBeInTheDocument();
+  });
+
+  it("shows empty and single-day guidance", () => {
+    const { rerender } = render(
+      <TournamentProgressChart
+        leaderboard={[{ ...leaderboard[0]!, scoreHistory: [] }]}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        "No scored days yet. Progress will appear after the first results.",
+      ),
+    ).toBeInTheDocument();
+
+    rerender(
+      <TournamentProgressChart
+        leaderboard={[
+          createEntry({
+            teamId: "team-east",
+            displayName: "East Side",
+            dailyScores: [1],
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Latest: Day 1")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "One day scored so far. Lines will form as more results arrive.",
+      ),
+    ).toBeInTheDocument();
+  });
+});
+
+function createEntry({
+  dailyScores,
+  displayName,
+  teamId,
+}: {
+  dailyScores: number[];
+  displayName: string;
+  teamId: string;
+}): LeaderboardEntry {
+  let cumulativeScore = 0;
+  const scoreHistory = dailyScores.map((dailyScore, index) => {
+    cumulativeScore += dailyScore;
+    return {
+      day: index + 1,
+      dailyScore,
+      cumulativeScore,
+      rikishiScores: [],
+    };
+  });
+
+  return {
+    rank: 1,
+    teamId,
+    displayName,
+    score: cumulativeScore,
+    latestDayScore: {
+      day: dailyScores.length,
+      score: dailyScores.at(-1) ?? 0,
+    },
+    scoreHistory,
+    rikishiScores: [],
+  };
+}

--- a/apps/web/src/components/TournamentProgressChart.tsx
+++ b/apps/web/src/components/TournamentProgressChart.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import type { LeaderboardEntry } from "../types";
 import "./TournamentProgressChart.css";
 
@@ -32,12 +32,19 @@ export function TournamentProgressChart({
   const [selectedPoint, setSelectedPoint] = useState<SelectedPoint | null>(
     null,
   );
+  const pointRefs = useRef<Map<string, SVGGElement>>(new Map());
   const scoredEntries = useMemo(
     () => leaderboard.filter((entry) => entry.scoreHistory.length > 0),
     [leaderboard],
   );
   const visibleEntries = scoredEntries.filter(
     (entry) => !hiddenTeamIds.has(entry.teamId),
+  );
+  const visiblePoints = visibleEntries.flatMap((entry) =>
+    entry.scoreHistory.map((history) => ({
+      day: history.day,
+      teamId: entry.teamId,
+    })),
   );
   const scoredDays = useMemo(
     () =>
@@ -98,6 +105,31 @@ export function TournamentProgressChart({
     });
   }
 
+  function movePointSelection(
+    currentPoint: SelectedPoint,
+    key: "ArrowDown" | "ArrowLeft" | "ArrowRight" | "ArrowUp" | "End" | "Home",
+  ) {
+    const currentIndex = visiblePoints.findIndex(
+      (point) =>
+        point.teamId === currentPoint.teamId && point.day === currentPoint.day,
+    );
+    if (currentIndex === -1 || visiblePoints.length === 0) {
+      return;
+    }
+
+    const nextIndex =
+      key === "Home"
+        ? 0
+        : key === "End"
+          ? visiblePoints.length - 1
+          : key === "ArrowLeft" || key === "ArrowUp"
+            ? (currentIndex - 1 + visiblePoints.length) % visiblePoints.length
+            : (currentIndex + 1) % visiblePoints.length;
+    const nextPoint = visiblePoints[nextIndex]!;
+    setSelectedPoint(nextPoint);
+    pointRefs.current.get(getPointKey(nextPoint))?.focus();
+  }
+
   return (
     <section className="progress-chart" aria-labelledby="progress-title">
       <div className="progress-chart-heading">
@@ -116,6 +148,7 @@ export function TournamentProgressChart({
         {scoredEntries.map((entry, index) => {
           const isVisible = !hiddenTeamIds.has(entry.teamId);
           const style = seriesStyles[index % seriesStyles.length]!;
+          const teamLabel = formatTeamLabel(entry);
 
           return (
             <button
@@ -123,8 +156,8 @@ export function TournamentProgressChart({
               aria-pressed={isVisible}
               aria-label={
                 entry.teamId === currentTeamId
-                  ? `${entry.displayName}, your team`
-                  : entry.displayName
+                  ? `${teamLabel}, your team`
+                  : teamLabel
               }
               className={
                 entry.teamId === currentTeamId ? "current-team" : undefined
@@ -132,14 +165,23 @@ export function TournamentProgressChart({
               key={entry.teamId}
               onClick={() => toggleTeam(entry.teamId)}
             >
-              <span
+              <svg
                 className="series-swatch"
-                style={{
-                  backgroundColor: style.color,
-                  opacity: isVisible ? 1 : 0.3,
-                }}
-              />
-              {entry.displayName}
+                viewBox="0 0 28 6"
+                aria-hidden="true"
+              >
+                <line
+                  x1="1"
+                  x2="27"
+                  y1="3"
+                  y2="3"
+                  stroke={style.color}
+                  strokeDasharray={style.dash}
+                  strokeOpacity={isVisible ? 1 : 0.3}
+                  strokeWidth="3"
+                />
+              </svg>
+              {teamLabel}
               {entry.teamId === currentTeamId && <small>Your team</small>}
             </button>
           );
@@ -178,8 +220,8 @@ export function TournamentProgressChart({
               <desc id="progress-svg-description">
                 {visibleEntries.length} team
                 {visibleEntries.length === 1 ? "" : "s"} shown through day{" "}
-                {latestDay}. Use the focusable points for exact daily and
-                cumulative scores.
+                {latestDay}. Tab into the selected point, then use the arrow
+                keys for exact daily and cumulative scores.
               </desc>
 
               {yTicks.map((tick) => {
@@ -283,15 +325,27 @@ export function TournamentProgressChart({
                       const isActive =
                         activePoint?.teamId === entry.teamId &&
                         activePoint.day === history.day;
-                      const label = `${entry.displayName}, day ${history.day}: ${formatSignedScore(history.dailyScore)} that day, ${history.cumulativeScore} cumulative points`;
+                      const point = {
+                        teamId: entry.teamId,
+                        day: history.day,
+                      };
+                      const label = `${formatTeamLabel(entry)}, day ${history.day}: ${formatSignedScore(history.dailyScore)} that day, ${history.cumulativeScore} cumulative points`;
 
                       return (
                         <g
                           className="chart-point-target"
                           key={history.day}
                           role="button"
-                          tabIndex={0}
+                          tabIndex={isActive ? 0 : -1}
                           aria-label={label}
+                          ref={(element) => {
+                            const key = getPointKey(point);
+                            if (element === null) {
+                              pointRefs.current.delete(key);
+                            } else {
+                              pointRefs.current.set(key, element);
+                            }
+                          }}
                           onClick={() =>
                             setSelectedPoint({
                               teamId: entry.teamId,
@@ -307,10 +361,17 @@ export function TournamentProgressChart({
                           onKeyDown={(event) => {
                             if (event.key === "Enter" || event.key === " ") {
                               event.preventDefault();
-                              setSelectedPoint({
-                                teamId: entry.teamId,
-                                day: history.day,
-                              });
+                              setSelectedPoint(point);
+                            } else if (
+                              event.key === "ArrowDown" ||
+                              event.key === "ArrowLeft" ||
+                              event.key === "ArrowRight" ||
+                              event.key === "ArrowUp" ||
+                              event.key === "End" ||
+                              event.key === "Home"
+                            ) {
+                              event.preventDefault();
+                              movePointSelection(point, event.key);
                             }
                           }}
                           onMouseEnter={() =>
@@ -346,7 +407,7 @@ export function TournamentProgressChart({
 
           {activeEntry !== undefined && activeHistory !== undefined && (
             <p className="progress-chart-detail" aria-live="polite">
-              <strong>{activeEntry.displayName}</strong>
+              <strong>{formatTeamLabel(activeEntry)}</strong>
               {activeEntry.teamId === currentTeamId && <span>Your team</span>}
               <span className="progress-chart-day">
                 Day {activeHistory.day}
@@ -400,7 +461,7 @@ function ScoreHistoryTable({
           <tbody>
             {entries.map((entry) => (
               <tr key={entry.teamId}>
-                <th scope="row">{entry.displayName}</th>
+                <th scope="row">{formatTeamLabel(entry)}</th>
                 {scoredDays.map((day) => {
                   const history = entry.scoreHistory.find(
                     (candidate) => candidate.day === day,
@@ -420,6 +481,14 @@ function ScoreHistoryTable({
       </div>
     </details>
   );
+}
+
+function formatTeamLabel(entry: LeaderboardEntry): string {
+  return `#${entry.rank} ${entry.displayName}`;
+}
+
+function getPointKey(point: SelectedPoint): string {
+  return `${point.teamId}:${point.day}`;
 }
 
 function resolveSelectedPoint(

--- a/apps/web/src/components/TournamentProgressChart.tsx
+++ b/apps/web/src/components/TournamentProgressChart.tsx
@@ -348,9 +348,14 @@ export function TournamentProgressChart({
             <p className="progress-chart-detail" aria-live="polite">
               <strong>{activeEntry.displayName}</strong>
               {activeEntry.teamId === currentTeamId && <span>Your team</span>}
-              <span>Day {activeHistory.day}</span>
-              <span>
-                {formatSignedScore(activeHistory.dailyScore)} that day
+              <span className="progress-chart-day">
+                Day {activeHistory.day}
+              </span>
+              <span className="progress-chart-daily-score">
+                <span className="progress-chart-daily-score-badge">
+                  {formatSignedScore(activeHistory.dailyScore)}
+                </span>{" "}
+                that day
               </span>
               <span>{activeHistory.cumulativeScore} cumulative pts</span>
             </p>

--- a/apps/web/src/components/TournamentProgressChart.tsx
+++ b/apps/web/src/components/TournamentProgressChart.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useRef, useState } from "react";
 import type { LeaderboardEntry } from "../types";
+import { DailyScoreBadge } from "./DailyScoreBadge";
 import "./TournamentProgressChart.css";
 
 interface TournamentProgressChartProps {
@@ -15,13 +16,13 @@ type SelectedPoint = {
 const chartWidth = 800;
 const chartHeight = 340;
 const chartPadding = { top: 32, right: 28, bottom: 48, left: 52 };
-const seriesStyles = [
-  { color: "#a84032", dash: undefined },
-  { color: "#183247", dash: "10 5" },
-  { color: "#2f6f5e", dash: "3 4" },
-  { color: "#8b5b16", dash: "14 5 3 5" },
-  { color: "#654c8a", dash: "7 4" },
-  { color: "#26758a", dash: "2 4" },
+const seriesColors = [
+  "#a84032",
+  "#183247",
+  "#2f6f5e",
+  "#8b5b16",
+  "#654c8a",
+  "#26758a",
 ] as const;
 
 export function TournamentProgressChart({
@@ -147,7 +148,7 @@ export function TournamentProgressChart({
       <div className="progress-chart-filters" aria-label="Teams shown on chart">
         {scoredEntries.map((entry, index) => {
           const isVisible = !hiddenTeamIds.has(entry.teamId);
-          const style = seriesStyles[index % seriesStyles.length]!;
+          const style = getSeriesStyle(index);
           const teamLabel = formatTeamLabel(entry);
 
           return (
@@ -296,8 +297,7 @@ export function TournamentProgressChart({
                 const originalIndex = scoredEntries.findIndex(
                   (candidate) => candidate.teamId === entry.teamId,
                 );
-                const style =
-                  seriesStyles[originalIndex % seriesStyles.length]!;
+                const style = getSeriesStyle(originalIndex);
                 const isCurrentTeam = entry.teamId === currentTeamId;
                 const points = entry.scoreHistory
                   .map(
@@ -388,6 +388,12 @@ export function TournamentProgressChart({
                             r={16}
                           />
                           <circle
+                            className="chart-point-focus-ring"
+                            cx={dayToX(history.day, latestDay)}
+                            cy={scoreToY(history.cumulativeScore, maximumScore)}
+                            r={isCurrentTeam ? 12 : 11}
+                          />
+                          <circle
                             className={
                               isActive ? "chart-point active" : "chart-point"
                             }
@@ -413,10 +419,7 @@ export function TournamentProgressChart({
                 Day {activeHistory.day}
               </span>
               <span className="progress-chart-daily-score">
-                <span className="progress-chart-daily-score-badge">
-                  {formatSignedScore(activeHistory.dailyScore)}
-                </span>{" "}
-                that day
+                <DailyScoreBadge score={activeHistory.dailyScore} /> that day
               </span>
               <span>{activeHistory.cumulativeScore} cumulative pts</span>
             </p>
@@ -485,6 +488,16 @@ function ScoreHistoryTable({
 
 function formatTeamLabel(entry: LeaderboardEntry): string {
   return `#${entry.rank} ${entry.displayName}`;
+}
+
+function getSeriesStyle(index: number): {
+  color: (typeof seriesColors)[number];
+  dash: string | undefined;
+} {
+  return {
+    color: seriesColors[index % seriesColors.length]!,
+    dash: index === 0 ? undefined : `${2 + (index % 5)} ${3 + index}`,
+  };
 }
 
 function getPointKey(point: SelectedPoint): string {

--- a/apps/web/src/components/TournamentProgressChart.tsx
+++ b/apps/web/src/components/TournamentProgressChart.tsx
@@ -1,0 +1,481 @@
+import { useMemo, useState } from "react";
+import type { LeaderboardEntry } from "../types";
+import "./TournamentProgressChart.css";
+
+interface TournamentProgressChartProps {
+  currentTeamId?: string;
+  leaderboard: LeaderboardEntry[];
+}
+
+type SelectedPoint = {
+  day: number;
+  teamId: string;
+};
+
+const chartWidth = 800;
+const chartHeight = 340;
+const chartPadding = { top: 32, right: 28, bottom: 48, left: 52 };
+const seriesStyles = [
+  { color: "#a84032", dash: undefined },
+  { color: "#183247", dash: "10 5" },
+  { color: "#2f6f5e", dash: "3 4" },
+  { color: "#8b5b16", dash: "14 5 3 5" },
+  { color: "#654c8a", dash: "7 4" },
+  { color: "#26758a", dash: "2 4" },
+] as const;
+
+export function TournamentProgressChart({
+  currentTeamId,
+  leaderboard,
+}: TournamentProgressChartProps) {
+  const [hiddenTeamIds, setHiddenTeamIds] = useState<Set<string>>(new Set());
+  const [selectedPoint, setSelectedPoint] = useState<SelectedPoint | null>(
+    null,
+  );
+  const scoredEntries = useMemo(
+    () => leaderboard.filter((entry) => entry.scoreHistory.length > 0),
+    [leaderboard],
+  );
+  const visibleEntries = scoredEntries.filter(
+    (entry) => !hiddenTeamIds.has(entry.teamId),
+  );
+  const scoredDays = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          scoredEntries.flatMap((entry) =>
+            entry.scoreHistory.map((history) => history.day),
+          ),
+        ),
+      ).sort((left, right) => left - right),
+    [scoredEntries],
+  );
+
+  if (scoredEntries.length === 0) {
+    return (
+      <section
+        className="progress-chart progress-chart-empty"
+        aria-labelledby="progress-title"
+      >
+        <div>
+          <p className="eyebrow">Tournament story</p>
+          <h3 id="progress-title">Score progress</h3>
+        </div>
+        <p>No scored days yet. Progress will appear after the first results.</p>
+      </section>
+    );
+  }
+
+  const latestDay = scoredDays.at(-1) ?? 1;
+  const maximumScore = Math.max(
+    1,
+    ...scoredEntries.flatMap((entry) =>
+      entry.scoreHistory.map((history) => history.cumulativeScore),
+    ),
+  );
+  const yTicks = createScoreTicks(maximumScore);
+  const activePoint =
+    resolveSelectedPoint(selectedPoint, visibleEntries) ??
+    getDefaultPoint(visibleEntries, latestDay);
+  const activeEntry = visibleEntries.find(
+    (entry) => entry.teamId === activePoint?.teamId,
+  );
+  const activeHistory = activeEntry?.scoreHistory.find(
+    (history) => history.day === activePoint?.day,
+  );
+
+  function toggleTeam(teamId: string) {
+    setHiddenTeamIds((current) => {
+      const next = new Set(current);
+
+      if (next.has(teamId)) {
+        next.delete(teamId);
+      } else {
+        next.add(teamId);
+      }
+
+      return next;
+    });
+  }
+
+  return (
+    <section className="progress-chart" aria-labelledby="progress-title">
+      <div className="progress-chart-heading">
+        <div>
+          <p className="eyebrow">Tournament story</p>
+          <h3 id="progress-title">Score progress</h3>
+        </div>
+        <span className="latest-day-badge">Latest: Day {latestDay}</span>
+      </div>
+      <p className="progress-chart-intro">
+        Cumulative points by scored day. Select teams to separate overlapping
+        lines.
+      </p>
+
+      <div className="progress-chart-filters" aria-label="Teams shown on chart">
+        {scoredEntries.map((entry, index) => {
+          const isVisible = !hiddenTeamIds.has(entry.teamId);
+          const style = seriesStyles[index % seriesStyles.length]!;
+
+          return (
+            <button
+              type="button"
+              aria-pressed={isVisible}
+              aria-label={
+                entry.teamId === currentTeamId
+                  ? `${entry.displayName}, your team`
+                  : entry.displayName
+              }
+              className={
+                entry.teamId === currentTeamId ? "current-team" : undefined
+              }
+              key={entry.teamId}
+              onClick={() => toggleTeam(entry.teamId)}
+            >
+              <span
+                className="series-swatch"
+                style={{
+                  backgroundColor: style.color,
+                  opacity: isVisible ? 1 : 0.3,
+                }}
+              />
+              {entry.displayName}
+              {entry.teamId === currentTeamId && <small>Your team</small>}
+            </button>
+          );
+        })}
+        {hiddenTeamIds.size > 0 && (
+          <button
+            type="button"
+            className="show-all-teams"
+            onClick={() => setHiddenTeamIds(new Set())}
+          >
+            Show all
+          </button>
+        )}
+      </div>
+
+      {visibleEntries.length === 0 ? (
+        <p className="progress-chart-no-selection" role="status">
+          Choose at least one team above to show its progress.
+        </p>
+      ) : (
+        <>
+          <div
+            className="progress-chart-scroll"
+            tabIndex={0}
+            aria-label="Scrollable score progress chart"
+          >
+            <svg
+              className="progress-chart-plot"
+              viewBox={`0 0 ${chartWidth} ${chartHeight}`}
+              role="group"
+              aria-labelledby="progress-svg-title progress-svg-description"
+            >
+              <title id="progress-svg-title">
+                Cumulative fantasy score progress
+              </title>
+              <desc id="progress-svg-description">
+                {visibleEntries.length} team
+                {visibleEntries.length === 1 ? "" : "s"} shown through day{" "}
+                {latestDay}. Use the focusable points for exact daily and
+                cumulative scores.
+              </desc>
+
+              {yTicks.map((tick) => {
+                const y = scoreToY(tick, maximumScore);
+                return (
+                  <g key={tick} aria-hidden="true">
+                    <line
+                      className="chart-grid-line"
+                      x1={chartPadding.left}
+                      x2={chartWidth - chartPadding.right}
+                      y1={y}
+                      y2={y}
+                    />
+                    <text
+                      className="chart-axis-label"
+                      x={chartPadding.left - 12}
+                      y={y + 4}
+                      textAnchor="end"
+                    >
+                      {tick}
+                    </text>
+                  </g>
+                );
+              })}
+
+              {scoredDays.map((day) => {
+                const x = dayToX(day, latestDay);
+                return (
+                  <g key={day} aria-hidden="true">
+                    <line
+                      className={
+                        day === latestDay
+                          ? "chart-latest-line"
+                          : "chart-day-tick"
+                      }
+                      x1={x}
+                      x2={x}
+                      y1={chartPadding.top}
+                      y2={chartHeight - chartPadding.bottom}
+                    />
+                    <text
+                      className="chart-axis-label"
+                      x={x}
+                      y={chartHeight - 20}
+                      textAnchor="middle"
+                    >
+                      D{day}
+                    </text>
+                  </g>
+                );
+              })}
+
+              <text
+                className="chart-axis-title"
+                x={18}
+                y={chartHeight / 2}
+                textAnchor="middle"
+                transform={`rotate(-90 18 ${chartHeight / 2})`}
+              >
+                Cumulative points
+              </text>
+              <text
+                className="chart-axis-title"
+                x={chartWidth / 2}
+                y={chartHeight - 2}
+                textAnchor="middle"
+              >
+                Basho day
+              </text>
+
+              {visibleEntries.map((entry) => {
+                const originalIndex = scoredEntries.findIndex(
+                  (candidate) => candidate.teamId === entry.teamId,
+                );
+                const style =
+                  seriesStyles[originalIndex % seriesStyles.length]!;
+                const isCurrentTeam = entry.teamId === currentTeamId;
+                const points = entry.scoreHistory
+                  .map(
+                    (history) =>
+                      `${dayToX(history.day, latestDay)},${scoreToY(history.cumulativeScore, maximumScore)}`,
+                  )
+                  .join(" ");
+
+                return (
+                  <g key={entry.teamId}>
+                    {entry.scoreHistory.length > 1 && (
+                      <polyline
+                        className={
+                          isCurrentTeam
+                            ? "chart-series current-team"
+                            : "chart-series"
+                        }
+                        fill="none"
+                        points={points}
+                        stroke={style.color}
+                        strokeDasharray={style.dash}
+                      />
+                    )}
+                    {entry.scoreHistory.map((history) => {
+                      const isActive =
+                        activePoint?.teamId === entry.teamId &&
+                        activePoint.day === history.day;
+                      const label = `${entry.displayName}, day ${history.day}: ${formatSignedScore(history.dailyScore)} that day, ${history.cumulativeScore} cumulative points`;
+
+                      return (
+                        <g
+                          className="chart-point-target"
+                          key={history.day}
+                          role="button"
+                          tabIndex={0}
+                          aria-label={label}
+                          onClick={() =>
+                            setSelectedPoint({
+                              teamId: entry.teamId,
+                              day: history.day,
+                            })
+                          }
+                          onFocus={() =>
+                            setSelectedPoint({
+                              teamId: entry.teamId,
+                              day: history.day,
+                            })
+                          }
+                          onKeyDown={(event) => {
+                            if (event.key === "Enter" || event.key === " ") {
+                              event.preventDefault();
+                              setSelectedPoint({
+                                teamId: entry.teamId,
+                                day: history.day,
+                              });
+                            }
+                          }}
+                          onMouseEnter={() =>
+                            setSelectedPoint({
+                              teamId: entry.teamId,
+                              day: history.day,
+                            })
+                          }
+                        >
+                          <circle
+                            className="chart-point-hit"
+                            cx={dayToX(history.day, latestDay)}
+                            cy={scoreToY(history.cumulativeScore, maximumScore)}
+                            r={16}
+                          />
+                          <circle
+                            className={
+                              isActive ? "chart-point active" : "chart-point"
+                            }
+                            cx={dayToX(history.day, latestDay)}
+                            cy={scoreToY(history.cumulativeScore, maximumScore)}
+                            fill={style.color}
+                            r={isCurrentTeam ? 7 : 6}
+                          />
+                        </g>
+                      );
+                    })}
+                  </g>
+                );
+              })}
+            </svg>
+          </div>
+
+          {activeEntry !== undefined && activeHistory !== undefined && (
+            <p className="progress-chart-detail" aria-live="polite">
+              <strong>{activeEntry.displayName}</strong>
+              {activeEntry.teamId === currentTeamId && <span>Your team</span>}
+              <span>Day {activeHistory.day}</span>
+              <span>
+                {formatSignedScore(activeHistory.dailyScore)} that day
+              </span>
+              <span>{activeHistory.cumulativeScore} cumulative pts</span>
+            </p>
+          )}
+
+          {latestDay === 1 && (
+            <p className="progress-chart-note">
+              One day scored so far. Lines will form as more results arrive.
+            </p>
+          )}
+        </>
+      )}
+
+      <ScoreHistoryTable entries={scoredEntries} scoredDays={scoredDays} />
+    </section>
+  );
+}
+
+function ScoreHistoryTable({
+  entries,
+  scoredDays,
+}: {
+  entries: LeaderboardEntry[];
+  scoredDays: number[];
+}) {
+  return (
+    <details className="score-history-table">
+      <summary>View score history table</summary>
+      <div>
+        <table>
+          <caption>Daily and cumulative fantasy points</caption>
+          <thead>
+            <tr>
+              <th scope="col">Team</th>
+              {scoredDays.map((day) => (
+                <th scope="col" key={day}>
+                  Day {day}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {entries.map((entry) => (
+              <tr key={entry.teamId}>
+                <th scope="row">{entry.displayName}</th>
+                {scoredDays.map((day) => {
+                  const history = entry.scoreHistory.find(
+                    (candidate) => candidate.day === day,
+                  );
+                  return (
+                    <td key={day}>
+                      {history === undefined
+                        ? "—"
+                        : `${formatSignedScore(history.dailyScore)} / ${history.cumulativeScore}`}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </details>
+  );
+}
+
+function resolveSelectedPoint(
+  selectedPoint: SelectedPoint | null,
+  visibleEntries: LeaderboardEntry[],
+): SelectedPoint | null {
+  if (selectedPoint === null) {
+    return null;
+  }
+
+  const entry = visibleEntries.find(
+    (candidate) => candidate.teamId === selectedPoint.teamId,
+  );
+  return entry?.scoreHistory.some(
+    (history) => history.day === selectedPoint.day,
+  )
+    ? selectedPoint
+    : null;
+}
+
+function getDefaultPoint(
+  visibleEntries: LeaderboardEntry[],
+  latestDay: number,
+): SelectedPoint | null {
+  const entry =
+    visibleEntries.find((candidate) =>
+      candidate.scoreHistory.some((history) => history.day === latestDay),
+    ) ?? visibleEntries[0];
+  const history = entry?.scoreHistory.at(-1);
+  return entry === undefined || history === undefined
+    ? null
+    : { teamId: entry.teamId, day: history.day };
+}
+
+function createScoreTicks(maximumScore: number): number[] {
+  const step = Math.max(1, Math.ceil(maximumScore / 5));
+  const ticks: number[] = [];
+
+  for (let score = 0; score <= maximumScore; score += step) {
+    ticks.push(score);
+  }
+
+  if (ticks.at(-1) !== maximumScore) {
+    ticks.push(maximumScore);
+  }
+
+  return ticks;
+}
+
+function dayToX(day: number, latestDay: number): number {
+  const plotWidth = chartWidth - chartPadding.left - chartPadding.right;
+  return latestDay === 1
+    ? chartPadding.left + plotWidth / 2
+    : chartPadding.left + ((day - 1) / (latestDay - 1)) * plotWidth;
+}
+
+function scoreToY(score: number, maximumScore: number): number {
+  const plotHeight = chartHeight - chartPadding.top - chartPadding.bottom;
+  return chartPadding.top + plotHeight - (score / maximumScore) * plotHeight;
+}
+
+function formatSignedScore(score: number): string {
+  return score > 0 ? `+${score}` : `${score}`;
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -44,6 +44,8 @@ Current behaviour:
 - Shows ordered team standings with the latest daily score, compact five-day
   team form, and expandable picked-rikishi tournament totals. Each rikishi row
   shows up to five recent outcomes and expands to the full result history.
+- Charts cumulative team scores across scored days with team filters,
+  inspectable points, and an accessible exact-value table.
 - Shows loading, empty, success, and API error states.
 - Has Vitest coverage through React Testing Library.
 

--- a/e2e/mvp-game-loop.spec.ts
+++ b/e2e/mvp-game-loop.spec.ts
@@ -163,22 +163,22 @@ test("advances the demo basho and refreshes scored leaderboard state", async ({
   ).toBe(true);
 
   const chartPoint = page.getByRole("button", {
-    name: /Dohyo Dreamers, day 2: \+1 that day, 2 cumulative points/,
+    name: /#1 Dohyo Dreamers, day 2: \+1 that day, 2 cumulative points/,
   });
   await chartPoint.focus();
   await expect(page.locator(".progress-chart-detail")).toContainText(
-    "Dohyo DreamersDay 2+1 that day2 cumulative pts",
+    "#1 Dohyo DreamersDay 2+1 that day2 cumulative pts",
   );
   await expect(page.locator(".progress-chart-daily-score-badge")).toHaveText(
     "+1",
   );
 
   const tachiaiFilter = page.getByRole("button", {
-    name: "Tachiai Titans",
+    name: "#3 Tachiai Titans",
     exact: true,
   });
   const yushoFilter = page.getByRole("button", {
-    name: "Yusho Hunters",
+    name: "#4 Yusho Hunters",
     exact: true,
   });
   await tachiaiFilter.click();
@@ -188,11 +188,11 @@ test("advances the demo basho and refreshes scored leaderboard state", async ({
 
   await page
     .getByRole("button", {
-      name: "Salt Circle, day 1: +1 that day, 1 cumulative points",
+      name: "#2 Salt Circle, day 1: +1 that day, 1 cumulative points",
     })
     .click();
   await expect(page.locator(".progress-chart-detail")).toContainText(
-    "Salt CircleDay 1+1 that day1 cumulative pts",
+    "#2 Salt CircleDay 1+1 that day1 cumulative pts",
   );
 
   await page.getByRole("button", { name: "Show all" }).click();

--- a/e2e/mvp-game-loop.spec.ts
+++ b/e2e/mvp-game-loop.spec.ts
@@ -169,6 +169,9 @@ test("advances the demo basho and refreshes scored leaderboard state", async ({
   await expect(page.locator(".progress-chart-detail")).toContainText(
     "Dohyo DreamersDay 2+1 that day2 cumulative pts",
   );
+  await expect(page.locator(".progress-chart-daily-score-badge")).toHaveText(
+    "+1",
+  );
 
   const tachiaiFilter = page.getByRole("button", {
     name: "Tachiai Titans",

--- a/e2e/mvp-game-loop.spec.ts
+++ b/e2e/mvp-game-loop.spec.ts
@@ -146,6 +146,21 @@ test("advances the demo basho and refreshes scored leaderboard state", async ({
     page.getByRole("group", { name: /^Cumulative fantasy score progress/ }),
   ).toBeVisible();
   await expect(page.getByText("Latest: Day 2")).toBeVisible();
+  expect(
+    await page.evaluate(() => {
+      const leaderboardList = document.querySelector(".leaderboard-list");
+      const progressChart = document.querySelector(".progress-chart");
+
+      return (
+        leaderboardList !== null &&
+        progressChart !== null &&
+        Boolean(
+          leaderboardList.compareDocumentPosition(progressChart) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+        )
+      );
+    }),
+  ).toBe(true);
 
   const chartPoint = page.getByRole("button", {
     name: /Dohyo Dreamers, day 2: \+1 that day, 2 cumulative points/,

--- a/e2e/mvp-game-loop.spec.ts
+++ b/e2e/mvp-game-loop.spec.ts
@@ -143,6 +143,49 @@ test("advances the demo basho and refreshes scored leaderboard state", async ({
     page.getByLabel("Recent results for Wakatakakage: day 1 Win, day 2 Loss"),
   ).toBeVisible();
   await expect(
+    page.getByRole("group", { name: /^Cumulative fantasy score progress/ }),
+  ).toBeVisible();
+  await expect(page.getByText("Latest: Day 2")).toBeVisible();
+
+  const chartPoint = page.getByRole("button", {
+    name: /Dohyo Dreamers, day 2: \+1 that day, 2 cumulative points/,
+  });
+  await chartPoint.focus();
+  await expect(page.locator(".progress-chart-detail")).toContainText(
+    "Dohyo DreamersDay 2+1 that day2 cumulative pts",
+  );
+
+  const tachiaiFilter = page.getByRole("button", {
+    name: "Tachiai Titans",
+    exact: true,
+  });
+  const yushoFilter = page.getByRole("button", {
+    name: "Yusho Hunters",
+    exact: true,
+  });
+  await tachiaiFilter.click();
+  await expect(tachiaiFilter).toHaveAttribute("aria-pressed", "false");
+  await yushoFilter.click();
+  await expect(yushoFilter).toHaveAttribute("aria-pressed", "false");
+
+  await page
+    .getByRole("button", {
+      name: "Salt Circle, day 1: +1 that day, 1 cumulative points",
+    })
+    .click();
+  await expect(page.locator(".progress-chart-detail")).toContainText(
+    "Salt CircleDay 1+1 that day1 cumulative pts",
+  );
+
+  await page.getByRole("button", { name: "Show all" }).click();
+  await expect(tachiaiFilter).toHaveAttribute("aria-pressed", "true");
+  await expect(yushoFilter).toHaveAttribute("aria-pressed", "true");
+
+  await page.getByText("View score history table").click();
+  await expect(
+    page.getByRole("table", { name: "Daily and cumulative fantasy points" }),
+  ).toBeVisible();
+  await expect(
     page.getByRole("region", { name: "Day-by-day score history" }),
   ).toHaveCount(0);
 
@@ -205,6 +248,14 @@ test("keeps navigation, ranks, and core views usable on the emulated device", as
   await page.getByRole("button", { name: "Leaderboard" }).click();
   await expect(
     page.getByRole("heading", { name: "Follow the leaderboard" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Score progress" }),
+  ).toBeVisible();
+  await expect(
+    page.getByText(
+      "No scored days yet. Progress will appear after the first results.",
+    ),
   ).toBeVisible();
   expect(
     await page.evaluate(

--- a/e2e/mvp-game-loop.spec.ts
+++ b/e2e/mvp-game-loop.spec.ts
@@ -133,9 +133,11 @@ test("advances the demo basho and refreshes scored leaderboard state", async ({
 
   await expect(page.getByText("Demo May Basho - Day 2 of 15")).toBeVisible();
   await expect(page.getByText("Status: Scoring in progress")).toBeVisible();
-  await expect(
-    page.getByRole("button", { name: /Dohyo Dreamers.*Day 2.*2 pts/ }),
-  ).toBeVisible();
+  const leadingTeamRow = page.getByRole("button", {
+    name: /Dohyo Dreamers.*Day 2.*2 pts/,
+  });
+  await expect(leadingTeamRow).toBeVisible();
+  await expect(leadingTeamRow.locator(".daily-score-badge")).toHaveText("+1");
   await expect(
     page.getByLabel("Recent form: day 1 +1, day 2 +1").first(),
   ).toBeVisible();
@@ -165,13 +167,19 @@ test("advances the demo basho and refreshes scored leaderboard state", async ({
   const chartPoint = page.getByRole("button", {
     name: /#1 Dohyo Dreamers, day 2: \+1 that day, 2 cumulative points/,
   });
-  await chartPoint.focus();
+  await page.locator(".progress-chart-scroll").focus();
+  await page.keyboard.press("Tab");
+  await expect(chartPoint).toBeFocused();
+  await expect(chartPoint.locator(".chart-point-focus-ring")).toHaveCSS(
+    "stroke",
+    "rgb(43, 118, 138)",
+  );
   await expect(page.locator(".progress-chart-detail")).toContainText(
     "#1 Dohyo DreamersDay 2+1 that day2 cumulative pts",
   );
-  await expect(page.locator(".progress-chart-daily-score-badge")).toHaveText(
-    "+1",
-  );
+  await expect(
+    page.locator(".progress-chart-detail .daily-score-badge"),
+  ).toHaveText("+1");
 
   const tachiaiFilter = page.getByRole("button", {
     name: "#3 Tachiai Titans",


### PR DESCRIPTION
Closes #55

## Summary
- add a dependency-free cumulative score progress chart backed directly by leaderboard `scoreHistory`
- keep the standings first, then show the chart below the leaderboard
- reuse one `DailyScoreBadge` component for the latest daily increase in leaderboard rows and the selected chart detail
- add team filters, latest-day emphasis, current submitted-team highlighting, and hover/tap/keyboard point details
- disambiguate team labels with leaderboard ranks and keep color/dash signatures distinct when the palette cycles beyond six teams
- mirror chart dash patterns in the legend and use one roving point tab stop with arrow/Home/End navigation plus a distinct keyboard focus ring
- add horizontal mobile chart scrolling, empty and single-day guidance, and an accessible exact-value history table

## Validation
- `make check` — pass; 146 unit/integration tests, lint, formatting, deployment workflow verification, and all builds
- `make e2e` — pass; 21 tests across desktop Chromium, mobile Chromium, and mobile WebKit
- agent-browser visual pass — pass at 1440x900 desktop and 390x844 mobile; shared badge styles match, keyboard focus ring is visible, chart scrolling is contained, and there is no page overflow or browser error
- dedicated pre-handoff reviews — committed branch and final uncommitted delta both passed with no actionable P1/P2 findings
- GitHub review follow-up — five P2 accessibility/clarity findings fixed, replied to, and resolved; latest two fixed in `0f19869`

## Docs
- update `docs/ARCHITECTURE.md` with the leaderboard progress chart behavior

## Non-goals
- no new scoring or API shape
- no persistent user identity; current-team highlighting applies when the app has the newly submitted team in session
- no charting dependency
